### PR TITLE
Refactor sdf::readXml

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -786,9 +786,9 @@ std::string getModelFilePath(const std::string &_modelDirPath)
 }
 
 //////////////////////////////////////////////////
-/// Helper function read the all the attributes of an element from TinyXML to
+/// Helper function that reads all the attributes of an element from TinyXML to
 /// sdf::Element.
-/// \param[in] _xml Pointer to element to read the attributes from.
+/// \param[in] _xml Pointer to XML element to read the attributes from.
 /// \param[in,out] _sdf sdf::Element pointer to parse the attribute data into.
 /// \param[out] _errors Captures errors found during parsing.
 /// \return True on success, false on error.
@@ -856,7 +856,7 @@ static bool readAttributes(TiXmlElement *_xml, ElementPtr _sdf, Errors &_errors)
 
 //////////////////////////////////////////////////
 /// Helper function to resolve file name from an //include/uri element.
-/// \param[in] _uriElem Pointer to the //include/uri element.
+/// \param[in] _uriElem Pointer to the //include/uri XML element.
 /// \param[out] _fileName Resolved file name.
 /// \param[out] _errors Captures errors found during parsing.
 /// \return True if the file name is successfully resolved, false on error.


### PR DESCRIPTION
## Summary
While working on a new feature for the `main` branch I got a codecheck error saying `sdf::readXml` is over 500 lines. This simply refactors two sections of the the function into helper functions.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
