### PR TITLE
Add a codecheck make target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,28 @@ else (build_errors)
   endif(BUILD_SDF)
 
   ########################################
+  # Setup Codecheck
+  include (IgnCodeCheck)
+  set(CPPCHECK_DIRS
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/test/integration
+    ${PROJECT_SOURCE_DIR}/test/performance)
+
+  set(CPPCHECK_INCLUDE_DIRS
+    ${PROJECT_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/test/integration
+    ${PROJECT_SOURCE_DIR}/test/performance)
+
+  # Ignore vendored directories.
+  file(WRITE ${PROJECT_BINARY_DIR}/cppcheck.suppress
+    "*:${PROJECT_SOURCE_DIR}/src/win/*\n"
+    "*:${PROJECT_SOURCE_DIR}/src/urdf/*\n"
+    )
+  ign_setup_target_for_codecheck()
+
+  ########################################
   # Make the package config file
   configure_file(${CMAKE_SOURCE_DIR}/cmake/sdformat_pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}.pc @ONLY)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -127,6 +127,13 @@ macro (check_gcc_visibility)
 endmacro()
 
 ########################################
+# Find ignition cmake2
+# Only for using the testing macros and creating the codecheck target, not 
+# really being use to configure the whole project
+find_package(ignition-cmake2 2.3 REQUIRED)
+set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
+
+########################################
 # Find ignition math
 # Set a variable for generating ProjectConfig.cmake
 find_package(ignition-math6 QUIET)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -130,7 +130,7 @@ endmacro()
 # Find ignition cmake2
 # Only for using the testing macros and creating the codecheck target, not 
 # really being use to configure the whole project
-find_package(ignition-cmake2 2.3 REQUIRED)
+find_package(ignition-cmake2 REQUIRED)
 set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 
 ########################################

--- a/include/sdf/Console.hh
+++ b/include/sdf/Console.hh
@@ -73,7 +73,7 @@ namespace sdf
       /// \brief Constructor.
       /// \param[in] _stream Pointer to an output stream operator. Can be
       /// NULL/nullptr.
-      public: ConsoleStream(std::ostream *_stream) :
+      public: explicit ConsoleStream(std::ostream *_stream) :
               stream(_stream) {}
 
       /// \brief Redirect whatever is passed in to both our ostream

--- a/include/sdf/Exception.hh
+++ b/include/sdf/Exception.hh
@@ -126,6 +126,7 @@ namespace sdf
     /// \param[in] _line Line number where the error occurred
     /// \param[in] _msg Error message
     public: InternalError(const char *_file, std::int64_t _line,
+                          // cppcheck-suppress passedByValue
                           const std::string _msg);
 
     /// \brief Destructor
@@ -148,8 +149,11 @@ namespace sdf
     /// \param[in] _msg Function where assertion failed
     public: AssertionInternalError(const char *_file,
                                    std::int64_t _line,
+                                   // cppcheck-suppress passedByValue
                                    const std::string _expr,
+                                   // cppcheck-suppress passedByValue
                                    const std::string _function,
+                                   // cppcheck-suppress passedByValue
                                    const std::string _msg = "");
     /// \brief Destructor
     public: virtual ~AssertionInternalError();

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -282,6 +282,7 @@ namespace sdf
   template<typename T>
   std::string ParamPrivate::TypeToString() const
   {
+    // cppcheck-suppress syntaxError
     if constexpr (std::is_same_v<T, bool>)
       return "bool";
     else if constexpr (std::is_same_v<T, char>)

--- a/include/sdf/parser_urdf.hh
+++ b/include/sdf/parser_urdf.hh
@@ -73,9 +73,13 @@ namespace sdf
     private: void ParseSDFExtension(TiXmlDocument &_urdfXml);
 
     /// list extensions for debugging
+    // cppcheck-suppress unusedPrivateFunction
+    // cppcheck-suppress unmatchedSuppression
     private: void ListSDFExtensions();
 
     /// list extensions for debugging
+    // cppcheck-suppress unusedPrivateFunction
+    // cppcheck-suppress unmatchedSuppression
     private: void ListSDFExtensions(const std::string &_reference);
   };
   }

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -57,7 +57,6 @@ namespace sdf
 inline namespace SDF_VERSION_NAMESPACE {
 
 /////////////////////////////////////////////////
-// cppcheck-suppress unusedFunction
 std::ostream &operator<<(std::ostream &_out, const sdf::Error &_err)
 {
   _out << "Error Code "

--- a/src/SDF.cc
+++ b/src/SDF.cc
@@ -51,7 +51,6 @@ static std::function<std::string(const std::string &)> g_findFileCB;
 std::string SDF::version = SDF_VERSION;  // NOLINT(runtime/string)
 
 /////////////////////////////////////////////////
-// cppcheck-suppress passedByValue
 void setFindCallback(std::function<std::string(const std::string &)> _cb)
 {
   g_findFileCB = _cb;
@@ -69,7 +68,6 @@ std::string findFile(const std::string &_filename, bool _searchLocalPath,
   {
     // Check to see if the URI in the global map is the first part of the
     // given filename
-    // cppcheck-suppress stlIfStrFind
     if (_filename.find(iter->first) == 0)
     {
       std::string suffix = _filename;

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -27,7 +27,6 @@
 #include "ign.hh"
 
 //////////////////////////////////////////////////
-// cppcheck-suppress unusedFunction
 extern "C" SDFORMAT_VISIBLE int cmdCheck(const char *_path)
 {
   int result = 0;
@@ -96,7 +95,6 @@ extern "C" SDFORMAT_VISIBLE int cmdCheck(const char *_path)
 }
 
 //////////////////////////////////////////////////
-// cppcheck-suppress unusedFunction
 extern "C" SDFORMAT_VISIBLE char *ignitionVersion()
 {
 #ifdef _MSC_VER
@@ -109,7 +107,6 @@ extern "C" SDFORMAT_VISIBLE char *ignitionVersion()
 //////////////////////////////////////////////////
 /// \brief Print the full description of the SDF spec.
 /// \return 0 on success, -1 if SDF could not be initialized.
-// cppcheck-suppress unusedFunction
 extern "C" SDFORMAT_VISIBLE int cmdDescribe(const char *_version)
 {
   sdf::SDFPtr sdf(new sdf::SDF());
@@ -130,7 +127,6 @@ extern "C" SDFORMAT_VISIBLE int cmdDescribe(const char *_version)
 }
 
 //////////////////////////////////////////////////
-// cppcheck-suppress unusedFunction
 extern "C" SDFORMAT_VISIBLE int cmdPrint(const char *_path)
 {
   if (!sdf::filesystem::exists(_path))

--- a/test/integration/locale_fix_cxx.cc
+++ b/test/integration/locale_fix_cxx.cc
@@ -25,7 +25,6 @@ TEST(CheckFixForLocal, CheckFixForCxxLocal)
 {
   struct CommaDecimalPointFacet : std::numpunct<char>
   {
-    // cppcheck-suppress unusedFunction
     char do_decimal_point() const
     {
       return ',';


### PR DESCRIPTION

# 🎉 New feature

## Summary
Follow up from https://github.com/ignitionrobotics/sdformat/pull/680#issuecomment-910467529

Utilizes ignition-cmake's IgnCodecheck module to create a `codecheck` target.
Needs https://github.com/ignitionrobotics/ign-cmake/pull/186 to eliminate some false positives.


## Test it
Run `make codecheck`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

