### PR TITLE
Bazel sdf11

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -114,7 +114,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "libsdformat_tools.so",
+    name = "sdformat.so",
     srcs = [
         "src/ign.cc",
         "src/ign.hh",
@@ -153,7 +153,7 @@ cmake_configure_file(
     out = "cmdsdformat.rb",
     cmakelists = ["CMakeLists.txt"],
     defines = [
-        "library_location=libsdformat_tools.so",
+        "library_location=sdformat.so",
         "PROJECT_VERSION_FULL=%d.%d.%d" % (SDF_MAJOR_VERSION, SDF_MINOR_VERSION, SDF_PATCH_VERSION),  # noqa
         "IGN_LIBRARY_NAME=%s" % [PROJECT_NAME],
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,7 +58,7 @@ public_headers_no_gen = glob(["include/sdf/*.hh"])
 
 private_headers = glob(["src/*.hh"])
 
-sources = glob(["src/*.cc"], exclude=["src/*_TEST.cc"]) + ["EmbeddedSdf.cc"]
+sources = glob(["src/*.cc"], exclude=["src/*_TEST.cc", "src/ign.cc"]) + ["EmbeddedSdf.cc"]
 
 test_sources = glob(["src/*_TEST.cc"], exclude=["src/ign_TEST.cc"])
 
@@ -114,9 +114,14 @@ cc_library(
 )
 
 cc_binary(
-    name = "libsdformat10.so",
-    deps = [":sdformat"],
+    name = "libsdformat_tools.so",
+    srcs = [
+        "src/ign.cc",
+        "src/ign.hh",
+    ],
+    includes = ["include"],
     linkshared = True,
+    deps = [":sdformat"],
 )
 
 [cc_test(
@@ -142,5 +147,26 @@ cc_binary(
     ],
 ) for src in test_sources]
 
+cmake_configure_file(
+    name = "sdformat.rb",
+    src = "src/cmd/cmdsdformat.rb.in",
+    out = "cmdsdformat.rb",
+    cmakelists = ["CMakeLists.txt"],
+    defines = [
+        "library_location=libsdformat_tools.so",
+        "PROJECT_VERSION_FULL=%d.%d.%d" % (SDF_MAJOR_VERSION, SDF_MINOR_VERSION, SDF_PATCH_VERSION),  # noqa
+        "IGN_LIBRARY_NAME=%s" % [PROJECT_NAME],
+    ],
+)
+
+CMDS = "    - sdf   : Utilities for SDF files."
+
+generate_yaml(
+    name = "sdf",
+    commands = CMDS,
+    library_name = PROJECT_NAME,
+    library_version = "%d.%d.%d" % (SDF_MAJOR_VERSION, SDF_MINOR_VERSION, SDF_PATCH_VERSION),
+    ruby_target = "sdformat.rb",
+)
+
 exports_files(["tools"])
-exports_files(["src/cmd/cmdsdformat.rb.in"])


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Added missing Bazel targets required for Ignition Tools ruby tool `sdformat:sdf` and `sdformat:sdformat.so`.
See https://github.com/ignitionrobotics/ign-tools/blob/bazel-tools1/BUILD.bazel

## Checklist
- [x ] Signed all commits for DCO

**Note to maintainers**: Remember to use **Squash-Merge**