### PR TITLE
Add pull request triage to sdf9

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,19 @@
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+name: Ticket opened
+jobs:
+  assign:
+    name: Add ticket to inbox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ticket to inbox
+        uses: technote-space/create-project-card-action@v1
+        with:
+          PROJECT: Core development
+          COLUMN: Inbox
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          CHECK_ORG_PROJECT: true
+


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

PRs targeting `sdf9` and `sdf10` aren't being added to the board.

I was partially wrong on https://github.com/ignitionrobotics/sdformat/pull/608#issuecomment-870123420; issue triage only depends on the default branch, but PR triage depends on the target branch.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
