### PR TITLE
Fix ABI break

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -489,9 +489,6 @@ namespace sdf
     /// \brief True if element is required
     public: std::string required;
 
-    /// \brief True if the element was set in the SDF file.
-    public: bool explicitlySetInFile;
-
     /// \brief Element description
     public: std::string description;
 
@@ -524,6 +521,9 @@ namespace sdf
 
     /// \brief Spec version that this was originally parsed from.
     public: std::string originalVersion;
+
+    /// \brief True if the element was set in the SDF file.
+    public: bool explicitlySetInFile;
   };
 
   ///////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This moves the recently added data member `explicitlySetInFile` to the
end of the `ElementPrivate` class to an ABI breakage (See https://github.com/ignitionrobotics/ign-gazebo/issues/891).

We are using the Pimpl pattern with the `Element` class to avoid ABI issues, however, we have template functions that use data members from the `ElementPrivate` class in `Element.hh`. These templates can get instantiated in a translation unit outside of the ones used to build `libsdformat` and the offset values for the data members be computed based on the order of the members at the time the translation unit is compiled. When we later change the order of the data members, the offsets in the translation units will become invalid causing a crash as seen in https://github.com/ignitionrobotics/ign-gazebo/issues/891

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
