### PR TITLE
added light_map to material spec

### DIFF
--- a/sdf/1.6/material.sdf
+++ b/sdf/1.6/material.sdf
@@ -90,6 +90,14 @@
       <element name="emissive_map" type="string" default="" required="0">
         <description>Filename of the emissive map.</description>
       </element>
+
+      <element name="light_map" type="string" default="" required="0">
+        <attribute name="uv_set" type="unsigned int" default="0" required="0">
+          <description>Index of the texture coordinate set to use.</description>
+        </attribute>
+        <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
+      </element>
+
     </element>
 
     <element name="specular" required="0">
@@ -130,6 +138,13 @@
       <element name="emissive_map" type="string" default="" required="0">
         <description>Filename of the emissive map.</description>
       </element>
+    </element>
+
+    <element name="light_map" type="string" default="" required="0">
+      <attribute name="uv_set" type="unsigned int" default="0" required="0">
+        <description>Index of the texture coordinate set to use.</description>
+      </attribute>
+      <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
     </element>
 
   </element>

--- a/sdf/1.7/material.sdf
+++ b/sdf/1.7/material.sdf
@@ -95,6 +95,14 @@
       <element name="emissive_map" type="string" default="" required="0">
         <description>Filename of the emissive map.</description>
       </element>
+
+      <element name="light_map" type="string" default="" required="0">
+        <attribute name="uv_set" type="unsigned int" default="0" required="0">
+          <description>Index of the texture coordinate set to use.</description>
+        </attribute>
+        <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
+      </element>
+
     </element>
 
     <element name="specular" required="0">
@@ -135,6 +143,13 @@
       <element name="emissive_map" type="string" default="" required="0">
         <description>Filename of the emissive map.</description>
       </element>
+    </element>
+
+    <element name="light_map" type="string" default="" required="0">
+      <attribute name="uv_set" type="unsigned int" default="0" required="0">
+        <description>Index of the texture coordinate set to use.</description>
+      </attribute>
+      <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
     </element>
 
   </element>


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/ignitionrobotics/sdformat/issues/639, changes will need to be ported to later versions to fully resolve.

## Summary
Added missing `//light_map` from `//material/pbr/metal` and `//material/pbr/specular` specification.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**