### PR TITLE
Remove deprecated functions and classes

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -32,7 +32,7 @@ The following deprecated methods and classes have been removed.
     + double InitialPosition() const;
     + void SetInitialPosition(const double)
 
-1. **src/Root.hh**:
+1. **sdf/Root.hh**:
     + const sdf::Model \*ModelByIndex();
     + uint64_t ModelCount();
     + bool ModelNameExists(const std::string &\_name) const;

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,23 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 11.x to 12.0
+
+### Removals
+
+The following deprecated methods and classes have been removed.
+
+1. **sdf/Element.hh**
+    + void SetInclude(const std::string);
+-   + std::string GetInclude() const;
+
+1. **sdf/Types.hh**
+    + sdf::Color class
+
+1. **sdf/JointAxis.hh**
+    + double InitialPosition() const;
+    + void SetInitialPosition(const double)
+
 ## libsdformat 11.1.0 to 11.2.0
 
 ABI was broken for `sdf::Element`, and restored on version 11.2.1.
@@ -332,6 +349,11 @@ ABI was broken for `sdf::Element`, and restored on version 11.2.1.
     + [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/245)
 
 ## SDFormat specification 1.8 to 1.9
+
+###Removals
+
+1. **joint.sdf**
+    + Deprecated elements `//joint/axis/initial_position` and `//joint/axis2/initial_position` have been removed
 
 ## SDFormat specification 1.7 to 1.8
 

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -395,14 +395,6 @@ namespace sdf
     ///        embedded Param.
     public: void Reset();
 
-    /// \brief Set the include filename to the passed in filename.
-    /// \param[in] _filename the filename to set the include filename to.
-    public: void SetInclude(const std::string &_filename) SDF_DEPRECATED(11.0);
-
-    /// \brief Get the include filename.
-    /// \return The include filename.
-    public: std::string GetInclude() const SDF_DEPRECATED(11.0);
-
     /// \brief Set the <include> element that was used to load this element.
     /// This is set by the parser on the first element of the included object
     /// (eg. Model, Actor, Light, etc). It is not passed down to children
@@ -561,9 +553,6 @@ namespace sdf
     /// <include> tag after the entity has been loaded. An example use case for
     /// this is when saving a loaded world back to SDFormat.
     public: ElementPtr includeElement;
-
-    /// name of the include file that was used to create this element
-    public: std::string includeFilename;
 
     /// \brief Name of reference sdf.
     public: std::string referenceSDF;

--- a/include/sdf/JointAxis.hh
+++ b/include/sdf/JointAxis.hh
@@ -52,17 +52,6 @@ namespace sdf
     /// an error code and message. An empty vector indicates no error.
     public: Errors Load(ElementPtr _sdf);
 
-    /// \brief Get the initial joint position for this joint axis. The
-    /// default value is zero (0.0).
-    /// \return The initial joint position.
-    /// \sa void SetInitialPosition(const double _pos)
-    public: double InitialPosition() const SDF_DEPRECATED(10.0);
-
-    /// \brief Set the initial joint position for this joint axis.
-    /// \param[in] _pos The initial joint position.
-    /// \sa double InitialPosition() const
-    public: void SetInitialPosition(const double _pos) SDF_DEPRECATED(10.0);
-
     /// \brief Get the x,y,z components of the axis unit vector.
     /// The axis is expressed in the frame named in XyzExpressedIn() and
     /// defaults to the joint frame if that method returns an empty string.

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -112,66 +112,6 @@ namespace sdf
   SDFORMAT_VISIBLE std::ostream &operator<<(
       std::ostream &_out, const sdf::Errors &_errs);
 
-  /// \brief Defines a color
-  class SDFORMAT_VISIBLE Color
-  {
-    /// \brief Constructor
-    /// \param[in] _r Red value (range 0 to 1)
-    /// \param[in] _g Green value (range 0 to 1
-    /// \param[in] _b Blue value (range 0 to 1
-    /// \param[in] _a Alpha value (0=transparent, 1=opaque)
-    /// \deprecated Use ignition::math::Color
-    public: Color(float _r = 0.0f, float _g = 0.0f,
-                  float _b = 0.0f, float _a = 1.0f) SDF_DEPRECATED(6.0)
-            : r(_r), g(_g), b(_b), a(_a)
-    {}
-
-    /// \brief Stream insertion operator
-    /// \param[in] _out the output stream
-    /// \param[in] _pt the color
-    /// \return the output stream
-    public: friend std::ostream &operator<< (std::ostream &_out,
-                                             const Color &_pt)
-    {
-      _out << _pt.r << " " << _pt.g << " " << _pt.b << " " << _pt.a;
-      return _out;
-    }
-
-    /// \brief Stream insertion operator
-    /// \param[in] _in the input stream
-    /// \param[in] _pt
-    public: friend std::istream &operator>> (std::istream &_in, Color &_pt)
-    {
-      // Skip white spaces
-      _in.setf(std::ios_base::skipws);
-      _in >> _pt.r >> _pt.g >> _pt.b >> _pt.a;
-      return _in;
-    }
-
-    /// \brief Equality operator
-    /// \param[in] _clr The color to check for equality
-    /// \return True if the this color equals _clf
-    public: bool operator ==(const Color &_clr) const
-    {
-      return equal(this->r, _clr.r) &&
-        equal(this->g, _clr.g) &&
-        equal(this->b, _clr.b) &&
-        equal(this->a, _clr.a);
-    }
-
-    /// \brief Red value
-    public: float r;
-
-    /// \brief Green value
-    public: float g;
-
-    /// \brief Blue value
-    public: float b;
-
-    /// \brief Alpha value
-    public: float a;
-  };
-
   /// \brief A Time class, can be used to hold wall- or sim-time.
   /// stored as sec and nano-sec.
   class SDFORMAT_VISIBLE Time

--- a/sdf/1.9/1_8.convert
+++ b/sdf/1.9/1_8.convert
@@ -1,3 +1,12 @@
 <convert name="sdf">
 
+<!-- Remove //axis/initial_position and //axis2/initial_position -->
+  <convert descendant_name="joint">
+    <convert name="axis">
+      <remove element="initial_position"/>
+    </convert>
+    <convert name="axis2">
+      <remove element="initial_position"/>
+    </convert>
+  </convert>
 </convert> <!-- End SDF -->

--- a/sdf/1.9/joint.sdf
+++ b/sdf/1.9/joint.sdf
@@ -45,11 +45,6 @@
       Parameters related to the axis of rotation for revolute joints,
       the axis of translation for prismatic joints.
     </description>
-    <element name="initial_position" type="double" default="0" required="-1">
-      <description>
-        (DEPRECATION WARNING: This tag has no known implementation. It is deprecated SDFormat 1.8 and will be removed in SDFormat 1.9) Default joint position for this joint axis.
-      </description>
-    </element>
     <element name="xyz" type="vector3" default="0 0 1" required="1">
       <description>
         Represents the x,y,z components of the axis unit vector. The axis is
@@ -107,11 +102,6 @@
     <description>
       Parameters related to the second axis of rotation for revolute2 joints and universal joints.
     </description>
-    <element name="initial_position" type="double" default="0" required="-1">
-      <description>
-        (DEPRECATION WARNING: This tag has no known implementation. It is deprecated SDFormat 1.8 and will be removed in SDFormat 1.9) Default joint position for this joint axis.
-      </description>
-    </element>
     <element name="xyz" type="vector3" default="0 0 1" required="1">
       <description>
         Represents the x,y,z components of the axis unit vector. The axis is

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -184,7 +184,6 @@ ElementPtr Element::Clone() const
   clone->dataPtr->name = this->dataPtr->name;
   clone->dataPtr->required = this->dataPtr->required;
   clone->dataPtr->copyChildren = this->dataPtr->copyChildren;
-  clone->dataPtr->includeFilename = this->dataPtr->includeFilename;
   clone->dataPtr->referenceSDF = this->dataPtr->referenceSDF;
   clone->dataPtr->path = this->dataPtr->path;
   clone->dataPtr->lineNumber = this->dataPtr->lineNumber;
@@ -233,7 +232,6 @@ void Element::Copy(const ElementPtr _elem)
   this->dataPtr->description = _elem->GetDescription();
   this->dataPtr->required = _elem->GetRequired();
   this->dataPtr->copyChildren = _elem->GetCopyChildren();
-  this->dataPtr->includeFilename = _elem->dataPtr->includeFilename;
   this->dataPtr->referenceSDF = _elem->ReferenceSDF();
   this->dataPtr->originalVersion = _elem->OriginalVersion();
   this->dataPtr->path = _elem->FilePath();
@@ -552,15 +550,7 @@ std::string Element::ToString(const std::string &_prefix) const
 void Element::ToString(const std::string &_prefix,
                        std::ostringstream &_out) const
 {
-  if (this->dataPtr->includeFilename.empty())
-  {
-    PrintValuesImpl(_prefix, _out);
-  }
-  else
-  {
-    _out << _prefix << "<include filename='"
-         << this->dataPtr->includeFilename << "'/>\n";
-  }
+  PrintValuesImpl(_prefix, _out);
 }
 
 /////////////////////////////////////////////////
@@ -964,18 +954,6 @@ void Element::Reset()
 void Element::AddElementDescription(ElementPtr _elem)
 {
   this->dataPtr->elementDescriptions.push_back(_elem);
-}
-
-/////////////////////////////////////////////////
-void Element::SetInclude(const std::string &_filename)
-{
-  this->dataPtr->includeFilename = _filename;
-}
-
-/////////////////////////////////////////////////
-std::string Element::GetInclude() const
-{
-  return this->dataPtr->includeFilename;
 }
 
 /////////////////////////////////////////////////

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -284,14 +284,6 @@ TEST(Element, Include)
 {
   sdf::Element elem;
 
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  ASSERT_EQ(elem.GetInclude(), "");
-
-  elem.SetInclude("foo.txt");
-
-  ASSERT_EQ(elem.GetInclude(), "foo.txt");
-  SDF_SUPPRESS_DEPRECATED_END
-
   auto includeElemToStore = std::make_shared<sdf::Element>();
   includeElemToStore->SetName("include");
   auto uriDesc = std::make_shared<sdf::Element>();
@@ -600,23 +592,6 @@ TEST(Element, ToStringClonedElement)
   sdf::ElementPtr parentClone = parent->Clone();
   EXPECT_TRUE(parentClone->GetAttributeSet("test"));
   EXPECT_EQ(parent->ToString("myprefix"), parentClone->ToString("myprefix"));
-}
-
-/////////////////////////////////////////////////
-TEST(Element, ToStringInclude)
-{
-  sdf::Element elem;
-
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  ASSERT_EQ(elem.GetInclude(), "");
-
-  elem.SetInclude("foo.txt");
-
-  ASSERT_EQ(elem.GetInclude(), "foo.txt");
-  SDF_SUPPRESS_DEPRECATED_END
-
-  std::string stringval = elem.ToString("myprefix");
-  ASSERT_EQ(stringval, "myprefix<include filename='foo.txt'/>\n");
 }
 
 /////////////////////////////////////////////////

--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -31,9 +31,6 @@ using namespace sdf;
 
 class sdf::JointAxis::Implementation
 {
-  /// \brief Default joint position for this joint axis.
-  public: double initialPosition = 0.0;
-
   /// \brief Represents the x,y,z components of the axis unit vector.
   /// The axis is expressed in the joint frame unless the
   /// use_parent_model_frame flag is set to true. The vector should be
@@ -104,10 +101,6 @@ Errors JointAxis::Load(ElementPtr _sdf)
 
   this->dataPtr->sdf = _sdf;
 
-  // Read the initial position. This is optional, with a default value of 0.
-  this->dataPtr->initialPosition = _sdf->Get<double>(
-      "initial_position", 0.0).first;
-
   // Read the xyz values.
   if (_sdf->HasElement("xyz"))
   {
@@ -165,17 +158,6 @@ Errors JointAxis::Load(ElementPtr _sdf)
   }
 
   return errors;
-}
-
-/////////////////////////////////////////////////
-double JointAxis::InitialPosition() const
-{
-  return this->dataPtr->initialPosition;
-}
-/////////////////////////////////////////////////
-void JointAxis::SetInitialPosition(const double _pos)
-{
-  this->dataPtr->initialPosition = _pos;
 }
 
 /////////////////////////////////////////////////

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -23,9 +23,6 @@ TEST(DOMJointAxis, Construction)
 {
   sdf::JointAxis axis;
   EXPECT_EQ(nullptr, axis.Element());
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  EXPECT_DOUBLE_EQ(0.0, axis.InitialPosition());
-  SDF_SUPPRESS_DEPRECATED_END
   EXPECT_EQ(ignition::math::Vector3d::UnitZ, axis.Xyz());
   EXPECT_TRUE(axis.XyzExpressedIn().empty());
   EXPECT_DOUBLE_EQ(0.0, axis.Damping());
@@ -38,11 +35,6 @@ TEST(DOMJointAxis, Construction)
   EXPECT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), axis.MaxVelocity());
   EXPECT_DOUBLE_EQ(1e8, axis.Stiffness());
   EXPECT_DOUBLE_EQ(1.0, axis.Dissipation());
-
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  axis.SetInitialPosition(1.2);
-  EXPECT_DOUBLE_EQ(1.2, axis.InitialPosition());
-  SDF_SUPPRESS_DEPRECATED_END
 
   {
     sdf::Errors errors = axis.SetXyz(ignition::math::Vector3d(0, 1, 0));

--- a/test/integration/joint_axis_dom.cc
+++ b/test/integration/joint_axis_dom.cc
@@ -86,11 +86,6 @@ TEST(DOMJointAxis, Complete)
   EXPECT_EQ("__model__", axis->XyzExpressedIn());
   EXPECT_TRUE(axis2->XyzExpressedIn().empty());
 
-  SDF_SUPPRESS_DEPRECATED_BEGIN
-  EXPECT_DOUBLE_EQ(0.5, axis->InitialPosition());
-  EXPECT_DOUBLE_EQ(1.5, axis2->InitialPosition());
-  SDF_SUPPRESS_DEPRECATED_END
-
   EXPECT_DOUBLE_EQ(-0.5, axis->Lower());
   EXPECT_DOUBLE_EQ(0.5, axis->Upper());
   EXPECT_DOUBLE_EQ(-1.0, axis2->Lower());
@@ -113,6 +108,10 @@ TEST(DOMJointAxis, Complete)
 
   EXPECT_DOUBLE_EQ(10.6, axis->SpringStiffness());
   EXPECT_DOUBLE_EQ(0.0, axis2->SpringStiffness());
+
+  // Ensure that //axis/initial_position is removed during conversion
+  EXPECT_FALSE(axis->Element()->HasElement("initial_position"));
+  EXPECT_FALSE(axis2->Element()->HasElement("initial_position"));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
This removes all deprecated functions and classes:

- `sdf::Element::SetInclude`
- `sdf::Element::GetInclude`
- `sdf::Color`
- `sdf::JointAxis::InitialPosition`
- `sdf::JointAxis::SetInitialPosition`

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
