### PR TITLE
Fix urdf link extension tags

### DIFF
--- a/src/SDFExtension.cc
+++ b/src/SDFExtension.cc
@@ -26,6 +26,7 @@ SDFExtension::SDFExtension()
   this->visual_blobs.clear();
   this->collision_blobs.clear();
   this->setStaticFlag = false;
+  this->isGravity = false;
   this->gravity = true;
   this->isDampingFactor = false;
   this->isMaxContacts = false;
@@ -74,6 +75,7 @@ SDFExtension::SDFExtension(const SDFExtension &_ge)
   this->visual_blobs = _ge.visual_blobs;
   this->collision_blobs = _ge.collision_blobs;
   this->setStaticFlag = _ge.setStaticFlag;
+  this->isGravity = _ge.isGravity;
   this->gravity = _ge.gravity;
   this->isDampingFactor = _ge.isDampingFactor;
   this->isMaxContacts = _ge.isMaxContacts;

--- a/src/SDFExtension.hh
+++ b/src/SDFExtension.hh
@@ -88,6 +88,7 @@ namespace sdf
 
     // body, default off
     public: bool setStaticFlag;
+    public: bool isGravity;
     public: bool gravity;
     public: bool isDampingFactor;
     public: double dampingFactor;

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -1343,6 +1343,7 @@ void URDF2SDF::ParseSDFExtension(TiXmlDocument &_urdfXml)
       else if (childElem->ValueStr() == "turnGravityOff")
       {
         std::string valueStr = GetKeyValueAsString(childElem);
+        sdf->isGravity = true;
 
         // default of gravity is true
         if (lowerStr(valueStr) == "false" || lowerStr(valueStr) == "no" ||
@@ -2069,13 +2070,9 @@ void InsertSDFExtensionLink(TiXmlElement *_elem, const std::string &_linkName)
           sdfIt->second.begin(); ge != sdfIt->second.end(); ++ge)
       {
         // insert gravity
-        if ((*ge)->gravity)
+        if ((*ge)->isGravity)
         {
-          AddKeyValue(_elem, "gravity", "true");
-        }
-        else
-        {
-          AddKeyValue(_elem, "gravity", "false");
+          AddKeyValue(_elem, "gravity", (*ge)->gravity ? "true" : "false");
         }
 
         // damping factor

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2079,16 +2079,16 @@ void InsertSDFExtensionLink(TiXmlElement *_elem, const std::string &_linkName)
         }
 
         // damping factor
-        TiXmlElement *velocityDecay = new TiXmlElement("velocity_decay");
         if ((*ge)->isDampingFactor)
         {
+          TiXmlElement *velocityDecay = new TiXmlElement("velocity_decay");
           /// @todo separate linear and angular velocity decay
           AddKeyValue(velocityDecay, "linear",
                       Values2str(1, &(*ge)->dampingFactor));
           AddKeyValue(velocityDecay, "angular",
                       Values2str(1, &(*ge)->dampingFactor));
+          _elem->LinkEndChild(velocityDecay);
         }
-        _elem->LinkEndChild(velocityDecay);
         // selfCollide tag
         if ((*ge)->isSelfCollide)
         {

--- a/test/integration/fixed_joint_reduction.cc
+++ b/test/integration/fixed_joint_reduction.cc
@@ -135,6 +135,7 @@ void FixedJointReductionCollisionVisualExtension(const std::string &_urdfFile,
        link = link->GetNextElement("link"))
   {
     EXPECT_FALSE(link->HasElement("self_collide"));
+    EXPECT_FALSE(link->HasElement("velocity_decay"));
     for (sdf::ElementPtr col = link->GetElement("collision"); col;
          col = col->GetNextElement("collision"))
     {
@@ -185,6 +186,7 @@ void FixedJointReductionCollisionVisualExtension(const std::string &_urdfFile,
        link = link->GetNextElement("link"))
   {
     EXPECT_FALSE(link->HasElement("self_collide"));
+    EXPECT_FALSE(link->HasElement("velocity_decay"));
     for (sdf::ElementPtr col = link->GetElement("collision"); col;
          col = col->GetNextElement("collision"))
     {

--- a/test/integration/fixed_joint_reduction.cc
+++ b/test/integration/fixed_joint_reduction.cc
@@ -134,6 +134,7 @@ void FixedJointReductionCollisionVisualExtension(const std::string &_urdfFile,
   for (sdf::ElementPtr link = urdfModel->GetElement("link"); link;
        link = link->GetNextElement("link"))
   {
+    EXPECT_FALSE(link->HasElement("gravity"));
     EXPECT_FALSE(link->HasElement("self_collide"));
     EXPECT_FALSE(link->HasElement("velocity_decay"));
     for (sdf::ElementPtr col = link->GetElement("collision"); col;
@@ -185,6 +186,7 @@ void FixedJointReductionCollisionVisualExtension(const std::string &_urdfFile,
   for (sdf::ElementPtr link = sdfModel->GetElement("link"); link;
        link = link->GetNextElement("link"))
   {
+    EXPECT_FALSE(link->HasElement("gravity"));
     EXPECT_FALSE(link->HasElement("self_collide"));
     EXPECT_FALSE(link->HasElement("velocity_decay"));
     for (sdf::ElementPtr col = link->GetElement("collision"); col;

--- a/test/integration/fixed_joint_reduction_collision_visual_empty_root.sdf
+++ b/test/integration/fixed_joint_reduction_collision_visual_empty_root.sdf
@@ -51,7 +51,6 @@
           </script>
         </material>
       </visual>
-      <gravity>1</gravity>
       <self_collide>0</self_collide>
     </link>
   </model>

--- a/test/integration/fixed_joint_reduction_collision_visual_empty_root.sdf
+++ b/test/integration/fixed_joint_reduction_collision_visual_empty_root.sdf
@@ -52,7 +52,6 @@
         </material>
       </visual>
       <gravity>1</gravity>
-      <velocity_decay/>
       <self_collide>0</self_collide>
     </link>
   </model>

--- a/test/integration/fixed_joint_reduction_collision_visual_extension.sdf
+++ b/test/integration/fixed_joint_reduction_collision_visual_extension.sdf
@@ -134,10 +134,7 @@
           </script>
         </material>
       </visual>
-      <velocity_decay/>
-      <velocity_decay/>
       <gravity>1</gravity>
-      <velocity_decay/>
     </link>
   </model>
 </sdf>

--- a/test/integration/fixed_joint_reduction_collision_visual_extension.sdf
+++ b/test/integration/fixed_joint_reduction_collision_visual_extension.sdf
@@ -134,7 +134,6 @@
           </script>
         </material>
       </visual>
-      <gravity>1</gravity>
     </link>
   </model>
 </sdf>

--- a/test/integration/urdf_gazebo_extensions.cc
+++ b/test/integration/urdf_gazebo_extensions.cc
@@ -100,4 +100,40 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
       EXPECT_TRUE(physics->Get<bool>("implicit_spring_damper"));
     }
   }
+
+  for (sdf::ElementPtr link = model->GetElement("link"); link;
+       link = link->GetNextElement("link"))
+  {
+    std::string linkName = link->Get<std::string>("name");
+    if (linkName == "link1" || linkName == "link2")
+    {
+      EXPECT_TRUE(link->HasElement("enable_wind"));
+
+      EXPECT_TRUE(link->HasElement("gravity"));
+      EXPECT_FALSE(link->Get<bool>("gravity"));
+
+      EXPECT_TRUE(link->HasElement("velocity_decay"));
+      auto velocityDecay = link->GetElement("velocity_decay");
+      EXPECT_DOUBLE_EQ(0.1, velocityDecay->Get<double>("linear"));
+
+      if (linkName == "link1")
+      {
+        EXPECT_TRUE(link->Get<bool>("enable_wind"));
+        EXPECT_DOUBLE_EQ(0.2, velocityDecay->Get<double>("angular"));
+      }
+      else
+      {
+        // linkName == "link2"
+        EXPECT_FALSE(link->Get<bool>("enable_wind"));
+        EXPECT_DOUBLE_EQ(0.1, velocityDecay->Get<double>("angular"));
+      }
+    }
+    else
+    {
+      // No gazebo tags added
+      EXPECT_FALSE(link->HasElement("enable_wind"));
+      EXPECT_FALSE(link->HasElement("gravity"));
+      EXPECT_FALSE(link->HasElement("velocity_decay"));
+    }
+  }
 }

--- a/test/integration/urdf_gazebo_extensions.urdf
+++ b/test/integration/urdf_gazebo_extensions.urdf
@@ -56,6 +56,14 @@
       <origin rpy="0 0 0" xyz="0 -1.5 0"/>
     </visual>
   </link>
+  <gazebo reference="link1">
+    <enable_wind>1</enable_wind>
+    <gravity>0</gravity>
+    <velocity_decay>
+      <linear>0.1</linear>
+      <angular>0.2</angular>
+    </velocity_decay>
+  </gazebo>
 
   <joint name="joint12" type="revolute">
     <origin rpy="-1.57079632679 0 -1.57079632679" xyz="0 -3.0 0.0"/>
@@ -81,6 +89,11 @@
       <origin rpy="0 0 0" xyz="0 0 1.0"/>
     </visual>
   </link>
+  <gazebo reference="link2">
+    <enable_wind>0</enable_wind>
+    <turnGravityOff>1</turnGravityOff>
+    <dampingFactor>0.1</dampingFactor>
+  </gazebo>
 
   <joint name="joint13" type="revolute">
     <origin rpy="-1.57079632679 0 -1.57079632679" xyz="0 -3.0 0.0"/>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes `<gravity/>` and `<velocity_decay/>` tags in URDF `<gazebo/>` extension elements

## Summary

Currently the `parser_urdf` code inserts empty `<velocity_decay>` elements and `<gravity>1</gravity>` elements to links when parsing `<gazebo/>` extensions. I noticed this because I was unable to set `<gravity>0</gravity>` from a `<gazebo/>` tag, since it was being inserted after and only the first one was being read.

This fixes the logic and adds some tests to confirm that these extensions can be properly set.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
