### PR TITLE
Error: move << operator from .hh to .cc file (backport to sdf9)

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -171,14 +171,8 @@ namespace sdf
     /// \param[in,out] _out The output stream.
     /// \param[in] _err The error to output.
     /// \return Reference to the given output stream
-    public: friend std::ostream &operator<<(std::ostream &_out,
-                                            const sdf::Error &_err)
-    {
-      _out << "Error Code "
-        << static_cast<std::underlying_type<sdf::ErrorCode>::type>(_err.Code())
-        << " Msg: " << _err.Message();
-      return _out;
-    }
+    public: friend SDFORMAT_VISIBLE std::ostream &operator<<(
+        std::ostream &_out, const sdf::Error &_err);
 
     /// \brief The error code value.
     private: ErrorCode code = ErrorCode::NONE;

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -51,3 +51,20 @@ bool Error::operator==(const bool _value) const
   return ((this->code != ErrorCode::NONE) && _value) ||
          ((this->code == ErrorCode::NONE) && !_value);
 }
+
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+
+/////////////////////////////////////////////////
+// cppcheck-suppress unusedFunction
+std::ostream &operator<<(std::ostream &_out, const sdf::Error &_err)
+{
+  _out << "Error Code "
+    << static_cast<std::underlying_type<sdf::ErrorCode>::type>(_err.Code())
+    << " Msg: " << _err.Message();
+  return _out;
+}
+}
+}


### PR DESCRIPTION
Backport #623 to `sdf9`: move the `sdf::Error` << operator from Error.hh to Error.cc