### PR TITLE
New pose proposal (#252)

### DIFF
--- a/sdf/1.9/pose.sdf
+++ b/sdf/1.9/pose.sdf
@@ -1,11 +1,37 @@
 <!-- Pose -->
 <element name="pose" type="pose" default="0 0 0 0 0 0" required="0">
-  <description>A position(x,y,z) and orientation(roll, pitch yaw) with respect to the frame named in the relative_to attribute.</description>
+  <description>A position(x,y,z) and orientation(roll, pitch, yaw) with respect to the frame named in the relative_to attribute.</description>
 
   <attribute name="relative_to" type="string" default="" required="*">
     <description>
       Name of frame relative to which the pose is applied.
     </description>
   </attribute>
+
+  <element name="translation" type="vector3" default="0 0 0" required="1">
+    <description>The position(x,y,z) with respect to the frame named in the relative_to attribute.</description>
+  </element>
+
+  <element name="rotation" type="vector3" default="0 0 0" required="1">
+    <description>The rotation with respect to the frame named in the relative_to attribute.</description>
+    <attribute name="type" type="string" default="__default__" required="1">
+      <description>The type of rotation convention, which must be one of the following:
+        (rpy_degrees) rotation in the form of (roll, pitch, yaw), in degrees.
+        (rpy_radians) rotation in the form of (roll, pitch, yaw), in radians.
+        (q_wxyz) rotation in the form of a quaternion (w, x, y, z).
+      </description>
+    </attribute>
+  </element>
+
+  <element name="rotation" type="quaternion" default="1 0 0 0" required="1">
+    <description>The rotation with respect to the frame named in the relative_to attribute.</description>
+    <attribute name="type" type="string" default="__default__" required="1">
+      <description>The type of rotation convention, which must be one of the following:
+        (rpy_degrees) rotation in the form of (roll, pitch, yaw), in degrees.
+        (rpy_radians) rotation in the form of (roll, pitch, yaw), in radians.
+        (q_wxyz) rotation in the form of a quaternion (w, x, y, z).
+      </description>
+    </attribute>
+  </element>
 
 </element> <!-- End Pose -->

--- a/sdf/1.9/pose.sdf
+++ b/sdf/1.9/pose.sdf
@@ -12,18 +12,7 @@
     <description>The position(x,y,z) with respect to the frame named in the relative_to attribute.</description>
   </element>
 
-  <element name="rotation" type="vector3" default="0 0 0" required="1">
-    <description>The rotation with respect to the frame named in the relative_to attribute.</description>
-    <attribute name="type" type="string" default="__default__" required="1">
-      <description>The type of rotation convention, which must be one of the following:
-        (rpy_degrees) rotation in the form of (roll, pitch, yaw), in degrees.
-        (rpy_radians) rotation in the form of (roll, pitch, yaw), in radians.
-        (q_wxyz) rotation in the form of a quaternion (w, x, y, z).
-      </description>
-    </attribute>
-  </element>
-
-  <element name="rotation" type="quaternion" default="1 0 0 0" required="1">
+  <element name="rotation" type="rotation" default="1 0 0 0" required="1">
     <description>The rotation with respect to the frame named in the relative_to attribute.</description>
     <attribute name="type" type="string" default="__default__" required="1">
       <description>The type of rotation convention, which must be one of the following:

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -67,7 +67,7 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
   // Start checking for translation and rotation elements.
   sdf::ElementPtr translationPtr = sdf->GetElement("translation");
   sdf::ElementPtr rotationPtr = sdf->GetElement("rotation");
-  
+
   // If both are not explicitly set, the pose is parsed using the value.
   if (!translationPtr->GetExplicitlySetInFile() &&
       !rotationPtr->GetExplicitlySetInFile())
@@ -80,7 +80,7 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
     // In this scenario, return true or false based on pose element value.
     return posePair.second;
   }
- 
+
   // Read the translation values.
   if (translationPtr->GetExplicitlySetInFile())
   {
@@ -88,10 +88,7 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
         translationPtr->Get<ignition::math::Vector3d>(
             "", ignition::math::Vector3d::Zero);
     if (translationPair.second)
-    {
-      std::cout << "found translation" << std::endl;
       pose.Set(translationPair.first, pose.Rot());
-    }
   }
 
   // Read the rotation values.
@@ -104,7 +101,6 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
 
     if (typePair.first == "rpy_degrees")
     {
-      std::cout << "found rpy deg" << std::endl;
       std::pair<ignition::math::Vector3d, bool> rpyDegPair =
           rotationPtr->Get<ignition::math::Vector3d>(
               "", ignition::math::Vector3d::Zero);
@@ -113,7 +109,6 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
     }
     else if (typePair.first == "rpy_radians")
     {
-      std::cout << "found rpy rad" << std::endl;
       std::pair<ignition::math::Vector3d, bool> rpyRadPair =
           rotationPtr->Get<ignition::math::Vector3d>(
               "", ignition::math::Vector3d::Zero);
@@ -122,15 +117,12 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
     }
     else if (typePair.first == "q_wxyz")
     {
-      std::cout << "found quat" << std::endl;
       std::pair<ignition::math::Quaterniond, bool> quatPair =
           rotationPtr->Get<ignition::math::Quaterniond>(
               "", ignition::math::Quaterniond::Identity);
       if (quatPair.second)
       {
         pose.Set(pose.Pos(), quatPair.first);
-        std::cout << quatPair.first << std::endl;
-        std::cout << "set quat" << std::endl;
       }
     }
     else

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -38,6 +38,7 @@ set(tests
   plugin_attribute.cc
   plugin_bool.cc
   plugin_include.cc
+  pose_1_9_sdf.cc
   provide_feedback.cc
   root_dom.cc
   scene_dom.cc

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -34,8 +34,8 @@ TEST(Pose1_9, ModelPoses)
 {
   using Pose = ignition::math::Pose3d;
 
-  const std::string testFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf", "pose.sdf");
+  const std::string testFile = sdf::testing::TestFile(
+      "sdf", "pose_1_9.sdf"); 
   
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -35,8 +35,8 @@ TEST(Pose1_9, ModelPoses)
   using Pose = ignition::math::Pose3d;
 
   const std::string testFile = sdf::testing::TestFile(
-      "sdf", "pose_1_9.sdf"); 
-  
+      "sdf", "pose_1_9.sdf");
+
   // Load the SDF file
   sdf::Root root;
   auto errors = root.Load(testFile);
@@ -45,17 +45,17 @@ TEST(Pose1_9, ModelPoses)
   // std::cout << errors << std::endl;
   ASSERT_TRUE(errors.empty());
   EXPECT_EQ(SDF_PROTOCOL_VERSION, root.Version());
-  
+
   const sdf::World *world = root.WorldByIndex(0);
   ASSERT_NE(nullptr, world);
-  
+
   std::cout << "modelWithEmptyPose" << std::endl;
   const sdf::Model *model = world->ModelByIndex(0);
   ASSERT_NE(nullptr, model);
   ASSERT_EQ("model_with_empty_pose", model->Name());
   EXPECT_EQ(Pose::Zero, model->RawPose());
- 
-  std::cout << "modelWithPoseValue" << std::endl; 
+
+  std::cout << "modelWithPoseValue" << std::endl;
   model = world->ModelByIndex(1);
   ASSERT_NE(nullptr, model);
   ASSERT_EQ("model_with_pose_value", model->Name());
@@ -77,13 +77,13 @@ TEST(Pose1_9, ModelPoses)
   model = world->ModelByIndex(4);
   ASSERT_NE(nullptr, model);
   ASSERT_EQ("model_with_empty_rpy_deg", model->Name());
-  EXPECT_EQ(Pose::Zero, model->RawPose()); 
+  EXPECT_EQ(Pose::Zero, model->RawPose());
 
   std::cout << "modelWithRPYDegValue" << std::endl;
   model = world->ModelByIndex(5);
   ASSERT_NE(nullptr, model);
   ASSERT_EQ("model_with_rpy_deg_value", model->Name());
-  EXPECT_EQ(Pose(0, 0, 0, 0, IGN_DTOR(90), IGN_DTOR(180)), model->RawPose()); 
+  EXPECT_EQ(Pose(0, 0, 0, 0, IGN_DTOR(90), IGN_DTOR(180)), model->RawPose());
 
   std::cout << "modelWithEmptyRPYRad" << std::endl;
   model = world->ModelByIndex(6);

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <string>
+#include <gtest/gtest.h>
+
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+#include "sdf/Element.hh"
+#include "sdf/Error.hh"
+#include "sdf/Model.hh"
+#include "sdf/Root.hh"
+#include "sdf/World.hh"
+#include "sdf/Filesystem.hh"
+#include "test_config.h"
+
+//////////////////////////////////////////////////
+TEST(Pose1_9, ModelPoses)
+{
+  using Pose = ignition::math::Pose3d;
+
+  const std::string testFile =
+      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf", "pose.sdf");
+  
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  for (const auto e : errors)
+    std::cout << e << std::endl;
+  // std::cout << errors << std::endl;
+  ASSERT_TRUE(errors.empty());
+  EXPECT_EQ(SDF_PROTOCOL_VERSION, root.Version());
+  
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  
+  std::cout << "modelWithEmptyPose" << std::endl;
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_empty_pose", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+ 
+  std::cout << "modelWithPoseValue" << std::endl; 
+  model = world->ModelByIndex(1);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_pose_value", model->Name());
+  EXPECT_EQ(Pose(1, 2, 3, 1, 2, 3), model->RawPose());
+
+  std::cout << "modelWithEmptyTranslation" << std::endl;
+  model = world->ModelByIndex(2);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_empty_translation", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithTranslationValue" << std::endl;
+  model = world->ModelByIndex(3);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_translation_value", model->Name());
+  EXPECT_EQ(Pose(2, 3, 4, 0, 0, 0), model->RawPose());
+
+  std::cout << "modelWithEmptyRPYDeg" << std::endl;
+  model = world->ModelByIndex(4);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_empty_rpy_deg", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose()); 
+
+  std::cout << "modelWithRPYDegValue" << std::endl;
+  model = world->ModelByIndex(5);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_rpy_deg_value", model->Name());
+  EXPECT_EQ(Pose(0, 0, 0, 0, IGN_DTOR(90), IGN_DTOR(180)), model->RawPose()); 
+
+  std::cout << "modelWithEmptyRPYRad" << std::endl;
+  model = world->ModelByIndex(6);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_empty_rpy_rad", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithRPYRadValue" << std::endl;
+  model = world->ModelByIndex(7);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_rpy_rad_value", model->Name());
+  EXPECT_EQ(Pose(0, 0, 0, 1, 2, 3), model->RawPose());
+
+  std::cout << "modelWithEmptyQuat" << std::endl;
+  model = world->ModelByIndex(8);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_empty_quat", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithQuatValue" << std::endl;
+  model = world->ModelByIndex(9);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_quat_value", model->Name());
+  EXPECT_EQ(Pose(0, 0, 0, 0.7071068, 0.7071068, 0, 0), model->RawPose());
+}
+

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -108,5 +108,72 @@ TEST(Pose1_9, ModelPoses)
   ASSERT_NE(nullptr, model);
   ASSERT_EQ("model_with_quat_value", model->Name());
   EXPECT_EQ(Pose(0, 0, 0, 0.7071068, 0.7071068, 0, 0), model->RawPose());
+
+  std::cout << "modelWithBothRotationsNoValue" << std::endl;
+  model = world->ModelByIndex(10);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_both_rotations_no_value", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithBothRotationsSecondValue" << std::endl;
+  model = world->ModelByIndex(11);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_both_rotations_second_value", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithBothRotationsFirstValue" << std::endl;
+  model = world->ModelByIndex(12);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_both_rotations_first_value", model->Name());
+  EXPECT_EQ(Pose(0, 0, 0, 1, 2, 3), model->RawPose());
+
+  std::cout << "modelWithTranslationRotationNoValue" << std::endl;
+  model = world->ModelByIndex(13);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_translation_rotation_no_value", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithTranslationRotationValue" << std::endl;
+  model = world->ModelByIndex(14);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_translation_rotation_value", model->Name());
+  EXPECT_EQ(Pose(2, 3, 4, 0.7071068, 0.7071068, 0, 0), model->RawPose());
+
+  std::cout << "modelWithValueAndTranslationNoValue" << std::endl;
+  model = world->ModelByIndex(15);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_value_and_translation_no_value", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithValueAndTranslationValue" << std::endl;
+  model = world->ModelByIndex(16);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_value_and_translation_value", model->Name());
+  EXPECT_EQ(Pose(2, 3, 4, 0, 0, 0), model->RawPose());
+
+  std::cout << "modelWithValueAndRotationNoValue" << std::endl;
+  model = world->ModelByIndex(17);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_value_and_rotation_no_value", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithValueAndRotationValue" << std::endl;
+  model = world->ModelByIndex(18);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_value_and_rotation_value", model->Name());
+  EXPECT_EQ(Pose(0, 0, 0, IGN_DTOR(1), IGN_DTOR(2), IGN_DTOR(3)),
+      model->RawPose());
+
+  std::cout << "modelWithValueAndTranslationRotationNoValue" << std::endl;
+  model = world->ModelByIndex(19);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_value_and_translation_rotation_no_value", model->Name());
+  EXPECT_EQ(Pose::Zero, model->RawPose());
+
+  std::cout << "modelWithValueAndTranslationRotationValue" << std::endl;
+  model = world->ModelByIndex(20);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_with_value_and_translation_rotation_value", model->Name());
+  EXPECT_EQ(Pose(2, 3, 4, 0.7071068, 0.7071068, 0, 0), model->RawPose());
 }
 

--- a/test/sdf/pose_1_9.sdf
+++ b/test/sdf/pose_1_9.sdf
@@ -1,0 +1,81 @@
+<?xml version="1.0" ?>
+<sdf version="1.9">
+  <world name="default">
+    
+    <model name="model_with_empty_pose">
+      <pose></pose>
+      <link name="link"/>
+    </model>
+    
+    <model name="model_with_pose_value">
+      <pose>1 2 3 1 2 3</pose>
+      <link name="link"/>
+    </model>
+    
+    <model name="model_with_empty_translation">
+      <pose>
+        <translation></translation>
+      </pose>
+      <link name="link"/>
+    </model>
+    
+    <model name="model_with_translation_value">
+      <pose>
+        <translation>2 3 4</translation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_empty_rpy_deg">
+      <pose>
+        <rotation type="rpy_degrees"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_rpy_deg_value">
+      <pose>
+        <rotation type="rpy_degrees">0 90 180</rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_empty_rpy_rad">
+      <pose>
+        <rotation type="rpy_radians"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_rpy_rad_value">
+      <pose>
+        <rotation type="rpy_radians">1 2 3</rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_empty_quat">
+      <pose>
+        <rotation type="q_wxyz"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_quat_value">
+      <pose>
+        <rotation type="q_wxyz">0.7071068 0.7071068 0 0</rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_both_rotations">
+      <pose>
+        <rotation type="rpy_radians"></rotation>
+        <rotation type="q_wxyz"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+  </world>
+</sdf>
+

--- a/test/sdf/pose_1_9.sdf
+++ b/test/sdf/pose_1_9.sdf
@@ -68,10 +68,92 @@
       <link name="link"/>
     </model>
 
-    <model name="model_with_both_rotations">
+    <model name="model_with_both_rotations_no_value">
       <pose>
         <rotation type="rpy_radians"></rotation>
         <rotation type="q_wxyz"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_both_rotations_second_value">
+      <pose>
+        <rotation type="rpy_radians"></rotation>
+        <rotation type="q_wxyz">0.7071068 0.7071068 0 0</rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_both_rotations_first_value">
+      <pose>
+        <rotation type="rpy_radians">1 2 3</rotation>
+        <rotation type="q_wxyz"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_translation_rotation_no_value">
+      <pose>
+        <translation></translation>
+        <rotation type="rpy_radians"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_translation_rotation_value">
+      <pose>
+        <translation>2 3 4</translation>
+        <rotation type="q_wxyz">0.7071068 0.7071068 0 0</rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_value_and_translation_no_value">
+      <pose>
+        1 2 3 1 2 3
+        <translation></translation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_value_and_translation_value">
+      <pose>
+        1 2 3 1 2 3
+        <translation>2 3 4</translation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_value_and_rotation_no_value">
+      <pose>
+        1 2 3 1 2 3
+        <rotation type="rpy_degrees"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_value_and_rotation_value">
+      <pose>
+        1 2 3 1 2 3
+        <rotation type="rpy_degrees">1 2 3</rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_value_and_translation_rotation_no_value">
+      <pose>
+        1 2 3 1 2 3
+        <translation></translation>
+        <rotation type="q_wxyz"></rotation>
+      </pose>
+      <link name="link"/>
+    </model>
+
+    <model name="model_with_value_and_translation_rotation_value">
+      <pose>
+        1 2 3 1 2 3
+        <translation>2 3 4</translation>
+        <rotation type="q_wxyz">0.7071068 0.7071068 0 0</rotation>
       </pose>
       <link name="link"/>
     </model>


### PR DESCRIPTION
# 🎉 New feature

Related to #252

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

* Adding specific `translation` and `rotation` elements to `pose`.
* `rotation` can be read according to its `type` attribute, `rpy_degrees`, `rpy_radians`, and `q_wxyz`.

Technically values and child elements are not supposed to live side-by-side, and there was no precedent of this use case. After some experimentation, I have found a workaround using the feature https://github.com/osrf/sdformat/pull/542, to find out whether the `translation` and `rotation` elements were explicitly set.

This branch requires
* https://github.com/osrf/sdformat/pull/568
* https://github.com/osrf/sdformat/pull/542

With the intention of deprecating the old `//pose` descriptions, this proposal parses the poses by hierarchy, whereby whenever a `translation` or `rotation` child element is present, even if a value is specified, it will be ignored, for example,

```
<pose>
  1 2 3 4 5 6
  <translation></translation>
<pose>
```
In this case, where the `translation` child element is present, it is treated as an indication to use the new pose proposal, therefore using the default `xyz` values of `(0, 0, 0)` for translation, while failing to find a `rotation` child element also uses the default values, which are `rpy` of `(0, 0, 0)`.

**Alternatively**, we could opt for overriding just the translation in this example, while leaving the `rpy` components to be `(4, 5, 6)`.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

```
source install/setup.bash
./build/sdformat12/test/integration/INTEGRATION_pose_1_9_sdf
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**