### PR TITLE
Emit an error instead of a warning when a file has multiple root level model, actor or light elements

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,24 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 11.x to 12.0
+
+An error is now emitted instead of a warning for a file containing more than
+one root level model, actor or light.
+
+### Removals
+
+1. **src/Root.hh**: The following deprecated methods have been removed.
+    + const sdf::Model \*ModelByIndex();
+    + uint64_t ModelCount();
+    + bool ModelNameExists(const std::string &\_name) const;
+    + const sdf::Light \*LightByIndex();
+    + uint64_t LightCount();
+    + bool LightNameExists(const std::string &\_name) const;
+    + const sdf::Actor \*ActorByIndex();
+    + uint64_t ActorCount();
+    + bool ActorNameExists(const std::string &\_name) const;
+
 ## libsdformat 11.1.0 to 11.2.0
 
 ABI was broken for `sdf::Element`, and restored on version 11.2.1.

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -130,92 +130,17 @@ namespace sdf
     /// \return True if there exists a world with the given name.
     public: bool WorldNameExists(const std::string &_name) const;
 
-    /// \brief Get the number of models that are immediate (not nested) children
-    /// of this Root object.
-    /// \return Number of models contained in this Root object.
-    public: uint64_t ModelCount() const SDF_DEPRECATED(11.0);
-
-    /// \brief Get a model based on an index.
-    /// \param[in] _index Index of the model. The index should be in the
-    /// range [0..ModelCount()).
-    /// \return Pointer to the model. Nullptr if the index does not exist.
-    /// \sa uint64_t ModelCount() const
-    public: const sdf::Model *ModelByIndex(const uint64_t _index) const
-        SDF_DEPRECATED(11.0);
-
-    /// \brief Get whether a model name exists.
-    /// \param[in] _name Name of the model to check.
-    /// \return True if there exists a model with the given name.
-    public: bool ModelNameExists(const std::string &_name) const
-        SDF_DEPRECATED(11.0);
-
     /// \brief Get a pointer to the model object if it exists.
-    ///
-    /// If there is more than one model, this will return the first element.
-    /// This method is preferred to ModelByIndex, as its behavior is
-    /// consistent with the planned future API. Having more than one Model, or
-    /// more than one of Model/Actor/Light is now considered deprecated and
-    /// should not be relied upon going forward.
     ///
     /// \return A pointer to the model, nullptr if it doesn't exist
     public: const sdf::Model *Model() const;
 
-    /// \brief Get the number of lights.
-    /// \return Number of lights contained in this Root object.
-    public: uint64_t LightCount() const SDF_DEPRECATED(11.0);
-
-    /// \brief Get a light based on an index.
-    /// \param[in] _index Index of the light. The index should be in the
-    /// range [0..LightCount()).
-    /// \return Pointer to the light. Nullptr if the index does not exist.
-    /// \sa uint64_t LightCount() const
-    public: const sdf::Light *LightByIndex(const uint64_t _index) const
-        SDF_DEPRECATED(11.0);
-
-    /// \brief Get whether a light name exists.
-    /// \param[in] _name Name of the light to check.
-    /// \return True if there exists a light with the given name.
-    public: bool LightNameExists(const std::string &_name) const
-        SDF_DEPRECATED(11.0);
-
     /// \brief Get a pointer to the light object if it exists.
-    ///
-    /// If there is more than one light, this will return the first element. If
-    /// there is already a model element, this will return null.
-    /// This method is preferred to LightByIndex, as its behavior is
-    /// consistent with the planned future API. Having more than one Light, or
-    /// more than one of Model/Actor/Light is now considered deprecated and
-    /// should not be relied upon going forward.
     ///
     /// \return A pointer to the light, nullptr if it doesn't exist
     public: const sdf::Light *Light() const;
 
-    /// \brief Get the number of actors.
-    /// \return Number of actors contained in this Root object.
-    public: uint64_t ActorCount() const SDF_DEPRECATED(11.0);
-
-    /// \brief Get an actor based on an index.
-    /// \param[in] _index Index of the actor. The actor should be in the
-    /// range [0..ActorCount()).
-    /// \return Pointer to the actor. Nullptr if the index does not exist.
-    /// \sa uint64_t ActorCount() const
-    public: const sdf::Actor *ActorByIndex(const uint64_t _index) const
-        SDF_DEPRECATED(11.0);
-
-    /// \brief Get whether an actor name exists.
-    /// \param[in] _name Name of the actor to check.
-    /// \return True if there exists an actor with the given name.
-    public: bool ActorNameExists(const std::string &_name) const
-        SDF_DEPRECATED(11.0);
-
     /// \brief Get a pointer to the actor object if it exists.
-    ///
-    /// If there is more than one actor, this will return the first element. If
-    /// there is already a model or light element, this will return null.
-    /// This method is preferred to ActorByIndex, as its behavior is
-    /// consistent with the planned future API. Having more than one Actor, or
-    /// more than one of Model/Actor/Light is now considered deprecated and
-    /// should not be relied upon going forward.
     ///
     /// \return A pointer to the actor, nullptr if it doesn't exist
     public: const sdf::Actor *Actor() const;

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -42,26 +42,6 @@ TEST(DOMRoot, Construction)
   EXPECT_EQ(nullptr, root.Model());
   EXPECT_EQ(nullptr, root.Light());
   EXPECT_EQ(nullptr, root.Actor());
-
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  EXPECT_FALSE(root.ModelNameExists("default"));
-  EXPECT_FALSE(root.ModelNameExists(""));
-  EXPECT_EQ(0u, root.ModelCount());
-  EXPECT_TRUE(root.ModelByIndex(0) == nullptr);
-  EXPECT_TRUE(root.ModelByIndex(1) == nullptr);
-
-  EXPECT_FALSE(root.LightNameExists("default"));
-  EXPECT_FALSE(root.LightNameExists(""));
-  EXPECT_EQ(0u, root.LightCount());
-  EXPECT_TRUE(root.LightByIndex(0) == nullptr);
-  EXPECT_TRUE(root.LightByIndex(1) == nullptr);
-
-  EXPECT_FALSE(root.ActorNameExists("default"));
-  EXPECT_FALSE(root.ActorNameExists(""));
-  EXPECT_EQ(0u, root.ActorCount());
-  EXPECT_TRUE(root.ActorByIndex(0) == nullptr);
-  EXPECT_TRUE(root.ActorByIndex(1) == nullptr);
-  SDF_SUPPRESS_DEPRECATED_END
 }
 
 /////////////////////////////////////////////////

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1234,10 +1234,10 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             return false;
           }
 
-          // For now there is only a warning if there is more than one model,
-          // actor or light element, or two different types of those elements.
-          // For compatibility with old behavior, this chooses the first element
-          // in the preference order: model->actor->light
+          // Emit an error if there is more than one model, actor or light
+          // element, or two different types of those elements. For
+          // compatibility with old behavior, this chooses the first element in
+          // the preference order: model->actor->light
           sdf::ElementPtr topLevelElem;
           for (const auto &elementType : {"model", "actor", "light"})
           {
@@ -1252,13 +1252,11 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 std::stringstream ss;
                 ss << "Found other top level element <" << elementType
                   << "> in addition to <" << topLevelElem->GetName()
-                  << "> in include file. This is unsupported and in future "
-                  << "versions of libsdformat will become an error";
+                  << "> in include file.";
                 Error err(
                     ErrorCode::ELEMENT_INCORRECT_TYPE, ss.str(), filename);
                 err.SetXmlPath("/sdf/" + std::string(elementType));
-                enforceConfigurablePolicyCondition(
-                    _config.WarningsPolicy(), err, _errors);
+                _errors.push_back(err);
               }
             }
           }
@@ -1283,14 +1281,12 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           if (nullptr != nextTopLevelElem)
           {
             std::stringstream ss;
-            ss << "Found more than one of " << topLevelElem->GetName()
-              << " for <include>. This is unsupported and in future "
-              << "versions of libsdformat will become an error";
+            ss << "Found more than one " << topLevelElem->GetName()
+              << " for <include>.";
             Error err(
                 ErrorCode::ELEMENT_INCORRECT_TYPE, ss.str(), filename);
             err.SetXmlPath("/sdf/" + topLevelElementType);
-            enforceConfigurablePolicyCondition(
-                _config.WarningsPolicy(), err, _errors);
+            _errors.push_back(err);
           }
 
           bool isModel = topLevelElementType == "model";

--- a/test/integration/model/nested_multiple_actors_error/model.sdf
+++ b/test/integration/model/nested_multiple_actors_error/model.sdf
@@ -1,8 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
-  <!-- The included sdf model contains multiple actor elements, and is an
-  example of poorly formed file. Currently this is unsupported and will
-  eventually become a parsing error -->
+  <!-- The included sdf model contains multiple actor elements, and is
+  considered an invalid file.-->
 
   <include>
     <!-- This search path for this model must be added by the test code -->

--- a/test/integration/model/nested_multiple_elements_error/model.sdf
+++ b/test/integration/model/nested_multiple_elements_error/model.sdf
@@ -1,8 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
-  <!-- The included sdf model contain actor, light and actor elements, and is an
-  example of poorly formed file. Currently this is unsupported and will
-  eventually become a parsing error -->
+  <!-- The included sdf model contain actor, light and actor elements, and is
+  considered an invalid file.-->
 
   <include>
     <!-- This search path for this model must be added by the test code -->

--- a/test/integration/model/nested_multiple_lights_error/model.sdf
+++ b/test/integration/model/nested_multiple_lights_error/model.sdf
@@ -1,8 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
-  <!-- The included sdf model contains multiple light elements, and is an
-  example of poorly formed file. Currently this is unsupported and will
-  eventually become a parsing error -->
+  <!-- The included sdf model contains multiple light elements, and is
+  considered an invalid file.-->
 
   <include>
     <!-- This search path for this model must be added by the test code -->

--- a/test/integration/model/nested_multiple_models_error/model.sdf
+++ b/test/integration/model/nested_multiple_models_error/model.sdf
@@ -1,8 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
-  <!-- The included sdf model contains multiple model elements, and is an
-  example of poorly formed file. Currently this is unsupported and will
-  eventually become a parsing error -->
+  <!-- The included sdf model contains multiple model elements, and is
+  considered an invalid file.-->
 
   <include>
     <!-- This search path for this model must be added by the test code -->

--- a/test/integration/nested_multiple_elements_error.cc
+++ b/test/integration/nested_multiple_elements_error.cc
@@ -40,8 +40,8 @@ std::string findFileCb(const std::string &_input)
 }
 
 //////////////////////////////////////////////////
-// Currently this only issues a parsing warning and should take the first model
-// element
+// Check that an error is emitted if there are multiple models in an included
+// file. Despite the error, the first model should be loaded.
 TEST(IncludesTest, NestedMultipleModelsError)
 {
   sdf::setFindCallback(findFileCb);
@@ -51,14 +51,9 @@ TEST(IncludesTest, NestedMultipleModelsError)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(sdfFile);
-  if (!errors.empty())
-  {
-    for (const auto &error : errors)
-    {
-      std::cout << error << std::endl;
-    }
-    ASSERT_TRUE(errors.empty());
-  }
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
+  EXPECT_EQ("Found more than one model for <include>.", errors[0].Message());
 
   const auto * model = root.Model();
   ASSERT_NE(nullptr, model);
@@ -72,8 +67,8 @@ TEST(IncludesTest, NestedMultipleModelsError)
 }
 
 //////////////////////////////////////////////////
-// Currently this only issues a parsing warning and should take the first actor
-// element
+// Check that an error is emitted if there are multiple actors in an included
+// file. Despite the error, the first actor should be loaded.
 TEST(IncludesTest, NestedMultipleActorsError)
 {
   sdf::setFindCallback(findFileCb);
@@ -83,14 +78,9 @@ TEST(IncludesTest, NestedMultipleActorsError)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(sdfFile);
-  if (!errors.empty())
-  {
-    for (const auto &error : errors)
-    {
-      std::cout << error << std::endl;
-    }
-    ASSERT_TRUE(errors.empty());
-  }
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
+  EXPECT_EQ("Found more than one actor for <include>.", errors[0].Message());
 
   EXPECT_EQ(nullptr, root.Model());
   EXPECT_EQ(nullptr, root.Light());
@@ -103,8 +93,8 @@ TEST(IncludesTest, NestedMultipleActorsError)
 }
 
 //////////////////////////////////////////////////
-// Currently this only issues a parsing warning and should take the first light
-// element
+// Check that an error is emitted if there are multiple lights in an included
+// file. Despite the error, the first light should be loaded.
 TEST(IncludesTest, NestedMultipleLightsError)
 {
   sdf::setFindCallback(findFileCb);
@@ -114,14 +104,9 @@ TEST(IncludesTest, NestedMultipleLightsError)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(sdfFile);
-  if (!errors.empty())
-  {
-    for (const auto &error : errors)
-    {
-      std::cout << error << std::endl;
-    }
-    ASSERT_TRUE(errors.empty());
-  }
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
+  EXPECT_EQ("Found more than one light for <include>.", errors[0].Message());
 
   EXPECT_EQ(nullptr, root.Model());
   EXPECT_EQ(nullptr, root.Actor());
@@ -133,8 +118,9 @@ TEST(IncludesTest, NestedMultipleLightsError)
 }
 
 //////////////////////////////////////////////////
-// Currently this only issues a parsing warning and should take the first
-// model, actor, light in that order
+// Check that an error is emitted if there are more than one of model, actor, or
+// light in an included file. Despite the error, the
+// the first model, actor, light should be loaded in that order of preference.
 TEST(IncludesTest, NestedMultipleElementsError)
 {
   sdf::setFindCallback(findFileCb);
@@ -144,14 +130,12 @@ TEST(IncludesTest, NestedMultipleElementsError)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(sdfFile);
-  if (!errors.empty())
-  {
-    for (const auto &error : errors)
-    {
-      std::cout << error << std::endl;
-    }
-    ASSERT_TRUE(errors.empty());
-  }
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
+  EXPECT_EQ(
+      "Found other top level element <actor> in addition to <model> in include "
+      "file.",
+      errors[0].Message());
 
   EXPECT_EQ(nullptr, root.Light());
   EXPECT_EQ(nullptr, root.Actor());
@@ -172,14 +156,8 @@ TEST(IncludesTest, NestedMultipleElementsErrorWorld)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(sdfFile);
-  if (!errors.empty())
-  {
-    for (const auto &error : errors)
-    {
-      std::cout << error << std::endl;
-    }
-    ASSERT_TRUE(errors.empty());
-  }
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
 
   EXPECT_EQ(nullptr, root.Light());
   EXPECT_EQ(nullptr, root.Actor());

--- a/test/integration/root_dom.cc
+++ b/test/integration/root_dom.cc
@@ -82,24 +82,15 @@ TEST(DOMRoot, LoadMultipleModels)
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
 
-  // Currently just warnings are issued in this case, eventually they may become
+  // An error should be emitted since there are multiple root models.
   // errors. For now, only the first model is loaded.
-  EXPECT_TRUE(errors.empty()) << errors;
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::ELEMENT_INCORRECT_TYPE, errors[0].Code());
+  EXPECT_EQ("Root object can only contain one model. Using the first one found",
+            errors[0].Message());
+
   ASSERT_NE(nullptr, root.Model());
   EXPECT_EQ("robot1", root.Model()->Name());
-
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  EXPECT_EQ(3u, root.ModelCount());
-
-  EXPECT_EQ("robot1", root.ModelByIndex(0)->Name());
-  EXPECT_EQ("robot2", root.ModelByIndex(1)->Name());
-  EXPECT_EQ("last_robot", root.ModelByIndex(2)->Name());
-
-  EXPECT_FALSE(root.ModelNameExists("robot"));
-  EXPECT_TRUE(root.ModelNameExists("robot1"));
-  EXPECT_TRUE(root.ModelNameExists("robot2"));
-  EXPECT_TRUE(root.ModelNameExists("last_robot"));
-  SDF_SUPPRESS_DEPRECATED_END
 }
 
 /////////////////////////////////////////////////
@@ -110,12 +101,10 @@ TEST(DOMRoot, LoadDuplicateModels)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
-  EXPECT_FALSE(errors.empty());
+  ASSERT_FALSE(errors.empty());
+  EXPECT_EQ(sdf::ErrorCode::DUPLICATE_NAME, errors[0].Code());
+  EXPECT_EQ("model with name[robot1] already exists.", errors[0].Message());
+
   EXPECT_NE(nullptr, root.Model());
   EXPECT_EQ("robot1", root.Model()->Name());
-
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  EXPECT_EQ(1u, root.ModelCount());
-  EXPECT_EQ("robot1", root.ModelByIndex(0)->Name());
-  SDF_SUPPRESS_DEPRECATED_END
 }


### PR DESCRIPTION
## Summary
https://github.com/ignitionrobotics/sdformat/pull/433 and https://github.com/ignitionrobotics/sdformat/pull/444 made it so that only one root level model, actor or light can be contained in an SDFormat file. So as to not break existing behavior, only a warning was issued if more than one is found. These have now been converted to errors. This PR also removes deprecated functions for accessing multiple model, actor or light elements from `sdf::Root`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
