### PR TITLE
BUG: add missing sdf files to CMakeLists

### DIFF
--- a/sdf/1.6/CMakeLists.txt
+++ b/sdf/1.6/CMakeLists.txt
@@ -1,6 +1,6 @@
 set (sdfs
-  air_pressure.sdf
   actor.sdf
+  air_pressure.sdf
   altimeter.sdf
   atmosphere.sdf
   audio_source.sdf

--- a/sdf/1.6/CMakeLists.txt
+++ b/sdf/1.6/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (sdfs
+  air_pressure.sdf
   actor.sdf
   altimeter.sdf
   atmosphere.sdf
@@ -21,6 +22,7 @@ set (sdfs
   imu.sdf
   inertial.sdf
   joint.sdf
+  lidar.sdf
   light.sdf
   light_state.sdf
   link.sdf
@@ -32,6 +34,7 @@ set (sdfs
   model.sdf
   model_state.sdf
   noise.sdf
+  particle_emitter.sdf
   physics.sdf
   plane_shape.sdf
   plugin.sdf

--- a/sdf/1.7/CMakeLists.txt
+++ b/sdf/1.7/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (sdfs
   actor.sdf
+  air_pressure.sdf
   altimeter.sdf
   atmosphere.sdf
   audio_source.sdf
@@ -21,6 +22,7 @@ set (sdfs
   imu.sdf
   inertial.sdf
   joint.sdf
+  lidar.sdf
   light.sdf
   light_state.sdf
   link.sdf
@@ -32,6 +34,7 @@ set (sdfs
   model.sdf
   model_state.sdf
   noise.sdf
+  particle_emitter.sdf
   physics.sdf
   plane_shape.sdf
   plugin.sdf

--- a/sdf/1.8/CMakeLists.txt
+++ b/sdf/1.8/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (sdfs
   actor.sdf
+  air_pressure.sdf
   altimeter.sdf
   atmosphere.sdf
   audio_source.sdf
@@ -23,6 +24,7 @@ set (sdfs
   imu.sdf
   inertial.sdf
   joint.sdf
+  lidar.sdf
   light.sdf
   light_state.sdf
   link.sdf
@@ -34,6 +36,7 @@ set (sdfs
   model.sdf
   model_state.sdf
   noise.sdf
+  particle_emitter.sdf
   physics.sdf
   plane_shape.sdf
   plugin.sdf


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/sdformat/issues/629

## Summary
Adds the missing sdf files to CMakeLists in v1.8.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**