### PR TITLE
Translate poses of nested models inside other nested models (sdf6)

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1084,7 +1084,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
       replace[elemName] = newName;
     }
 
-    if (elem->GetName() == "link")
+    if ((elem->GetName() == "link") || (elem->GetName() == "model"))
     {
       if (elem->HasElementDescription("pose"))
       {

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1074,7 +1074,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
   std::string modelName = modelPtr->Get<std::string>("name");
   while (elem)
   {
-    if (elem->GetName() == "link")
+    if (elem->GetName() == "link" || elem->GetName() == "model")
     {
       std::string elemName = elem->Get<std::string>("name");
       std::string newName =  modelName + "::" + elemName;

--- a/test/integration/frame.cc
+++ b/test/integration/frame.cc
@@ -1255,3 +1255,63 @@ TEST(Frame, IncludeFrame)
   EXPECT_EQ(modelPoseElem->Get<ignition::math::Pose3d>(),
             ignition::math::Pose3d(5, -2, 1, 0, 0, 0));
 }
+
+////////////////////////////////////////
+// Test parsing a include element that has a pose element and includes a
+// submodel
+TEST(Frame, IncludeFrameWithSubmodel)
+{
+  const std::string MODEL_PATH =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
+                            "model", "box_with_submodel");
+
+  std::ostringstream stream;
+  std::string version = SDF_VERSION;
+  stream
+    << "<sdf version='" << version << "'>"
+    << "<world name='default'>"
+    << "<model name='top_level_model'>"
+    << "  <include>"
+    << "    <static>false</static>"
+    << "    <pose>5 5 0 0 0 0</pose>"
+    << "    <uri>" + MODEL_PATH +"</uri>"
+    << "  </include>"
+    << "</model>"
+    << "</world>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed));
+  sdf::ElementPtr worldElem = sdfParsed->Root()->GetElement("world");
+
+  /* top level model: using include will merge top_level_model and box_with_submodel into:
+   *  <model name='top_level_model'>
+   *   <link name='box_with_submodel::link'>
+   *     <pose frame=''>5 5 0 0 -0 0</pose>  <<-- pose has been translated
+   *   </link>
+   *   <model name='box_with_submodel::submodel_box_with_submodel'>
+   *   ...
+   *   </model>
+   * </model>
+  */
+  sdf::ElementPtr modelElem = worldElem->GetElement("model");
+  EXPECT_EQ(modelElem->Get<std::string>("name"), "top_level_model");
+  sdf::ElementPtr modelPoseElem = modelElem->GetElement("link")->GetElement("pose");
+  EXPECT_EQ(modelPoseElem->Get<ignition::math::Pose3d>(),
+            ignition::math::Pose3d(5, 5, 0, 0, 0, 0));
+  /* submodel: pose from parent is translated to model. links are the same
+   * ...
+   *   <model name='box_with_submodel::submodel_box_with_submodel'>
+   *     <link name='submodel_link'>
+   *       <pose frame=''>0 0 0 0 -0 0</pose>
+   *     </link>
+   *     <pose frame=''>5 5 0 0 -0 0</pose>
+   *   </model>
+   */
+  sdf::ElementPtr subModelElem = modelElem->GetElement("model");
+  EXPECT_EQ(subModelElem->Get<std::string>("name"), "box_with_submodel::submodel_of_box_with_submodel");
+  sdf::ElementPtr subModelPoseElem = subModelElem->GetElement("pose");
+  EXPECT_EQ(subModelPoseElem->Get<ignition::math::Pose3d>(),
+            ignition::math::Pose3d(5, 5, 0, 0, 0, 0));
+}

--- a/test/integration/model/box_with_submodel/model.config
+++ b/test/integration/model/box_with_submodel/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>BoxWithSubmodel</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Jose Luis Rivero</name>
+    <email>jrivero@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A box with a nested model
+  </description>
+</model>

--- a/test/integration/model/box_with_submodel/model.config
+++ b/test/integration/model/box_with_submodel/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>BoxWithSubmodel</name>
   <version>1.0</version>
-  <sdf version="1.5">model.sdf</sdf>
+  <sdf version="1.6">model.sdf</sdf>
 
   <author>
     <name>Jose Luis Rivero</name>

--- a/test/integration/model/box_with_submodel/model.sdf
+++ b/test/integration/model/box_with_submodel/model.sdf
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="box_with_submodel">
+    <link name="link">
+      <pose>0 0 0 0 0 0</pose>
+    </link>
+    <model name="submodel_of_box_with_submodel">
+      <link name="submodel_link">
+        <pose>0 0 0 0 0 0</pose>
+      </link>
+    </model>
+  </model>
+</sdf>


### PR DESCRIPTION
When `addNestedModel` function is called, it processes links and joints to translate the pose accordingly to parent pose. This was not done for nested models inside the SDF being processed by the function, hence they were not aware of parent pose.

This PR includes nested models in the same way that is doing for links and add a test that fails without the change.
The change was proposed by @azeey. If we are not wrong, the change is not present in newer versions of sdformat after the implementation of frame semantics.
