### PR TITLE
Fix ABI break on sdf11

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -582,7 +582,6 @@ namespace sdf
 
     /// \brief XML path of this element.
     public: std::string xmlPath;
-
   };
 
   ///////////////////////////////////////////////

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -519,9 +519,6 @@ namespace sdf
     /// \brief True if element is required
     public: std::string required;
 
-    /// \brief True if the element was set in the SDF file.
-    public: bool explicitlySetInFile;
-
     /// \brief Element description
     public: std::string description;
 
@@ -574,14 +571,18 @@ namespace sdf
     /// \brief Path to file where this element came from
     public: std::string path;
 
+    /// \brief Spec version that this was originally parsed from.
+    public: std::string originalVersion;
+
+    /// \brief True if the element was set in the SDF file.
+    public: bool explicitlySetInFile;
+
     /// \brief Line number in file where this element came from
     public: std::optional<int> lineNumber;
 
     /// \brief XML path of this element.
     public: std::string xmlPath;
 
-    /// \brief Spec version that this was originally parsed from.
-    public: std::string originalVersion;
   };
 
   ///////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Similar to #605, but with additional changes for the sdf11 branch. The recently added members to `sdf::ElementPrivate` are
`explicitlySetInFile`, `lineNumber`, and `xmlPath` (https://github.com/osrf/sdformat/compare/sdformat11_11.1.0...sdformat11_11.2.0)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
