### PR TITLE
STY: change booleans from 0 to "false"

### DIFF
--- a/sdf/1.4/joint.sdf
+++ b/sdf/1.4/joint.sdf
@@ -119,7 +119,7 @@
     <description>Parameters that are specific to a certain physics engine.</description>
     <element name="simbody" required="0">
       <description>Simbody specific parameters</description>
-      <element name="must_be_loop_joint" type="bool" default="0" required="0">
+      <element name="must_be_loop_joint" type="bool" default="false" required="0">
         <description>Force cut in the multibody graph at this joint.</description>
       </element>
     </element>

--- a/sdf/1.4/physics.sdf
+++ b/sdf/1.4/physics.sdf
@@ -173,7 +173,7 @@
       <element name="sor" type="double" default="1.3" required="1">
         <description>Set the successive over-relaxation parameter.</description>
       </element>
-      <element name="use_dynamic_moi_rescaling" type="bool" default="0" required="1">
+      <element name="use_dynamic_moi_rescaling" type="bool" default="false" required="1">
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.

--- a/sdf/1.4/surface.sdf
+++ b/sdf/1.4/surface.sdf
@@ -48,7 +48,7 @@
 
   <element name="contact" required="0">
     <description></description>
-    <element name="collide_without_contact" type="bool" default="0" required="0">
+    <element name="collide_without_contact" type="bool" default="false" required="0">
       <description>Flag to disable contact force generation, while still allowing collision checks and contact visualization to occur.</description>
     </element>
     <element name="collide_without_contact_bitmask" type="unsigned int" default="1" required="0">

--- a/sdf/1.5/joint.sdf
+++ b/sdf/1.5/joint.sdf
@@ -163,7 +163,7 @@
     <description>Parameters that are specific to a certain physics engine.</description>
     <element name="simbody" required="0">
       <description>Simbody specific parameters</description>
-      <element name="must_be_loop_joint" type="bool" default="0" required="0">
+      <element name="must_be_loop_joint" type="bool" default="false" required="0">
         <description>Force cut in the multibody graph at this joint.</description>
       </element>
     </element>

--- a/sdf/1.5/physics.sdf
+++ b/sdf/1.5/physics.sdf
@@ -185,7 +185,7 @@
       <element name="sor" type="double" default="1.3" required="1">
         <description>Set the successive over-relaxation parameter.</description>
       </element>
-      <element name="use_dynamic_moi_rescaling" type="bool" default="0" required="1">
+      <element name="use_dynamic_moi_rescaling" type="bool" default="false" required="1">
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.

--- a/sdf/1.5/surface.sdf
+++ b/sdf/1.5/surface.sdf
@@ -77,7 +77,7 @@
 
   <element name="contact" required="0">
     <description></description>
-    <element name="collide_without_contact" type="bool" default="0" required="0">
+    <element name="collide_without_contact" type="bool" default="false" required="0">
       <description>Flag to disable contact force generation, while still allowing collision checks and contact visualization to occur.</description>
     </element>
     <element name="collide_without_contact_bitmask" type="unsigned int" default="1" required="0">

--- a/sdf/1.6/joint.sdf
+++ b/sdf/1.6/joint.sdf
@@ -174,7 +174,7 @@
     <description>Parameters that are specific to a certain physics engine.</description>
     <element name="simbody" required="0">
       <description>Simbody specific parameters</description>
-      <element name="must_be_loop_joint" type="bool" default="0" required="0">
+      <element name="must_be_loop_joint" type="bool" default="false" required="0">
         <description>Force cut in the multibody graph at this joint.</description>
       </element>
     </element>

--- a/sdf/1.6/physics.sdf
+++ b/sdf/1.6/physics.sdf
@@ -193,10 +193,10 @@
       <element name="sor" type="double" default="1.3" required="1">
         <description>Set the successive over-relaxation parameter.</description>
       </element>
-      <element name="thread_position_correction" type="bool" default="0" required="0">
+      <element name="thread_position_correction" type="bool" default="false" required="0">
         <description>Flag to use threading to speed up position correction computation.</description>
       </element>
-      <element name="use_dynamic_moi_rescaling" type="bool" default="0" required="1">
+      <element name="use_dynamic_moi_rescaling" type="bool" default="false" required="1">
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.

--- a/sdf/1.6/surface.sdf
+++ b/sdf/1.6/surface.sdf
@@ -133,7 +133,7 @@
 
   <element name="contact" required="0">
     <description></description>
-    <element name="collide_without_contact" type="bool" default="0" required="0">
+    <element name="collide_without_contact" type="bool" default="false" required="0">
       <description>Flag to disable contact force generation, while still allowing collision checks and contact visualization to occur.</description>
     </element>
     <element name="collide_without_contact_bitmask" type="unsigned int" default="1" required="0">

--- a/sdf/1.7/joint.sdf
+++ b/sdf/1.7/joint.sdf
@@ -170,7 +170,7 @@
     <description>Parameters that are specific to a certain physics engine.</description>
     <element name="simbody" required="0">
       <description>Simbody specific parameters</description>
-      <element name="must_be_loop_joint" type="bool" default="0" required="0">
+      <element name="must_be_loop_joint" type="bool" default="false" required="0">
         <description>Force cut in the multibody graph at this joint.</description>
       </element>
     </element>

--- a/sdf/1.7/physics.sdf
+++ b/sdf/1.7/physics.sdf
@@ -193,10 +193,10 @@
       <element name="sor" type="double" default="1.3" required="1">
         <description>Set the successive over-relaxation parameter.</description>
       </element>
-      <element name="thread_position_correction" type="bool" default="0" required="0">
+      <element name="thread_position_correction" type="bool" default="false" required="0">
         <description>Flag to use threading to speed up position correction computation.</description>
       </element>
-      <element name="use_dynamic_moi_rescaling" type="bool" default="0" required="1">
+      <element name="use_dynamic_moi_rescaling" type="bool" default="false" required="1">
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.

--- a/sdf/1.7/surface.sdf
+++ b/sdf/1.7/surface.sdf
@@ -133,7 +133,7 @@
 
   <element name="contact" required="0">
     <description></description>
-    <element name="collide_without_contact" type="bool" default="0" required="0">
+    <element name="collide_without_contact" type="bool" default="false" required="0">
       <description>Flag to disable contact force generation, while still allowing collision checks and contact visualization to occur.</description>
     </element>
     <element name="collide_without_contact_bitmask" type="unsigned int" default="1" required="0">

--- a/sdf/1.8/joint.sdf
+++ b/sdf/1.8/joint.sdf
@@ -170,7 +170,7 @@
     <description>Parameters that are specific to a certain physics engine.</description>
     <element name="simbody" required="0">
       <description>Simbody specific parameters</description>
-      <element name="must_be_loop_joint" type="bool" default="0" required="0">
+      <element name="must_be_loop_joint" type="bool" default="false" required="0">
         <description>Force cut in the multibody graph at this joint.</description>
       </element>
     </element>

--- a/sdf/1.8/physics.sdf
+++ b/sdf/1.8/physics.sdf
@@ -193,10 +193,10 @@
       <element name="sor" type="double" default="1.3" required="1">
         <description>Set the successive over-relaxation parameter.</description>
       </element>
-      <element name="thread_position_correction" type="bool" default="0" required="0">
+      <element name="thread_position_correction" type="bool" default="false" required="0">
         <description>Flag to use threading to speed up position correction computation.</description>
       </element>
-      <element name="use_dynamic_moi_rescaling" type="bool" default="0" required="1">
+      <element name="use_dynamic_moi_rescaling" type="bool" default="false" required="1">
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.

--- a/sdf/1.8/surface.sdf
+++ b/sdf/1.8/surface.sdf
@@ -133,7 +133,7 @@
 
   <element name="contact" required="0">
     <description></description>
-    <element name="collide_without_contact" type="bool" default="0" required="0">
+    <element name="collide_without_contact" type="bool" default="false" required="0">
       <description>Flag to disable contact force generation, while still allowing collision checks and contact visualization to occur.</description>
     </element>
     <element name="collide_without_contact_bitmask" type="unsigned int" default="1" required="0">


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Changes all occurrences of `default="0"` for boolean elements that I found to `default="false"` as discussed in #653 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
