### PR TITLE
Fix segfault when checking for required elements in joint

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1495,13 +1495,13 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           if (_sdf->GetName() == "joint" &&
               _sdf->Get<std::string>("type") != "ball")
           {
-            Error err(
+            Error missingElementError(
                 ErrorCode::ELEMENT_MISSING,
                 "XML Missing required element[" + elemDesc->GetName() +
                 "], child of element[" + _sdf->GetName() + "]",
-                errorSourcePath, elemXml->GetLineNum());
-            err.SetXmlPath(elemXmlPath);
-            _errors.push_back(err);
+                errorSourcePath, _xml->GetLineNum());
+            missingElementError.SetXmlPath(elemXmlPath);
+            _errors.push_back(missingElementError);
             return false;
           }
           else

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -791,16 +791,9 @@ TEST(Parser, MissingRequiredElement)
       </world>
     </sdf>)";
 
-  auto findFileCb = [](const std::string &_uri)
-  {
-    return sdf::testing::TestFile("integration", "model", _uri);
-  };
-
-  sdf::ParserConfig config;
-  config.SetFindCallback(findFileCb);
   sdf::Errors errors;
   sdf::SDFPtr sdf = InitSDF();
-  EXPECT_FALSE(sdf::readString(testString, config, sdf, errors));
+  EXPECT_FALSE(sdf::readString(testString, sdf, errors));
 
   ASSERT_NE(errors.size(), 0u);
   std::cerr << errors[0] << std::endl;

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -801,7 +801,7 @@ TEST(Parser, MissingRequiredElement)
   sdf::Errors errors;
   sdf::SDFPtr sdf = InitSDF();
   EXPECT_FALSE(sdf::readString(testString, config, sdf, errors));
-  
+
   ASSERT_NE(errors.size(), 0u);
   std::cerr << errors[0] << std::endl;
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

# 🦟 Bug fix

Fixes #590 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

* Switched to using `xml->GetLineNum()` instead of `elemXml->GetLineNum()`
* Added test for this particular error.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**