### PR TITLE
BUG: add missing //plugin to //include

### DIFF
--- a/sdf/1.5/model.sdf
+++ b/sdf/1.5/model.sdf
@@ -34,6 +34,7 @@
     <element name="pose" type="pose" default="0 0 0 0 0 0" required="0">
       <description>Override the pose of the included model. A position and orientation in the global coordinate frame for the model. Position(x,y,z) and rotation (roll, pitch yaw) in the global coordinate frame.</description>
     </element>
+    <include filename="plugin.sdf" required="*"/>
 
     <element name="name" type="string" default="" required="0">
       <description>Override the name of the included model.</description>

--- a/sdf/1.5/world.sdf
+++ b/sdf/1.5/world.sdf
@@ -28,6 +28,7 @@
     </element>
 
     <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
   </element>
 
 

--- a/sdf/1.6/model.sdf
+++ b/sdf/1.6/model.sdf
@@ -34,6 +34,7 @@
     <element name="pose" type="pose" default="0 0 0 0 0 0" required="0">
       <description>Override the pose of the included model. A position and orientation in the global coordinate frame for the model. Position(x,y,z) and rotation (roll, pitch yaw) in the global coordinate frame.</description>
     </element>
+    <include filename="plugin.sdf" required="*"/>
 
     <element name="name" type="string" default="" required="0">
       <description>Override the name of the included model.</description>

--- a/sdf/1.6/world.sdf
+++ b/sdf/1.6/world.sdf
@@ -36,6 +36,7 @@
     </element>
 
     <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
   </element>
 
   <element name="gravity" type="vector3" default="0 0 -9.8" required="1">

--- a/sdf/1.7/model.sdf
+++ b/sdf/1.7/model.sdf
@@ -41,6 +41,7 @@
     </element>
 
     <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
 
     <element name="name" type="string" default="" required="0">
       <description>Override the name of the included model.</description>

--- a/sdf/1.7/world.sdf
+++ b/sdf/1.7/world.sdf
@@ -36,6 +36,7 @@
     </element>
 
     <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
   </element>
 
   <element name="gravity" type="vector3" default="0 0 -9.8" required="1">

--- a/sdf/1.8/model.sdf
+++ b/sdf/1.8/model.sdf
@@ -46,6 +46,7 @@
     </element>
 
     <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
 
     <element name="name" type="string" default="" required="0">
       <description>Override the name of the included model.</description>

--- a/sdf/1.8/world.sdf
+++ b/sdf/1.8/world.sdf
@@ -38,6 +38,7 @@
     </element>
 
     <include filename="pose.sdf" required="0"/>
+    <include filename="plugin.sdf" required="*"/>
 
     <element name="placement_frame" type="string" default="" required="0">
       <description>The frame inside the included entity whose pose will be set by the specified pose element. If this element is specified, the pose must be specified.</description>


### PR DESCRIPTION
# 🦟 Bug fix

Partially addresses #641 . It adds the missing element, but doesn't do anything about additional namespaced elements.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge*
