### PR TITLE
Fix flattening logic for nested model names (sdf6)

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1111,23 +1111,23 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
   {
     std::string old_name(iter->first);
     std::string name_with_nested_prefix(iter->second);
-    replace_all(str, "\"" + old_name + "\"",
-                     "\"" + name_with_nested_prefix + "\"");
-    replace_all(str, "'" + old_name + "'",
-                     "'" + name_with_nested_prefix + "'");
-    replace_all(str, ">" + old_name + "<",
-                     ">" + name_with_nested_prefix + "<");
+    replace_all(str, std::string("\"") + old_name + "\"",
+                     std::string("\"") + name_with_nested_prefix + "\"");
+    replace_all(str, std::string("'") + old_name + "'",
+                     std::string("'") + name_with_nested_prefix + "'");
+    replace_all(str, std::string(">") + old_name + "<",
+                     std::string(">") + name_with_nested_prefix + "<");
     // Deal with nested model inside other nested model and already with
-    // '::component::' entries in the name
-    // Case A. ::component1::iter.first::component2
-    replace_all(str, "::" + old_name + "::",
-                     "::" + name_with_nested_prefix + "::");
+    // ::namespace:: entries in the name
+    // Case A. ::namespace1::iter.first::namespace2
+    replace_all(str, std::string("::") + old_name + "::",
+                     std::string("::") + name_with_nested_prefix + "::");
     // Case B. >iter.first::component
-    replace_all(str, ">" + old_name + "::",
-                     ">" + name_with_nested_prefix + "::");
+    replace_all(str, std::string(">") + old_name + "::",
+                     std::string(">") + name_with_nested_prefix + "::");
     // Case C.::component::iter.first<
-    replace_all(str, "::" + old_name + "<",
-                     "::" + name_with_nested_prefix + "<");
+    replace_all(str, std::string("::") + old_name + "<",
+                     std::string("::") + name_with_nested_prefix + "<");
     // remove duplicate prefixes introduced by the logic above (cases
     // A,B,C) if the full name (iter.second) was used in the original SDF: (i.e
     // iter.second::component)

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1074,9 +1074,15 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
   std::string modelName = modelPtr->Get<std::string>("name");
   while (elem)
   {
-    std::string elemName = elem->Get<std::string>("name");
-    std::string newName =  modelName + "::" + elemName;
-    replace[elemName] = newName;
+    // protect elements that should not change the name attribute
+    // i.e: plugin
+    if ((elem->GetName() == "link") || (elem->GetName() == "joint") ||
+        (elem->GetName() == "model"))
+    {
+      std::string elemName = elem->Get<std::string>("name");
+      std::string newName =  modelName + "::" + elemName;
+      replace[elemName] = newName;
+    }
 
     if (elem->GetName() == "link")
     {

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1074,11 +1074,12 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
   std::string modelName = modelPtr->Get<std::string>("name");
   while (elem)
   {
+    std::string elemName = elem->Get<std::string>("name");
+    std::string newName =  modelName + "::" + elemName;
+    replace[elemName] = newName;
+
     if (elem->GetName() == "link")
     {
-      std::string elemName = elem->Get<std::string>("name");
-      std::string newName =  modelName + "::" + elemName;
-      replace[elemName] = newName;
       if (elem->HasElementDescription("pose"))
       {
         ignition::math::Pose3d offsetPose =
@@ -1092,11 +1093,6 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
     }
     else if (elem->GetName() == "joint")
     {
-      // for joints, we need to
-      //   prefix name like we did with links, and
-      std::string elemName = elem->Get<std::string>("name");
-      std::string newName =  modelName + "::" + elemName;
-      replace[elemName] = newName;
       //   rotate the joint axis because they are model-global
       if (elem->HasElement("axis"))
       {
@@ -1113,12 +1109,14 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
   for (std::map<std::string, std::string>::iterator iter = replace.begin();
        iter != replace.end(); ++iter)
   {
-    replace_all(str, std::string("\"") + iter->first + "\"",
-                std::string("\"") + iter->second + "\"");
-    replace_all(str, std::string("'") + iter->first + "'",
-                std::string("'") + iter->second + "'");
-    replace_all(str, std::string(">") + iter->first + "<",
-                std::string(">") + iter->second + "<");
+    std::string old_name(iter->first);
+    std::string name_with_nested_prefix(iter->second);
+    replace_all(str, "\"" + old_name + "\"",
+                     "\"" + name_with_nested_prefix + "\"");
+    replace_all(str, "'" + old_name + "'",
+                     "'" + name_with_nested_prefix + "'");
+    replace_all(str, ">" + old_name + "<",
+                     ">" + name_with_nested_prefix + "<");
   }
 
   _includeSDF->ClearElements();

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1109,35 +1109,35 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
   for (std::map<std::string, std::string>::iterator iter = replace.begin();
        iter != replace.end(); ++iter)
   {
-    std::string old_name(iter->first);
-    std::string name_with_nested_prefix(iter->second);
-    replace_all(str, std::string("\"") + old_name + "\"",
-                     std::string("\"") + name_with_nested_prefix + "\"");
-    replace_all(str, std::string("'") + old_name + "'",
-                     std::string("'") + name_with_nested_prefix + "'");
-    replace_all(str, std::string(">") + old_name + "<",
-                     std::string(">") + name_with_nested_prefix + "<");
+    std::string oldName(iter->first);
+    std::string nameWithNestedPrefix(iter->second);
+    replace_all(str, std::string("\"") + oldName + "\"",
+                     std::string("\"") + nameWithNestedPrefix + "\"");
+    replace_all(str, std::string("'") + oldName + "'",
+                     std::string("'") + nameWithNestedPrefix + "'");
+    replace_all(str, std::string(">") + oldName + "<",
+                     std::string(">") + nameWithNestedPrefix + "<");
     // Deal with nested model inside other nested model and already with
     // ::namespace:: entries in the name
-    replace_all(str, std::string(">") + old_name + "::",
-                     std::string(">") + name_with_nested_prefix + "::");
+    replace_all(str, std::string(">") + oldName + "::",
+                     std::string(">") + nameWithNestedPrefix + "::");
     // remove duplicate prefixes introduced by the logic above
     // if the full name (iter.second) was used in the original SDF: (i.e
     // iter.second::component)
-    std::string::size_type found = name_with_nested_prefix.find(old_name);
+    std::string::size_type found = nameWithNestedPrefix.find(oldName);
     if (found != std::string::npos)
     {
-      std::string nested_prefix = name_with_nested_prefix;
-      nested_prefix.erase(found, old_name.length());
-      replace_all(str, nested_prefix + nested_prefix, nested_prefix);
+      std::string nestedPrefix = nameWithNestedPrefix;
+      nestedPrefix.erase(found, oldName.length());
+      replace_all(str, nestedPrefix + nestedPrefix, nestedPrefix);
     }
     else
     {
-      // should never happen since name_with_nested_prefix =
-      // nested model name + old_name
-      sdferr << "Nested name '" << name_with_nested_prefix <<
+      // should never happen since nameWithNestedPrefix =
+      // nested model name + oldName
+      sdferr << "Nested name '" << nameWithNestedPrefix <<
                 "' does not contain the plain name of the element '" <<
-                old_name << "'. Please report an issue. \n";
+                oldName << "'. Please report an issue. \n";
     }
   }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1127,24 +1127,6 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
     // ::namespace:: entries in the name
     replace_all(str, std::string(">") + oldName + "::",
                      std::string(">") + nameWithNestedPrefix + "::");
-    // remove duplicate prefixes introduced by the logic above
-    // if the full name (iter.second) was used in the original SDF: (i.e
-    // iter.second::component)
-    std::string::size_type found = nameWithNestedPrefix.find(oldName);
-    if (found != std::string::npos)
-    {
-      std::string nestedPrefix = nameWithNestedPrefix;
-      nestedPrefix.erase(found, oldName.length());
-      replace_all(str, nestedPrefix + nestedPrefix, nestedPrefix);
-    }
-    else
-    {
-      // should never happen since nameWithNestedPrefix =
-      // nested model name + oldName
-      sdferr << "Nested name '" << nameWithNestedPrefix <<
-                "' does not contain the plain name of the element '" <<
-                oldName << "'. Please report an issue. \n";
-    }
   }
 
   _includeSDF->ClearElements();

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1119,17 +1119,10 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF)
                      std::string(">") + name_with_nested_prefix + "<");
     // Deal with nested model inside other nested model and already with
     // ::namespace:: entries in the name
-    // Case A. ::namespace1::iter.first::namespace2
-    replace_all(str, std::string("::") + old_name + "::",
-                     std::string("::") + name_with_nested_prefix + "::");
-    // Case B. >iter.first::component
     replace_all(str, std::string(">") + old_name + "::",
                      std::string(">") + name_with_nested_prefix + "::");
-    // Case C.::component::iter.first<
-    replace_all(str, std::string("::") + old_name + "<",
-                     std::string("::") + name_with_nested_prefix + "<");
-    // remove duplicate prefixes introduced by the logic above (cases
-    // A,B,C) if the full name (iter.second) was used in the original SDF: (i.e
+    // remove duplicate prefixes introduced by the logic above
+    // if the full name (iter.second) was used in the original SDF: (i.e
     // iter.second::component)
     std::string::size_type found = name_with_nested_prefix.find(old_name);
     if (found != std::string::npos)

--- a/test/integration/model/nested_names_test/model.config
+++ b/test/integration/model/nested_names_test/model.config
@@ -1,0 +1,14 @@
+<?xml version='1.0'?>
+
+<model>
+  <name>Submodel</name>
+  <version>0.1.0</version>
+  <sdf version='1.5'>submodel_test.sdf</sdf>
+  <author>
+    <name>Christina Gomez</name>
+    <email>cgomez@swri.org</email>
+  </author>
+  <description>
+    A hinged door with two handles
+  </description>
+</model>

--- a/test/integration/model/nested_names_test/submodel_test.sdf
+++ b/test/integration/model/nested_names_test/submodel_test.sdf
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+<model name='main_model_prefix'>
+      <link name='frame'>
+        <pose frame=''>0.06 -0.0005 0 0 -0 0</pose>
+      </link>
+      <model name='subnested_model'>
+	  <link name='link1' />
+      </model>
+
+      <joint name='joint1' type='revolute'>
+        <parent>subnested_model</parent>
+        <child>subnested_model::link1</child>
+      </joint>
+
+      <joint name='joint2' type='revolute'>
+        <parent>main_model_prefix::subnested_model::link1</parent>
+        <child>other_prefix::subnested_model</child>
+      </joint>
+    </model>
+</sdf>

--- a/test/integration/model/nested_names_test/submodel_test.sdf
+++ b/test/integration/model/nested_names_test/submodel_test.sdf
@@ -15,7 +15,7 @@
 
       <joint name='joint2' type='revolute'>
         <parent>main_model_prefix::subnested_model::link1</parent>
-        <child>other_prefix::subnested_model</child>
+        <child>joint1</child>
       </joint>
     </model>
 </sdf>

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -285,4 +285,7 @@ TEST(NestedModel, IncludeFlatteningNames)
   EXPECT_EQ(joint2Elem->Get<std::string>("parent"),
     "main_model_prefix::subnested_model::link1") <<
     "Flattening logic for nested models failed (check parser.cc)";
+  EXPECT_EQ(joint2Elem->Get<std::string>("child"),
+    "main_model_prefix::joint1") <<
+    "Flattening logic for nested models failed (check parser.cc)";
 }

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -278,15 +278,11 @@ TEST(NestedModel, IncludeFlatteningNames)
     "main_model_prefix::subnested_model");
   EXPECT_EQ(jointElem->Get<std::string>("child"),
     "main_model_prefix::subnested_model::link1") <<
-    "Flattening logic for nested models failed for case B (check parser.cc)";
+    "Flattening logic for nested models failed (check parser.cc)";
 
   sdf::ElementPtr joint2Elem = jointElem->GetNextElement("joint");
   EXPECT_EQ(joint2Elem->Get<std::string>("name"), "main_model_prefix::joint2");
   EXPECT_EQ(joint2Elem->Get<std::string>("parent"),
     "main_model_prefix::subnested_model::link1") <<
-    "Flattening logic for nested models failed for case A" <<
-    "(check parser.cc) + duplicates";
-  EXPECT_EQ(joint2Elem->Get<std::string>("child"),
-    "other_prefix::main_model_prefix::subnested_model") <<
-    "Flattening logic for nested models failed for case C (check parser.cc)";
+    "Flattening logic for nested models failed (check parser.cc)";
 }

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -24,6 +24,8 @@
 
 #include "sdf/sdf.hh"
 
+#include "test_config.h"
+
 ////////////////////////////////////////
 // Test parsing nested model with joint
 TEST(NestedModel, NestedModel)
@@ -238,4 +240,53 @@ TEST(NestedModel, State)
   EXPECT_TRUE(nestedLinkStateElem->HasElement("wrench"));
   EXPECT_EQ(nestedLinkStateElem->Get<ignition::math::Pose3d>("wrench"),
     ignition::math::Pose3d(0, 0, 0, 0, 0, 0));
+}
+
+////////////////////////////////////////
+// Test parsing a include element that has a pose element and includes a
+// submodel
+TEST(NestedModel, IncludeFlatteningNames)
+{
+  const std::string MODEL_PATH =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
+                            "model", "nested_names_test");
+
+  std::ostringstream stream;
+  std::string version = SDF_VERSION;
+  stream
+    << "<sdf version='" << version << "'>"
+    << "<model name='top_level_model'>"
+    << "  <include>"
+    << "    <uri>" + MODEL_PATH +"</uri>"
+    << "  </include>"
+    << "</model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed));
+
+  sdf::ElementPtr modelElem = sdfParsed->Root()->GetElement("model");
+  EXPECT_EQ(modelElem->Get<std::string>("name"), "top_level_model");
+
+  sdf::ElementPtr linkElem = modelElem->GetElement("link");
+  EXPECT_EQ(linkElem->Get<std::string>("name"), "main_model_prefix::frame");
+
+  sdf::ElementPtr jointElem = modelElem->GetElement("joint");
+  EXPECT_EQ(jointElem->Get<std::string>("name"), "main_model_prefix::joint1");
+  EXPECT_EQ(jointElem->Get<std::string>("parent"),
+    "main_model_prefix::subnested_model");
+  EXPECT_EQ(jointElem->Get<std::string>("child"),
+    "main_model_prefix::subnested_model::link1") <<
+    "Flattening logic for nested models failed for case B (check parser.cc)";
+
+  sdf::ElementPtr joint2Elem = jointElem->GetNextElement("joint");
+  EXPECT_EQ(joint2Elem->Get<std::string>("name"), "main_model_prefix::joint2");
+  EXPECT_EQ(joint2Elem->Get<std::string>("parent"),
+    "main_model_prefix::subnested_model::link1") <<
+    "Flattening logic for nested models failed for case A (check parser.cc)" +
+    "duplicates";
+  EXPECT_EQ(joint2Elem->Get<std::string>("child"),
+    "other_prefix::main_model_prefix::subnested_model") <<
+    "Flattening logic for nested models failed for case C (check parser.cc)";
 }

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -284,8 +284,8 @@ TEST(NestedModel, IncludeFlatteningNames)
   EXPECT_EQ(joint2Elem->Get<std::string>("name"), "main_model_prefix::joint2");
   EXPECT_EQ(joint2Elem->Get<std::string>("parent"),
     "main_model_prefix::subnested_model::link1") <<
-    "Flattening logic for nested models failed for case A (check parser.cc)" +
-    "duplicates";
+    "Flattening logic for nested models failed for case A" <<
+    "(check parser.cc) + duplicates";
   EXPECT_EQ(joint2Elem->Get<std::string>("child"),
     "other_prefix::main_model_prefix::subnested_model") <<
     "Flattening logic for nested models failed for case C (check parser.cc)";


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #574

## Summary
I think that the current flattening logic deal with names using  `<`, `>`, `\` or `'` as separators. That leaves out some cases were the user use composed names (component::element) since the separator here is `::`. I added some logic to deal with use cases were element is present in different situations with other components of the name:

 * case A: `::component1::element::component2`
 * case B. `>element::component`
 * case C. `::component::element<`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests

**Note to maintainers**: Remember to use **Squash-Merge**