### PR TITLE
Use Ubuntu bionic in CI

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: ubuntu:xenial
+image: ubuntu:bionic
 
 pipelines:
   default:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes Ubuntu Jenkins builds on `sdf6` branch

## Summary

Our Jenkins Ubuntu builds use the docker image name specified in the `bitbucket-pipelines.yml` file (see [sdformat.dsl](https://github.com/ignition-tooling/release-tools/blob/5a37d5c79c604115f6f28825c3be8ada9332abd7/jenkins-scripts/dsl/sdformat.dsl#L50-L57), but Ubuntu xenial is now EOL, so update it to bionic. See Ubuntu test failures in https://github.com/ignitionrobotics/sdformat/pull/500

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
