### PR TITLE
Support parsing elements that are not part of the schema

### DIFF
--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -260,13 +260,14 @@ namespace sdf
     /// \brief This parameter's default value
     public: ParamVariant defaultValue;
 
-    /// \brief Method used to set the Element from a passed-in string
+    /// \brief Method used to set the Param from a passed-in string
     /// \param[in] _typeName The data type of the value to set
     /// \param[in] _valueStr The value as a string
     /// \param[out] _valueToSet The value to set
-    public: bool ValueFromStringImpl(const std::string &_typeName,
-                                     const std::string &_valueStr,
-                                     ParamVariant &_valueToSet);
+    public: bool SDFORMAT_VISIBLE ValueFromStringImpl(
+                                    const std::string &_typeName,
+                                    const std::string &_valueStr,
+                                    ParamVariant &_valueToSet) const;
   };
 
   ///////////////////////////////////////////////

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -349,7 +349,9 @@ namespace sdf
   {
     T *value = std::get_if<T>(&this->dataPtr->value);
     if (value)
+    {
       _value = *value;
+    }
     else
     {
       std::string typeStr = this->dataPtr->TypeToString<T>();
@@ -364,7 +366,22 @@ namespace sdf
       bool success = this->dataPtr->ValueFromStringImpl(typeStr, valueStr, pv);
 
       if (success)
+      {
         _value = std::get<T>(pv);
+      }
+      else if (typeStr == "bool" && this->dataPtr->typeName == "string")
+      {
+        valueStr = lowercase(valueStr);
+
+        std::stringstream tmp;
+        if (valueStr == "true" || valueStr == "1")
+          tmp << "1";
+        else
+          tmp << "0";
+
+        tmp >> _value;
+        return true;
+      }
 
       return success;
     }

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -264,11 +264,57 @@ namespace sdf
     /// \param[in] _typeName The data type of the value to set
     /// \param[in] _valueStr The value as a string
     /// \param[out] _valueToSet The value to set
+    /// \return True if the value was successfully set, false otherwise
     public: bool SDFORMAT_VISIBLE ValueFromStringImpl(
                                     const std::string &_typeName,
                                     const std::string &_valueStr,
                                     ParamVariant &_valueToSet) const;
+
+    /// \brief Data type to string mapping
+    /// \return The type as a string, empty string if unknown type
+    public: template<typename T>
+            std::string TypeToString() const;
   };
+
+  ///////////////////////////////////////////////
+  template<typename T>
+  std::string ParamPrivate::TypeToString() const
+  {
+    if constexpr (std::is_same_v<T, bool>)
+      return "bool";
+    else if constexpr (std::is_same_v<T, char>)
+      return "char";
+    else if constexpr (std::is_same_v<T, std::string>)
+      return "string";
+    else if constexpr (std::is_same_v<T, int>)
+      return "int";
+    else if constexpr (std::is_same_v<T, std::uint64_t>)
+      return "uint64_t";
+    else if constexpr (std::is_same_v<T, unsigned int>)
+      return "unsigned int";
+    else if constexpr (std::is_same_v<T, double>)
+      return "double";
+    else if constexpr (std::is_same_v<T, float>)
+      return "float";
+    else if constexpr (std::is_same_v<T, sdf::Time>)
+      return "time";
+    else if constexpr (std::is_same_v<T, ignition::math::Angle>)
+      return "angle";
+    else if constexpr (std::is_same_v<T, ignition::math::Color>)
+      return "color";
+    else if constexpr (std::is_same_v<T, ignition::math::Vector2i>)
+      return "vector2i";
+    else if constexpr (std::is_same_v<T, ignition::math::Vector2d>)
+      return "vector2d";
+    else if constexpr (std::is_same_v<T, ignition::math::Vector3d>)
+      return "vector3";
+    else if constexpr (std::is_same_v<T, ignition::math::Quaterniond>)
+      return "quaternion";
+    else if constexpr (std::is_same_v<T, ignition::math::Pose3d>)
+      return "pose";
+    else
+      return "";
+  }
 
   ///////////////////////////////////////////////
   template<typename T>
@@ -306,50 +352,16 @@ namespace sdf
       _value = *value;
     else
     {
-      std::string valueStr = this->GetAsString();
-      bool success = false;
-      ParamPrivate::ParamVariant pv;
-
-      if constexpr (std::is_same_v<T, bool>)
-        success = this->dataPtr->ValueFromStringImpl("bool", valueStr, pv);
-      else if constexpr (std::is_same_v<T, char>)
-        success = this->dataPtr->ValueFromStringImpl("char", valueStr, pv);
-      else if constexpr (std::is_same_v<T, std::string>)
-        success = this->dataPtr->ValueFromStringImpl("string", valueStr, pv);
-      else if constexpr (std::is_same_v<T, int>)
-        success = this->dataPtr->ValueFromStringImpl("int", valueStr, pv);
-      else if constexpr (std::is_same_v<T, std::uint64_t>)
-        success = this->dataPtr->ValueFromStringImpl("uint64_t", valueStr, pv);
-      else if constexpr (std::is_same_v<T, unsigned int>)
+      std::string typeStr = this->dataPtr->TypeToString<T>();
+      if (typeStr.empty())
       {
-        success
-          = this->dataPtr->ValueFromStringImpl("unsigned int", valueStr, pv);
-      }
-      else if constexpr (std::is_same_v<T, double>)
-        success = this->dataPtr->ValueFromStringImpl("double", valueStr, pv);
-      else if constexpr (std::is_same_v<T, float>)
-        success = this->dataPtr->ValueFromStringImpl("float", valueStr, pv);
-      else if constexpr (std::is_same_v<T, sdf::Time>)
-        success = this->dataPtr->ValueFromStringImpl("time", valueStr, pv);
-      else if constexpr (std::is_same_v<T, ignition::math::Angle>)
-        success = this->dataPtr->ValueFromStringImpl("angle", valueStr, pv);
-      else if constexpr (std::is_same_v<T, ignition::math::Color>)
-        success = this->dataPtr->ValueFromStringImpl("color", valueStr, pv);
-      else if constexpr (std::is_same_v<T, ignition::math::Vector2i>)
-        success = this->dataPtr->ValueFromStringImpl("vector2i", valueStr, pv);
-      else if constexpr (std::is_same_v<T, ignition::math::Vector2d>)
-        success = this->dataPtr->ValueFromStringImpl("vector2d", valueStr, pv);
-      else if constexpr (std::is_same_v<T, ignition::math::Vector3d>)
-        success = this->dataPtr->ValueFromStringImpl("vector3", valueStr, pv);
-      else if constexpr (std::is_same_v<T, ignition::math::Quaterniond>)
-      {
-        success
-          = this->dataPtr->ValueFromStringImpl("quaternion", valueStr, pv);
-      }
-      else if constexpr (std::is_same_v<T, ignition::math::Pose3d>)
-        success = this->dataPtr->ValueFromStringImpl("pose", valueStr, pv);
-      else
         sdferr << "Unknown parameter type[" << typeid(T).name() << "]\n";
+        return false;
+      }
+
+      std::string valueStr = this->GetAsString();
+      ParamPrivate::ParamVariant pv;
+      bool success = this->dataPtr->ValueFromStringImpl(typeStr, valueStr, pv);
 
       if (success)
         _value = std::get<T>(pv);

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -371,6 +371,9 @@ namespace sdf
       }
       else if (typeStr == "bool" && this->dataPtr->typeName == "string")
       {
+        // this section for handling bool types is to keep backward behavior
+        // TODO(anyone) remove for Fortress. For more details:
+        // https://github.com/ignitionrobotics/sdformat/pull/638
         valueStr = lowercase(valueStr);
 
         std::stringstream tmp;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,7 @@ if (BUILD_SDF_TEST)
     Collision_TEST.cc
     Console_TEST.cc
     Cylinder_TEST.cc
+    Element_TEST.cc
     Error_TEST.cc
     Exception_TEST.cc
     Frame_TEST.cc
@@ -122,12 +123,16 @@ if (BUILD_SDF_TEST)
     Mesh_TEST.cc
     Model_TEST.cc
     Noise_TEST.cc
+    parser_urdf_TEST.cc
+    Param_TEST.cc
+    parser_TEST.cc
     Pbr_TEST.cc
     Physics_TEST.cc
     Plane_TEST.cc
     Root_TEST.cc
     Scene_TEST.cc
     SemanticPose_TEST.cc
+    SDF_TEST.cc
     Sensor_TEST.cc
     Sky_TEST.cc
     Sphere_TEST.cc
@@ -135,15 +140,6 @@ if (BUILD_SDF_TEST)
     Types_TEST.cc
     Visual_TEST.cc
     World_TEST.cc
-  )
-
-  # tests which require Param.cc (e.g., uses Param::Get<T>)
-  set(param_required_tests
-    Element_TEST.cc
-    Param_TEST.cc
-    parser_TEST.cc
-    parser_urdf_TEST.cc
-    SDF_TEST.cc
   )
 
   # Build this test file only if Ignition Tools is installed.
@@ -156,7 +152,7 @@ if (BUILD_SDF_TEST)
   sdf_build_tests(${gtest_sources})
 
   if (NOT WIN32)
-    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Utils.cc Param.cc)
+    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Utils.cc)
     sdf_build_tests(Utils_TEST.cc)
   endif()
 
@@ -168,11 +164,6 @@ if (BUILD_SDF_TEST)
   if (NOT WIN32)
     set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Converter.cc)
     sdf_build_tests(Converter_TEST.cc)
-  endif()
-
-  if (NOT WIN32)
-    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Param.cc)
-    sdf_build_tests(${param_required_tests})
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,7 +104,6 @@ if (BUILD_SDF_TEST)
     Collision_TEST.cc
     Console_TEST.cc
     Cylinder_TEST.cc
-    Element_TEST.cc
     Error_TEST.cc
     Exception_TEST.cc
     Frame_TEST.cc
@@ -123,16 +122,12 @@ if (BUILD_SDF_TEST)
     Mesh_TEST.cc
     Model_TEST.cc
     Noise_TEST.cc
-    parser_urdf_TEST.cc
-    Param_TEST.cc
-    parser_TEST.cc
     Pbr_TEST.cc
     Physics_TEST.cc
     Plane_TEST.cc
     Root_TEST.cc
     Scene_TEST.cc
     SemanticPose_TEST.cc
-    SDF_TEST.cc
     Sensor_TEST.cc
     Sky_TEST.cc
     Sphere_TEST.cc
@@ -140,6 +135,15 @@ if (BUILD_SDF_TEST)
     Types_TEST.cc
     Visual_TEST.cc
     World_TEST.cc
+  )
+
+  # tests which require Param.cc (e.g., uses Param::Get<T>)
+  set(param_required_tests
+    Element_TEST.cc
+    Param_TEST.cc
+    parser_TEST.cc
+    parser_urdf_TEST.cc
+    SDF_TEST.cc
   )
 
   # Build this test file only if Ignition Tools is installed.
@@ -152,7 +156,7 @@ if (BUILD_SDF_TEST)
   sdf_build_tests(${gtest_sources})
 
   if (NOT WIN32)
-    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Utils.cc)
+    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Utils.cc Param.cc)
     sdf_build_tests(Utils_TEST.cc)
   endif()
 
@@ -164,6 +168,11 @@ if (BUILD_SDF_TEST)
   if (NOT WIN32)
     set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Converter.cc)
     sdf_build_tests(Converter_TEST.cc)
+  endif()
+
+  if (NOT WIN32)
+    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Param.cc)
+    sdf_build_tests(${param_required_tests})
   endif()
 endif()
 

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -281,8 +281,8 @@ bool Param::ValueFromString(const std::string &_value)
 
 //////////////////////////////////////////////////
 bool ParamPrivate::ValueFromStringImpl(const std::string &_typeName,
-                                      const std::string &_valueStr,
-                                      ParamVariant &_valueToSet)
+                                       const std::string &_valueStr,
+                                       ParamVariant &_valueToSet) const
 {
   // Under some circumstances, latin locales (es_ES or pt_BR) will return a
   // comma for decimal position instead of a dot, making the conversion

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -274,13 +274,23 @@ std::string Param::GetDefaultAsString() const
 //////////////////////////////////////////////////
 bool Param::ValueFromString(const std::string &_value)
 {
+  return this->dataPtr->ValueFromStringImpl(this->dataPtr->typeName,
+                                           _value,
+                                           this->dataPtr->value);
+}
+
+//////////////////////////////////////////////////
+bool ParamPrivate::ValueFromStringImpl(const std::string &_typeName,
+                                      const std::string &_valueStr,
+                                      ParamVariant &_valueToSet)
+{
   // Under some circumstances, latin locales (es_ES or pt_BR) will return a
   // comma for decimal position instead of a dot, making the conversion
   // to fail. See bug #60 for more information. Force to use always C
   setlocale(LC_NUMERIC, "C");
 
-  std::string tmp(_value);
-  std::string lowerTmp = lowercase(_value);
+  std::string tmp(_valueStr);
+  std::string lowerTmp = lowercase(_valueStr);
 
   // "true" and "false" doesn't work properly
   if (lowerTmp == "true")
@@ -304,15 +314,15 @@ bool Param::ValueFromString(const std::string &_value)
       numericBase = 16;
     }
 
-    if (this->dataPtr->typeName == "bool")
+    if (_typeName == "bool")
     {
       if (lowerTmp == "true" || lowerTmp == "1")
       {
-        this->dataPtr->value = true;
+        _valueToSet = true;
       }
       else if (lowerTmp == "false" || lowerTmp == "0")
       {
-        this->dataPtr->value = false;
+        _valueToSet = false;
       }
       else
       {
@@ -320,107 +330,116 @@ bool Param::ValueFromString(const std::string &_value)
         return false;
       }
     }
-    else if (this->dataPtr->typeName == "char")
+    else if (_typeName == "char")
     {
-      this->dataPtr->value = tmp[0];
+      _valueToSet = tmp[0];
     }
-    else if (this->dataPtr->typeName == "std::string" ||
-             this->dataPtr->typeName == "string")
+    else if (_typeName == "std::string" ||
+             _typeName == "string")
     {
-      this->dataPtr->value = tmp;
+      _valueToSet = tmp;
     }
-    else if (this->dataPtr->typeName == "int")
+    else if (_typeName == "int")
     {
-      this->dataPtr->value = std::stoi(tmp, nullptr, numericBase);
+      _valueToSet = std::stoi(tmp, nullptr, numericBase);
     }
-    else if (this->dataPtr->typeName == "uint64_t")
+    else if (_typeName == "uint64_t")
     {
       StringStreamClassicLocale ss(tmp);
       std::uint64_t u64tmp;
 
       ss >> u64tmp;
-      this->dataPtr->value = u64tmp;
+      _valueToSet = u64tmp;
     }
-    else if (this->dataPtr->typeName == "unsigned int")
+    else if (_typeName == "unsigned int")
     {
-      this->dataPtr->value = static_cast<unsigned int>(
+      _valueToSet = static_cast<unsigned int>(
           std::stoul(tmp, nullptr, numericBase));
     }
-    else if (this->dataPtr->typeName == "double")
+    else if (_typeName == "double")
     {
-      this->dataPtr->value = std::stod(tmp);
+      _valueToSet = std::stod(tmp);
     }
-    else if (this->dataPtr->typeName == "float")
+    else if (_typeName == "float")
     {
-      this->dataPtr->value = std::stof(tmp);
+      _valueToSet = std::stof(tmp);
     }
-    else if (this->dataPtr->typeName == "sdf::Time" ||
-             this->dataPtr->typeName == "time")
+    else if (_typeName == "sdf::Time" ||
+             _typeName == "time")
     {
       StringStreamClassicLocale ss(tmp);
       sdf::Time timetmp;
 
       ss >> timetmp;
-      this->dataPtr->value = timetmp;
+      _valueToSet = timetmp;
     }
-    else if (this->dataPtr->typeName == "ignition::math::Color" ||
-             this->dataPtr->typeName == "color")
+    else if (_typeName == "ignition::math::Angle" ||
+             _typeName == "angle")
+    {
+      StringStreamClassicLocale ss(tmp);
+      ignition::math::Angle angletmp;
+
+      ss >> angletmp;
+      _valueToSet = angletmp;
+    }
+    else if (_typeName == "ignition::math::Color" ||
+             _typeName == "color")
     {
       StringStreamClassicLocale ss(tmp);
       ignition::math::Color colortmp;
 
       ss >> colortmp;
-      this->dataPtr->value = colortmp;
+      _valueToSet = colortmp;
     }
-    else if (this->dataPtr->typeName == "ignition::math::Vector2i" ||
-             this->dataPtr->typeName == "vector2i")
+    else if (_typeName == "ignition::math::Vector2i" ||
+             _typeName == "vector2i")
     {
       StringStreamClassicLocale ss(tmp);
       ignition::math::Vector2i vectmp;
 
       ss >> vectmp;
-      this->dataPtr->value = vectmp;
+      _valueToSet = vectmp;
     }
-    else if (this->dataPtr->typeName == "ignition::math::Vector2d" ||
-             this->dataPtr->typeName == "vector2d")
+    else if (_typeName == "ignition::math::Vector2d" ||
+             _typeName == "vector2d")
     {
       StringStreamClassicLocale ss(tmp);
       ignition::math::Vector2d vectmp;
 
       ss >> vectmp;
-      this->dataPtr->value = vectmp;
+      _valueToSet = vectmp;
     }
-    else if (this->dataPtr->typeName == "ignition::math::Vector3d" ||
-             this->dataPtr->typeName == "vector3")
+    else if (_typeName == "ignition::math::Vector3d" ||
+             _typeName == "vector3")
     {
       StringStreamClassicLocale ss(tmp);
       ignition::math::Vector3d vectmp;
 
       ss >> vectmp;
-      this->dataPtr->value = vectmp;
+      _valueToSet = vectmp;
     }
-    else if (this->dataPtr->typeName == "ignition::math::Pose3d" ||
-             this->dataPtr->typeName == "pose" ||
-             this->dataPtr->typeName == "Pose")
+    else if (_typeName == "ignition::math::Pose3d" ||
+             _typeName == "pose" ||
+             _typeName == "Pose")
     {
       StringStreamClassicLocale ss(tmp);
       ignition::math::Pose3d posetmp;
 
       ss >> posetmp;
-      this->dataPtr->value = posetmp;
+      _valueToSet = posetmp;
     }
-    else if (this->dataPtr->typeName == "ignition::math::Quaterniond" ||
-             this->dataPtr->typeName == "quaternion")
+    else if (_typeName == "ignition::math::Quaterniond" ||
+             _typeName == "quaternion")
     {
       StringStreamClassicLocale ss(tmp);
       ignition::math::Quaterniond quattmp;
 
       ss >> quattmp;
-      this->dataPtr->value = quattmp;
+      _valueToSet = quattmp;
     }
     else
     {
-      sdferr << "Unknown parameter type[" << this->dataPtr->typeName << "]\n";
+      sdferr << "Unknown parameter type[" << _typeName << "]\n";
       return false;
     }
   }
@@ -428,16 +447,16 @@ bool Param::ValueFromString(const std::string &_value)
   catch(std::invalid_argument &)
   {
     sdferr << "Invalid argument. Unable to set value ["
-           << _value << " ] for key["
-           << this->dataPtr->key << "].\n";
+           << _valueStr << " ] for key["
+           << this->key << "].\n";
     return false;
   }
   // Catch out of range exception from std::stoi/stoul/stod/stof
   catch(std::out_of_range &)
   {
     sdferr << "Out of range. Unable to set value ["
-           << _value << " ] for key["
-           << this->dataPtr->key << "].\n";
+           << _valueStr << " ] for key["
+           << this->key << "].\n";
     return false;
   }
 

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 
 #include <ignition/math/Angle.hh>
+#include <ignition/math/Color.hh>
+#include <ignition/math/Pose3.hh>
 
 #include "sdf/Exception.hh"
 #include "sdf/Param.hh"
@@ -75,11 +77,6 @@ TEST(Param, Bool)
   strParam.Get<bool>(value);
   EXPECT_TRUE(value);
 
-  // Anything other than 1 or true is treated as a false value
-  strParam.Set("%");
-  strParam.Get<bool>(value);
-  EXPECT_FALSE(value);
-
   boolParam.Set(true);
   std::any anyValue;
   EXPECT_TRUE(boolParam.GetAny(anyValue));
@@ -102,6 +99,27 @@ TEST(SetFromString, Decimals)
 }
 
 ////////////////////////////////////////////////////
+/// Test setting param as a string but getting it as different type
+TEST(Param, StringTypeGet)
+{
+  sdf::Param stringParam("key", "string", "", false, "description");
+
+  // pose type
+  ignition::math::Pose3d pose;
+  EXPECT_TRUE(stringParam.SetFromString("1 1 1 0 0 0"));
+  EXPECT_TRUE(stringParam.Get<ignition::math::Pose3d>(pose));
+  EXPECT_EQ(ignition::math::Pose3d(1, 1, 1, 0, 0, 0), pose);
+  EXPECT_EQ("string", stringParam.GetTypeName());
+
+  // color type
+  ignition::math::Color color;
+  EXPECT_TRUE(stringParam.SetFromString("0 0 1 1"));
+  EXPECT_TRUE(stringParam.Get<ignition::math::Color>(color));
+  EXPECT_EQ(ignition::math::Color(0, 0, 1, 1), color);
+  EXPECT_EQ("string", stringParam.GetTypeName());
+}
+
+////////////////////////////////////////////////////
 /// Test Inf
 TEST(SetFromString, DoublePositiveInf)
 {
@@ -112,9 +130,14 @@ TEST(SetFromString, DoublePositiveInf)
   {
     sdf::Param doubleParam("key", "double", "0", false, "description");
     double value = 0.;
-
     EXPECT_TRUE(doubleParam.SetFromString(infString));
     doubleParam.Get<double>(value);
+    EXPECT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), value);
+
+    sdf::Param stringParam("key", "string", "0", false, "description");
+    value = 0;
+    EXPECT_TRUE(stringParam.SetFromString(infString));
+    EXPECT_TRUE(stringParam.Get<double>(value));
     EXPECT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), value);
   }
 }
@@ -130,10 +153,15 @@ TEST(SetFromString, DoubleNegativeInf)
   {
     sdf::Param doubleParam("key", "double", "0", false, "description");
     double value = 0.;
-
     EXPECT_TRUE(doubleParam.SetFromString(infString));
     doubleParam.Get<double>(value);
-    EXPECT_DOUBLE_EQ(- std::numeric_limits<double>::infinity(), value);
+    EXPECT_DOUBLE_EQ(-std::numeric_limits<double>::infinity(), value);
+
+    sdf::Param stringParam("key", "string", "0", false, "description");
+    value = 0;
+    EXPECT_TRUE(stringParam.SetFromString(infString));
+    EXPECT_TRUE(stringParam.Get<double>(value));
+    EXPECT_DOUBLE_EQ(-std::numeric_limits<double>::infinity(), value);
   }
 }
 

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -77,8 +77,10 @@ TEST(Param, Bool)
   strParam.Get<bool>(value);
   EXPECT_TRUE(value);
 
+  // Anything other than 1 or true is treated as a false value
   strParam.Set("%");
-  EXPECT_FALSE(strParam.Get<bool>(value));
+  strParam.Get<bool>(value);
+  EXPECT_FALSE(value);
 
   boolParam.Set(true);
   std::any anyValue;

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -77,6 +77,9 @@ TEST(Param, Bool)
   strParam.Get<bool>(value);
   EXPECT_TRUE(value);
 
+  strParam.Set("%");
+  EXPECT_FALSE(strParam.Get<bool>(value));
+
   boolParam.Set(true);
   std::any anyValue;
   EXPECT_TRUE(boolParam.GetAny(anyValue));

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -3,50 +3,46 @@ set(TEST_TYPE "INTEGRATION")
 set(tests
   actor_dom.cc
   audio.cc
-  collision_dom.cc
-  default_elements.cc
-  deprecated_specs.cc
-  geometry_dom.cc
-  include.cc
-  joint_axis_dom.cc
-  joint_dom.cc
-  light_dom.cc
-  link_dom.cc
-  model_dom.cc
-  model_versions.cc
-  parser_error_detection.cc
-  root_dom.cc
-  scene_dom.cc
-  sdf_basic.cc
-  surface_dom.cc
-  visual_dom.cc
-  world_dom.cc
-)
-
-# tests which require Param.cc (e.g., uses Param::Get<T>)
-set(param_required_tests
   category_bitmask.cc
   cfm_damping_implicit_spring_damper.cc
+  collision_dom.cc
   converter.cc
+  default_elements.cc
+  deprecated_specs.cc
   disable_fixed_joint_reduction.cc
   fixed_joint_reduction.cc
   force_torque_sensor.cc
   frame.cc
+  geometry_dom.cc
+  include.cc
   includes.cc
   joint_axis_frame.cc
+  joint_axis_dom.cc
+  joint_dom.cc
+  light_dom.cc
+  link_dom.cc
   link_light.cc
   locale_fix.cc
   locale_fix_cxx.cc
   material_pbr.cc
+  model_dom.cc
+  model_versions.cc
   nested_model.cc
+  parser_error_detection.cc
   plugin_attribute.cc
   plugin_bool.cc
   plugin_include.cc
   provide_feedback.cc
+  root_dom.cc
+  scene_dom.cc
+  sdf_basic.cc
   sdf_custom.cc
+  surface_dom.cc
   unknown.cc
   urdf_gazebo_extensions.cc
   urdf_joint_parameters.cc
+  visual_dom.cc
+  world_dom.cc
 )
 
 if (PYTHONINTERP_FOUND AND PY_PSUTIL)
@@ -63,11 +59,6 @@ endif()
 link_directories(${PROJECT_BINARY_DIR}/test)
 
 sdf_build_tests(${tests})
-
-if (NOT WIN32)
-  set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS ${CMAKE_SOURCE_DIR}/src/Param.cc)
-  sdf_build_tests(${param_required_tests})
-endif()
 
 if (EXISTS ${XMLLINT_EXE})
   # Need to run schema target (build .xsd files) before running schema_test

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -3,46 +3,50 @@ set(TEST_TYPE "INTEGRATION")
 set(tests
   actor_dom.cc
   audio.cc
-  category_bitmask.cc
-  cfm_damping_implicit_spring_damper.cc
   collision_dom.cc
-  converter.cc
   default_elements.cc
   deprecated_specs.cc
-  disable_fixed_joint_reduction.cc
-  fixed_joint_reduction.cc
-  force_torque_sensor.cc
-  frame.cc
   geometry_dom.cc
   include.cc
-  includes.cc
-  joint_axis_frame.cc
   joint_axis_dom.cc
   joint_dom.cc
   light_dom.cc
   link_dom.cc
+  model_dom.cc
+  model_versions.cc
+  parser_error_detection.cc
+  root_dom.cc
+  scene_dom.cc
+  sdf_basic.cc
+  surface_dom.cc
+  visual_dom.cc
+  world_dom.cc
+)
+
+# tests which require Param.cc (e.g., uses Param::Get<T>)
+set(param_required_tests
+  category_bitmask.cc
+  cfm_damping_implicit_spring_damper.cc
+  converter.cc
+  disable_fixed_joint_reduction.cc
+  fixed_joint_reduction.cc
+  force_torque_sensor.cc
+  frame.cc
+  includes.cc
+  joint_axis_frame.cc
   link_light.cc
   locale_fix.cc
   locale_fix_cxx.cc
   material_pbr.cc
-  model_dom.cc
-  model_versions.cc
   nested_model.cc
-  parser_error_detection.cc
   plugin_attribute.cc
   plugin_bool.cc
   plugin_include.cc
   provide_feedback.cc
-  root_dom.cc
-  scene_dom.cc
-  sdf_basic.cc
   sdf_custom.cc
-  surface_dom.cc
   unknown.cc
   urdf_gazebo_extensions.cc
   urdf_joint_parameters.cc
-  visual_dom.cc
-  world_dom.cc
 )
 
 if (PYTHONINTERP_FOUND AND PY_PSUTIL)
@@ -60,6 +64,11 @@ link_directories(${PROJECT_BINARY_DIR}/test)
 
 sdf_build_tests(${tests})
 
+if (NOT WIN32)
+  set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS ${CMAKE_SOURCE_DIR}/src/Param.cc)
+  sdf_build_tests(${param_required_tests})
+endif()
+
 if (EXISTS ${XMLLINT_EXE})
   # Need to run schema target (build .xsd files) before running schema_test
   add_dependencies(${TEST_TYPE}_schema_test schema)
@@ -71,5 +80,3 @@ if (UNIX AND NOT APPLE)
   add_test(NAME INTEGRATION_versioned_symbols
     COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/all_symbols_have_version.bash ${CMAKE_BINARY_DIR}/src/libsdformat${SDF_MAJOR_VERSION}.so)
 endif()
-
-


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #603

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

`sdf::Param::Get` parses a value to a given type regardless of the `typeName` of the `sdf::Param`. Previously when `typeName = "string"` then `sdf::Param::Get<double>("inf")` would return `0`, now it returns the expected value `inf`.

Test:
```bash
./build/sdformat9/src/UNIT_Param_TEST --gtest_filter=SetFromString.DoublePositiveInf
./build/sdformat9/src/UNIT_Param_TEST --gtest_filter=SetFromString.DoubleNegativeInf
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**