### PR TITLE
Add Element::FindElement as an alternative to Element::GetElement

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,13 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 9.3 to 9.5
+
+### Additions
+
+1. **sdf/Element.hh**
+    + sdf::ElementPtr FindElement() const
+
 ## libsdformat 9.3 to 9.4
 
 ### Modifications

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -52,6 +52,10 @@ namespace sdf
   /// \brief Shared pointer to an SDF Element
   typedef std::shared_ptr<Element> ElementPtr;
 
+  /// \def ElementConstPtr
+  /// \brief Shared pointer to a const SDF Element
+  typedef std::shared_ptr<const Element> ElementConstPtr;
+
   /// \def ElementWeakPtr
   /// \brief Weak pointer to an SDF Element
   typedef std::weak_ptr<Element> ElementWeakPtr;
@@ -377,7 +381,18 @@ namespace sdf
     /// \param[in] _name Name of the child element to retreive.
     /// \return Pointer to the existing child element, or nullptr
     /// if the child element was not found.
-    public: ElementPtr FindElement(const std::string &_name) const;
+    public: ElementPtr FindElement(const std::string &_name);
+
+    /// \brief Return a pointer to the child element with the provided name.
+    ///
+    /// Unlike \ref GetElement, this does not create a new child element if it
+    /// fails to find an existing element.
+    /// \remarks If there are multiple elements with the given tag, it returns
+    ///          the first one.
+    /// \param[in] _name Name of the child element to retreive.
+    /// \return Pointer to the existing child element, or nullptr
+    /// if the child element was not found.
+    public: ElementConstPtr FindElement(const std::string &_name) const;
 
     /// \brief Add a named element.
     /// \param[in] _name the name of the element to add.

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -359,13 +359,25 @@ namespace sdf
     /// \brief Return a pointer to the child element with the provided name.
     ///
     /// A new child element, with the provided name, is added to this element
-    /// if there is no existing child element.
+    /// if there is no existing child element. If this is not desired see \ref
+    /// FindElement
     /// \remarks If there are multiple elements with the given tag, it returns
     ///          the first one.
     /// \param[in] _name Name of the child element to retreive.
     /// \return Pointer to the existing child element, or a new child
     /// element if an existing child element did not exist.
     public: ElementPtr GetElement(const std::string &_name);
+
+    /// \brief Return a pointer to the child element with the provided name.
+    ///
+    /// Unlike \ref GetElement, this does not create a new child element if it
+    /// fails to find an existing element.
+    /// \remarks If there are multiple elements with the given tag, it returns
+    ///          the first one.
+    /// \param[in] _name Name of the child element to retreive.
+    /// \return Pointer to the existing child element, or nullptr
+    /// if the child element was not found.
+    public: ElementPtr FindElement(const std::string &_name) const;
 
     /// \brief Add a named element.
     /// \param[in] _name the name of the element to add.

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -828,7 +828,13 @@ ElementPtr Element::GetElement(const std::string &_name)
 }
 
 /////////////////////////////////////////////////
-ElementPtr Element::FindElement(const std::string &_name) const
+ElementPtr Element::FindElement(const std::string &_name)
+{
+  return this->GetElementImpl(_name);
+}
+
+/////////////////////////////////////////////////
+ElementConstPtr Element::FindElement(const std::string &_name) const
 {
   return this->GetElementImpl(_name);
 }

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -828,6 +828,12 @@ ElementPtr Element::GetElement(const std::string &_name)
 }
 
 /////////////////////////////////////////////////
+ElementPtr Element::FindElement(const std::string &_name) const
+{
+  return this->GetElementImpl(_name);
+}
+
+/////////////////////////////////////////////////
 void Element::InsertElement(ElementPtr _elem)
 {
   this->dataPtr->elements.push_back(_elem);

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -827,7 +827,7 @@ TEST(Element, GetNextElementMultiple)
 
 /////////////////////////////////////////////////
 /// Helper function to add child elements without having to create descriptions
-sdf::ElementPtr AddChildElement(sdf::ElementPtr _parent,
+sdf::ElementPtr addChildElement(sdf::ElementPtr _parent,
                                 const std::string &_elementName,
                                 const bool _addNameAttribute,
                                 const std::string &_childName)
@@ -864,11 +864,11 @@ TEST(Element, CountNamedElements)
   // <element name="child2"/>
   // <element name="child3"/>
   // <element />
-  AddChildElement(parent, "child", true, "child1");
-  AddChildElement(parent, "child", true, "child2");
-  AddChildElement(parent, "element", true, "child2");
-  AddChildElement(parent, "element", true, "child3");
-  AddChildElement(parent, "element", false, "unset");
+  addChildElement(parent, "child", true, "child1");
+  addChildElement(parent, "child", true, "child2");
+  addChildElement(parent, "element", true, "child2");
+  addChildElement(parent, "element", true, "child3");
+  addChildElement(parent, "element", false, "unset");
 
   // test GetElementTypeNames
   auto typeNames = parent->GetElementTypeNames();
@@ -934,14 +934,14 @@ TEST(Element, FindElement)
 
   // Create elements
   {
-    auto elemA = AddChildElement(root, "elem_A", false, "");
-    AddChildElement(elemA, "child_elem_A", false, "");
+    auto elemA = addChildElement(root, "elem_A", false, "");
+    addChildElement(elemA, "child_elem_A", false, "");
 
-    auto elemB = AddChildElement(root, "elem_B", false, "");
+    auto elemB = addChildElement(root, "elem_B", false, "");
     auto firstChildElemB =
-        AddChildElement(elemB, "child_elem_B", true, "first_child");
+        addChildElement(elemB, "child_elem_B", true, "first_child");
 
-    AddChildElement(elemB, "child_elem_B", false, "");
+    addChildElement(elemB, "child_elem_B", false, "");
   }
 
   {

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -842,7 +842,7 @@ sdf::ElementPtr AddChildElement(sdf::ElementPtr _parent,
     child->AddAttribute("name", "string", _childName, false, "description");
   }
   return child;
-};
+}
 
 /////////////////////////////////////////////////
 TEST(Element, CountNamedElements)
@@ -960,6 +960,21 @@ TEST(Element, FindElement)
   }
 
   // Check that it works with const pointers
+  {
+    sdf::ElementConstPtr rootConst = root;
+    sdf::ElementConstPtr elemA = rootConst->FindElement("elem_A");
+    ASSERT_NE(nullptr, elemA);
+    EXPECT_NE(nullptr, elemA->FindElement("child_elem_A"));
+    EXPECT_EQ(nullptr, elemA->FindElement("non_existent_elem"));
+
+    sdf::ElementConstPtr elemB = root->FindElement("elem_B");
+    ASSERT_NE(nullptr, elemB);
+    // This should find the first "child_elem_B" element, which has the name
+    // attribute
+    sdf::ElementConstPtr childElemB = elemB->FindElement("child_elem_B");
+    ASSERT_TRUE(childElemB->HasAttribute("name"));
+    EXPECT_EQ("first_child", childElemB->GetAttribute("name")->GetAsString());
+  }
   {
     sdf::ElementConstPtr rootConst = root;
     sdf::ElementConstPtr elemA = rootConst->FindElement("elem_A");


### PR DESCRIPTION
# 🎉 New feature

Closes #188

## Summary
`Element::GetElement` may create a child element if it doesn't exist.
This makes it a non-const function. Instead of changing this behavior, a
new function `Element::FindElement` is added that returns a `nullptr` if
the child element is not found instead of creating a new element.

## Test it
Run test `UNIT_Element_TEST`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
