### PR TITLE
Merge 9 -> 11

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -150,6 +150,14 @@ namespace sdf
     /// \param[in] _prefix String value to prefix to the output.
     public: void PrintValues(std::string _prefix) const;
 
+    /// \brief Output Element's values to stdout.
+    /// \param[in] _prefix String value to prefix to the output.
+    /// \param[in] _includeDefaultElements flag to print default elements.
+    /// \param[in] _includeDefaultAttributes flag to print default attributes.
+    public: void PrintValues(const std::string &_prefix,
+                             bool _includeDefaultElements,
+                             bool _includeDefaultAttributes) const;
+
     /// \brief Helper function for SDF::PrintDoc
     ///
     /// This generates the SDF html documentation.
@@ -171,6 +179,18 @@ namespace sdf
     /// \param[in] _prefix String value to prefix to the output.
     /// \return The string representation.
     public: std::string ToString(const std::string &_prefix) const;
+
+    /// \brief Convert the element values to a string representation.
+    /// Current behavior of ToString(const std::string &_prefix) can be
+    /// achieved by calling this function with _includeDefaultElements=true
+    /// and _includeDefaultAttributes=false
+    /// \param[in] _prefix String value to prefix to the output.
+    /// \param[in] _includeDefaultElements flag to include default elements.
+    /// \param[in] _includeDefaultAttributes flag to include default attributes.
+    /// \return The string representation.
+    public: std::string ToString(const std::string &_prefix,
+                                 bool _includeDefaultElements,
+                                 bool _includeDefaultAttributes) const;
 
     /// \brief Add an attribute value.
     /// \param[in] _key Key value.
@@ -480,14 +500,22 @@ namespace sdf
 
     /// \brief Generate a string (XML) representation of this object.
     /// \param[in] _prefix arbitrary prefix to put on the string.
+    /// \param[in] _includeDefaultElements flag to include default elements.
+    /// \param[in] _includeDefaultAttributes flag to include default attributes.
     /// \param[out] _out the std::ostreamstream to write output to.
     private: void ToString(const std::string &_prefix,
+                           bool _includeDefaultElements,
+                           bool _includeDefaultAttributes,
                            std::ostringstream &_out) const;
 
     /// \brief Generate a string (XML) representation of this object.
     /// \param[in] _prefix arbitrary prefix to put on the string.
+    /// \param[in] _includeDefaultElements flag to include default elements.
+    /// \param[in] _includeDefaultAttributes flag to include default attributes.
     /// \param[out] _out the std::ostreamstream to write output to.
     private: void PrintValuesImpl(const std::string &_prefix,
+                                  bool _includeDefaultElements,
+                                  bool _includeDefaultAttributes,
                                   std::ostringstream &_out) const;
 
     /// \brief Create a new Param object and return it.

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -487,47 +487,59 @@ void Element::PrintDocLeftPane(std::string &_html, int _spacing,
 }
 
 void Element::PrintValuesImpl(const std::string &_prefix,
+                              bool _includeDefaultElements,
+                              bool _includeDefaultAttributes,
                               std::ostringstream &_out) const
 {
-  _out << _prefix << "<" << this->dataPtr->name;
+  if (this->GetExplicitlySetInFile() || _includeDefaultElements)
+  {
+    _out << _prefix << "<" << this->dataPtr->name;
 
-  Param_V::const_iterator aiter;
-  for (aiter = this->dataPtr->attributes.begin();
-       aiter != this->dataPtr->attributes.end(); ++aiter)
-  {
-    // Only print attribute values if they were set
-    // TODO(anyone): GetRequired is added here to support up-conversions where a
-    // new required attribute with a default value is added. We would have
-    // better separation of concerns if the conversion process set the required
-    // attributes with their default values.
-    if ((*aiter)->GetSet() || (*aiter)->GetRequired())
+    Param_V::const_iterator aiter;
+    for (aiter = this->dataPtr->attributes.begin();
+         aiter != this->dataPtr->attributes.end(); ++aiter)
     {
-      _out << " " << (*aiter)->GetKey() << "='"
-           << (*aiter)->GetAsString() << "'";
+      // Only print attribute values if they were set
+      // TODO(anyone): GetRequired is added here to support up-conversions where
+      // a new required attribute with a default value is added. We would have
+      // better separation of concerns if the conversion process set the
+      // required attributes with their default values.
+      if ((*aiter)->GetSet() || (*aiter)->GetRequired() ||
+          _includeDefaultAttributes)
+      {
+        _out << " " << (*aiter)->GetKey() << "='"
+             << (*aiter)->GetAsString() << "'";
+      }
     }
-  }
 
-  if (this->dataPtr->elements.size() > 0)
-  {
-    _out << ">\n";
-    ElementPtr_V::const_iterator eiter;
-    for (eiter = this->dataPtr->elements.begin();
-         eiter != this->dataPtr->elements.end(); ++eiter)
+    if (this->dataPtr->elements.size() > 0)
     {
-      (*eiter)->ToString(_prefix + "  ", _out);
-    }
-    _out << _prefix << "</" << this->dataPtr->name << ">\n";
-  }
-  else
-  {
-    if (this->dataPtr->value)
-    {
-      _out << ">" << this->dataPtr->value->GetAsString()
-           << "</" << this->dataPtr->name << ">\n";
+      _out << ">\n";
+      ElementPtr_V::const_iterator eiter;
+      for (eiter = this->dataPtr->elements.begin();
+           eiter != this->dataPtr->elements.end(); ++eiter)
+      {
+        if ((*eiter)->GetExplicitlySetInFile() || _includeDefaultElements)
+        {
+          (*eiter)->ToString(_prefix + "  ",
+                             _includeDefaultElements,
+                             _includeDefaultAttributes,
+                             _out);
+        }
+      }
+      _out << _prefix << "</" << this->dataPtr->name << ">\n";
     }
     else
     {
-      _out << "/>\n";
+      if (this->dataPtr->value)
+      {
+        _out << ">" << this->dataPtr->value->GetAsString()
+             << "</" << this->dataPtr->name << ">\n";
+      }
+      else
+      {
+        _out << "/>\n";
+      }
     }
   }
 }
@@ -536,7 +548,20 @@ void Element::PrintValuesImpl(const std::string &_prefix,
 void Element::PrintValues(std::string _prefix) const
 {
   std::ostringstream ss;
-  PrintValuesImpl(_prefix, ss);
+  PrintValuesImpl(_prefix, true, false, ss);
+  std::cout << ss.str();
+}
+
+/////////////////////////////////////////////////
+void Element::PrintValues(const std::string &_prefix,
+                          bool _includeDefaultElements,
+                          bool _includeDefaultAttributes) const
+{
+  std::ostringstream ss;
+  PrintValuesImpl(_prefix,
+                  _includeDefaultElements,
+                  _includeDefaultAttributes,
+                  ss);
   std::cout << ss.str();
 }
 
@@ -544,17 +569,35 @@ void Element::PrintValues(std::string _prefix) const
 std::string Element::ToString(const std::string &_prefix) const
 {
   std::ostringstream out;
-  this->ToString(_prefix, out);
+  this->ToString(_prefix, true, false, out);
+  return out.str();
+}
+
+/////////////////////////////////////////////////
+std::string Element::ToString(const std::string &_prefix,
+                              bool _includeDefaultElements,
+                              bool _includeDefaultAttributes) const
+{
+  std::ostringstream out;
+  this->ToString(_prefix,
+                 _includeDefaultElements,
+                 _includeDefaultAttributes,
+                 out);
   return out.str();
 }
 
 /////////////////////////////////////////////////
 void Element::ToString(const std::string &_prefix,
+                       bool _includeDefaultElements,
+                       bool _includeDefaultAttributes,
                        std::ostringstream &_out) const
 {
   if (this->dataPtr->includeFilename.empty())
   {
-    PrintValuesImpl(_prefix, _out);
+    PrintValuesImpl(_prefix,
+                    _includeDefaultElements,
+                    _includeDefaultAttributes,
+                    _out);
   }
   else
   {

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -582,7 +582,6 @@ TEST(Element, ToStringValue)
             "myprefix< test='foo'>val</>\n");
 }
 
-
 /////////////////////////////////////////////////
 TEST(Element, ToStringClonedElement)
 {
@@ -617,6 +616,75 @@ TEST(Element, ToStringInclude)
 
   std::string stringval = elem.ToString("myprefix");
   ASSERT_EQ(stringval, "myprefix<include filename='foo.txt'/>\n");
+}
+
+/////////////////////////////////////////////////
+TEST(Element, ToStringDefaultElements)
+{
+  sdf::ElementPtr parent = std::make_shared<sdf::Element>();
+  parent->SetName("parent");
+  sdf::ElementPtr elem = std::make_shared<sdf::Element>();
+  elem->SetName("elem");
+  elem->SetParent(parent);
+  parent->InsertElement(elem);
+  sdf::ElementPtr elem2 = std::make_shared<sdf::Element>();
+  elem2->SetName("elem2");
+  elem2->SetParent(parent);
+  parent->InsertElement(elem2);
+
+  std::ostringstream stream;
+  stream
+    << "<parent>\n"
+    << "  <elem/>\n"
+    << "  <elem2/>\n"
+    << "</parent>\n";
+
+  EXPECT_EQ(parent->ToString("", false, false), stream.str());
+  EXPECT_EQ(parent->ToString(""), stream.str());
+  EXPECT_EQ(parent->ToString("", true, false), stream.str());
+
+  elem->SetExplicitlySetInFile(false);
+
+  std::ostringstream stream2;
+  stream2
+    << "<parent>\n"
+    << "  <elem2/>\n"
+    << "</parent>\n";
+
+  EXPECT_EQ(parent->ToString("", false, false), stream2.str());
+  EXPECT_EQ(parent->ToString(""), stream.str());
+  EXPECT_EQ(parent->ToString("", true, false), stream.str());
+
+  parent->SetExplicitlySetInFile(false);
+
+  EXPECT_EQ(parent->ToString("", false, false), "");
+  EXPECT_EQ(parent->ToString(""), stream.str());
+  EXPECT_EQ(parent->ToString("", true, false), stream.str());
+}
+
+/////////////////////////////////////////////////
+TEST(Element, ToStringDefaultAttributes)
+{
+  sdf::ElementPtr element = std::make_shared<sdf::Element>();
+  element->SetName("foo");
+  element->AddAttribute("test", "string", "foo", false, "foo description");
+  element->AddAttribute("test2", "string", "bar", true, "bar description");
+
+  EXPECT_EQ(element->ToString(""), element->ToString("", true, false));
+  EXPECT_EQ(element->ToString(""), element->ToString("", false, false));
+
+  std::ostringstream stream;
+  stream << "<foo test2='bar'/>\n";
+
+  EXPECT_EQ(element->ToString(""), stream.str());
+  EXPECT_EQ(element->ToString("", true, false), stream.str());
+  EXPECT_EQ(element->ToString("", false, false), stream.str());
+
+  std::ostringstream stream2;
+  stream2 << "<foo test='foo' test2='bar'/>\n";
+
+  EXPECT_EQ(element->ToString("", true, true), stream2.str());
+  EXPECT_EQ(element->ToString("", false, true), stream2.str());
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/default_elements.cc
+++ b/test/integration/default_elements.cc
@@ -31,12 +31,12 @@
 //////////////////////////////////////////////////
 TEST(ExplicitlySetInFile, EmptyRoadSphCoords)
 {
-  const std::string test_file =
+  const std::string testFile =
     sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
         "empty_road_sph_coords.sdf");
 
   sdf::Root root;
-  sdf::Errors errors = root.Load(test_file);
+  sdf::Errors errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty());
 
   sdf::ElementPtr rootPtr = root.Element();
@@ -109,12 +109,12 @@ TEST(ExplicitlySetInFile, EmptyRoadSphCoords)
 //////////////////////////////////////////////////
 TEST(ExplicitlySetInFile, EmptyAxis)
 {
-  const std::string test_file =
+  const std::string testFile =
     sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
         "empty_axis.sdf");
 
   sdf::Root root;
-  sdf::Errors errors = root.Load(test_file);
+  sdf::Errors errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty());
 
   sdf::ElementPtr rootPtr = root.Element();
@@ -152,4 +152,100 @@ TEST(ExplicitlySetInFile, EmptyAxis)
 
   sdf::ElementPtr upperLimitPtr = lowerLimitPtr->GetNextElement();
   EXPECT_FALSE(upperLimitPtr->GetExplicitlySetInFile());
+}
+
+//////////////////////////////////////////////////
+TEST(ExplicitlySetInFile, ToString)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "empty_road_sph_coords.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+
+  EXPECT_EQ(root.Element()->ToString(""),
+            root.Element()->ToString("", true, false));
+
+  std::ostringstream stream;
+  std::string version = SDF_VERSION;
+  stream
+    << "<sdf version='" << version << "'>\n"
+    << "  <world name='default'>\n"
+    << "    <road name='empty_road'>\n"
+    << "    </road>\n"
+    << "    <spherical_coordinates>\n"
+    << "    </spherical_coordinates>\n"
+    << "  </world>\n"
+    << "</sdf>\n";
+
+  EXPECT_EQ(root.Element()->ToString("", false, false), stream.str());
+
+  stream.str(std::string());
+  stream
+    << "<sdf version='" << version << "'>\n"
+    << "  <world name='default'>\n"
+    << "    <road name='empty_road'>\n"
+    << "      <width>1</width>\n"
+    << "      <point>0 0 0</point>\n"
+    << "    </road>\n"
+    << "    <spherical_coordinates>\n"
+    << "      <surface_model>EARTH_WGS84</surface_model>\n"
+    << "      <latitude_deg>0</latitude_deg>\n"
+    << "      <longitude_deg>0</longitude_deg>\n"
+    << "      <elevation>0</elevation>\n"
+    << "      <heading_deg>0</heading_deg>\n"
+    << "    </spherical_coordinates>\n"
+    << "    <gravity>0 0 -9.8</gravity>\n"
+    << "    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>\n"
+    << "    <atmosphere type='adiabatic'/>\n"
+    << "    <physics type='ode'>\n"
+    << "      <max_step_size>0.001</max_step_size>\n"
+    << "      <real_time_factor>1</real_time_factor>\n"
+    << "      <real_time_update_rate>1000</real_time_update_rate>\n"
+    << "    </physics>\n"
+    << "    <scene>\n"
+    << "      <ambient>0.4 0.4 0.4 1</ambient>\n"
+    << "      <background>0.7 0.7 0.7 1</background>\n"
+    << "      <shadows>1</shadows>\n"
+    << "    </scene>\n"
+    << "  </world>\n"
+    << "</sdf>\n";
+
+  EXPECT_EQ(root.Element()->ToString(""), stream.str());
+  EXPECT_EQ(root.Element()->ToString("", true, false), stream.str());
+
+  stream.str(std::string());
+  stream
+    << "<sdf version='" << version << "'>\n"
+    << "  <world name='default'>\n"
+    << "    <road name='empty_road'>\n"
+    << "      <width>1</width>\n"
+    << "      <point>0 0 0</point>\n"
+    << "    </road>\n"
+    << "    <spherical_coordinates>\n"
+    << "      <surface_model>EARTH_WGS84</surface_model>\n"
+    << "      <latitude_deg>0</latitude_deg>\n"
+    << "      <longitude_deg>0</longitude_deg>\n"
+    << "      <elevation>0</elevation>\n"
+    << "      <heading_deg>0</heading_deg>\n"
+    << "    </spherical_coordinates>\n"
+    << "    <gravity>0 0 -9.8</gravity>\n"
+    << "    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>\n"
+    << "    <atmosphere type='adiabatic'/>\n"
+    << "    <physics name='default_physics' default='0' type='ode'>\n"
+    << "      <max_step_size>0.001</max_step_size>\n"
+    << "      <real_time_factor>1</real_time_factor>\n"
+    << "      <real_time_update_rate>1000</real_time_update_rate>\n"
+    << "    </physics>\n"
+    << "    <scene>\n"
+    << "      <ambient>0.4 0.4 0.4 1</ambient>\n"
+    << "      <background>0.7 0.7 0.7 1</background>\n"
+    << "      <shadows>1</shadows>\n"
+    << "    </scene>\n"
+    << "  </world>\n"
+    << "</sdf>\n";
+
+  EXPECT_EQ(root.Element()->ToString("", true, true), stream.str());
 }

--- a/test/sdf/empty_road_sph_coords.sdf
+++ b/test/sdf/empty_road_sph_coords.sdf
@@ -16,7 +16,7 @@
 <!--<gravity>0 0 -9.8</gravity>
     <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     <atmosphere type='adiabatic'/>
-    <physics type='ode'>
+    <physics name='default_physics' default='0' type='ode'>
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>1000</real_time_update_rate>


### PR DESCRIPTION
# ➡️ Forward port

Port `sdf9` to `sdf11`. Normally I would merge from `sdf10` to `sdf11` after #614, but I wasn't sure if the parameter passing prototype on `sdf10` is ready to be merged forward to edifice. Meanwhile, there are a lot of conflicts between #601 and #602 that completely disappear after taking several minutes to resolve them all, so I wanted to simplify our lives by getting that conflict resolution out of the way.

Branch comparison: https://github.com/ignitionrobotics/sdformat/compare/sdf11...sdf9

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)
