### PR TITLE
Add World::ValidateGraphs method (sdf9)

### DIFF
--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -74,6 +74,12 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(ElementPtr _sdf);
 
+    /// \brief Check that the FrameAttachedToGraph and PoseRelativeToGraph
+    /// are valid.
+    /// \return Errors, which is a vector of Error objects. Each Error includes
+    /// an error code and message. An empty vector indicates no error.
+    public: Errors ValidateGraphs() const;
+
     /// \brief Get the name of the model.
     /// The name of the model should be unique within the scope of a World.
     /// \return Name of the model.

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -76,6 +76,12 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(ElementPtr _sdf);
 
+    /// \brief Check that the FrameAttachedToGraph and PoseRelativeToGraph
+    /// are valid.
+    /// \return Errors, which is a vector of Error objects. Each Error includes
+    /// an error code and message. An empty vector indicates no error.
+    public: Errors ValidateGraphs() const;
+
     /// \brief Get the name of the world.
     /// \return Name of the world.
     public: std::string Name() const;

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -1346,7 +1346,7 @@ Errors resolveFrameAttachedToBody(
     {
       errors.push_back({ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR,
           "Graph has __model__ scope but sink vertex named [" +
-          sinkVertex.Name() + "] does not have FrameType LINK OR MODEL "
+          sinkVertex.Name() + "] does not have FrameType LINK or MODEL "
           "when starting from vertex with name [" + _vertexName + "]."});
       return errors;
     }

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -410,6 +410,35 @@ Errors Model::Load(ElementPtr _sdf)
 }
 
 /////////////////////////////////////////////////
+Errors Model::ValidateGraphs() const
+{
+  Errors errors;
+  if (!this->dataPtr->frameAttachedToGraph)
+  {
+    errors.push_back({ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR,
+        "FrameAttachedToGraph pointer is null."});
+  }
+  else
+  {
+    errors = validateFrameAttachedToGraph(*this->dataPtr->frameAttachedToGraph);
+  }
+
+  if (!this->dataPtr->poseGraph)
+  {
+    errors.push_back({ErrorCode::POSE_RELATIVE_TO_GRAPH_ERROR,
+        "PoseRelativeToGraph pointer is null."});
+  }
+  else
+  {
+    Errors poseErrors =
+        validatePoseRelativeToGraph(*this->dataPtr->poseGraph);
+    errors.insert(errors.end(), poseErrors.begin(), poseErrors.end());
+  }
+
+  return errors;
+}
+
+/////////////////////////////////////////////////
 std::string Model::Name() const
 {
   return this->dataPtr->name;

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -109,6 +109,17 @@ TEST(DOMModel, Construction)
     // expect errors when trying to resolve pose
     EXPECT_FALSE(semanticPose.Resolve(pose).empty());
   }
+
+  auto errors = model.ValidateGraphs();
+  EXPECT_EQ(2u, errors.size());
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR);
+  EXPECT_NE(std::string::npos,
+    errors[0].Message().find(
+      "FrameAttachedToGraph pointer is null"));
+  EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::POSE_RELATIVE_TO_GRAPH_ERROR);
+  EXPECT_NE(std::string::npos,
+    errors[1].Message().find(
+      "PoseRelativeToGraph pointer is null"));
 }
 
 /////////////////////////////////////////////////

--- a/src/World.cc
+++ b/src/World.cc
@@ -387,6 +387,35 @@ Errors World::Load(sdf::ElementPtr _sdf)
 }
 
 /////////////////////////////////////////////////
+Errors World::ValidateGraphs() const
+{
+  Errors errors;
+  if (!this->dataPtr->frameAttachedToGraph)
+  {
+    errors.push_back({ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR,
+        "FrameAttachedToGraph pointer is null."});
+  }
+  else
+  {
+    errors = validateFrameAttachedToGraph(*this->dataPtr->frameAttachedToGraph);
+  }
+
+  if (!this->dataPtr->poseRelativeToGraph)
+  {
+    errors.push_back({ErrorCode::POSE_RELATIVE_TO_GRAPH_ERROR,
+        "PoseRelativeToGraph pointer is null."});
+  }
+  else
+  {
+    Errors poseErrors =
+        validatePoseRelativeToGraph(*this->dataPtr->poseRelativeToGraph);
+    errors.insert(errors.end(), poseErrors.begin(), poseErrors.end());
+  }
+
+  return errors;
+}
+
+/////////////////////////////////////////////////
 std::string World::Name() const
 {
   return this->dataPtr->name;

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -53,6 +53,17 @@ TEST(DOMWorld, Construction)
   EXPECT_FALSE(world.FrameNameExists("default"));
 
   EXPECT_EQ(1u, world.PhysicsCount());
+
+  auto errors = world.ValidateGraphs();
+  EXPECT_EQ(2u, errors.size());
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR);
+  EXPECT_NE(std::string::npos,
+    errors[0].Message().find(
+      "FrameAttachedToGraph pointer is null"));
+  EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::POSE_RELATIVE_TO_GRAPH_ERROR);
+  EXPECT_NE(std::string::npos,
+    errors[1].Message().find(
+      "PoseRelativeToGraph pointer is null"));
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/frame.cc
+++ b/test/integration/frame.cc
@@ -759,7 +759,7 @@ TEST(DOMFrame, LoadWorldFramesInvalidAttachedTo)
   sdf::World world;
   auto worldLoadErrors = world.Load(worldElem);
   ASSERT_EQ(10u, worldLoadErrors.size());
-  for(int i = 0; i < 10; ++i)
+  for (int i = 0; i < 10; ++i)
   {
     EXPECT_EQ(errors[i].Code(), worldLoadErrors[i].Code());
     EXPECT_EQ(errors[i].Message(), worldLoadErrors[i].Message());

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -144,6 +144,9 @@ TEST(DOMRoot, LoadDoublePendulum)
 
   EXPECT_TRUE(model->JointNameExists("upper_joint"));
   EXPECT_TRUE(model->JointNameExists("lower_joint"));
+
+  auto graphErrors = model->ValidateGraphs();
+  EXPECT_EQ(0u, graphErrors.size());
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/world_dom.cc
+++ b/test/integration/world_dom.cc
@@ -102,6 +102,8 @@ TEST(DOMWorld, Load)
   EXPECT_EQ(world->Gravity(), ignition::math::Vector3d(1, 2, 3));
   EXPECT_EQ(world->MagneticField(), ignition::math::Vector3d(-1, 0.5, 10));
   EXPECT_EQ(testFile, world->Element()->FilePath());
+  auto graphErrors = world->ValidateGraphs();
+  EXPECT_EQ(0u, graphErrors.size());
 
   const sdf::Atmosphere *atmosphere = world->Atmosphere();
   ASSERT_NE(nullptr, atmosphere);


### PR DESCRIPTION
# 🎉 New feature

I noticed a bug in ign-physics that needs a new API in libsdformat to properly fix it. This is similar to #601 but is targeted at `sdf9`.

## Summary

I noticed a test in ign-physics in which some models do not have properly loaded graphs, but it's hard to detect since the graph data is private. This creates a `World::ValidateGraphs()` method to call the hidden `validate*Graph` functions in FrameSemantics.cc  with the private graph data. It also requires an extra check in the `validate*Graph` functions that the scope points to a valid graph.

## Test it

Run the `UNIT_World_TEST` and `INTEGRATION_world_dom` tests and see that they pass.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
