### PR TITLE
Error: move << operator from .hh to .cc file

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -221,8 +221,8 @@ namespace sdf
     /// \param[in,out] _out The output stream.
     /// \param[in] _err The error to output.
     /// \return Reference to the given output stream
-    public: friend std::ostream &operator<<(std::ostream &_out,
-                                            const sdf::Error &_err);
+    public: friend SDFORMAT_VISIBLE std::ostream &operator<<(
+        std::ostream &_out, const sdf::Error &_err);
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -222,29 +222,7 @@ namespace sdf
     /// \param[in] _err The error to output.
     /// \return Reference to the given output stream
     public: friend std::ostream &operator<<(std::ostream &_out,
-                                            const sdf::Error &_err)
-    {
-      std::string pathInfo = "";
-
-      if (_err.XmlPath().has_value())
-        pathInfo += _err.XmlPath().value();
-
-      if (_err.FilePath().has_value())
-        pathInfo += ":" + _err.FilePath().value();
-
-      if (_err.LineNumber().has_value())
-        pathInfo += ":L" + std::to_string(_err.LineNumber().value());
-
-      if (!pathInfo.empty())
-        pathInfo = "[" + pathInfo + "]: ";
-
-      _out << "Error Code "
-          << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
-              _err.Code()) << ": "
-          << pathInfo
-          << "Msg: " << _err.Message();
-      return _out;
-    }
+                                            const sdf::Error &_err);
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -121,7 +121,13 @@ bool Error::operator==(const bool _value) const
          ((this->dataPtr->code == ErrorCode::NONE) && !_value);
 }
 
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+
 /////////////////////////////////////////////////
+// cppcheck-suppress unusedFunction
 std::ostream &operator<<(std::ostream &_out, const sdf::Error &_err)
 {
   std::string pathInfo = "";
@@ -144,4 +150,6 @@ std::ostream &operator<<(std::ostream &_out, const sdf::Error &_err)
       << pathInfo
       << "Msg: " << _err.Message();
   return _out;
+}
+}
 }

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -120,3 +120,28 @@ bool Error::operator==(const bool _value) const
   return ((this->dataPtr->code != ErrorCode::NONE) && _value) ||
          ((this->dataPtr->code == ErrorCode::NONE) && !_value);
 }
+
+/////////////////////////////////////////////////
+std::ostream &operator<<(std::ostream &_out, const sdf::Error &_err)
+{
+  std::string pathInfo = "";
+
+  if (_err.XmlPath().has_value())
+    pathInfo += _err.XmlPath().value();
+
+  if (_err.FilePath().has_value())
+    pathInfo += ":" + _err.FilePath().value();
+
+  if (_err.LineNumber().has_value())
+    pathInfo += ":L" + std::to_string(_err.LineNumber().value());
+
+  if (!pathInfo.empty())
+    pathInfo = "[" + pathInfo + "]: ";
+
+  _out << "Error Code "
+      << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
+          _err.Code()) << ": "
+      << pathInfo
+      << "Msg: " << _err.Message();
+  return _out;
+}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes seg-fault of test in ign-physics when printing `sdf::Error` messages.

## Summary

An ign-physics test was observed to seg-fault in https://github.com/ignitionrobotics/ign-physics/pull/261 when printing `sdf::Error` messages (see https://github.com/ignitionrobotics/ign-physics/pull/261#issuecomment-878717357). From that comment:

> I can now reproduce it with sdformat build from source. The trick is to build it with g++ 7.5 as it's done by the nightly debbuilder. My new hypothesis is that `sdf::operator<<(std::ostream, const std::Error&)` is inlined in ign-physics code because it's defined in `sdf/Error.hh`. And since ign-physics is compiled with g++ 8, there might be some weird ABI issues between symbols accessed by the inlined code and the ones available in `libsdformat.so`.

> I see two options:
> 
> 1. Move `sdf::operator<<(std::ostream, const std::Error&)` to `Error.cc` so it won't get inlined.
> 2. Use g++8 in the sdformat nightly debbuilder job.

This takes the second approach. I'm interested to see if the ABI checker is ok with this.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
