### PR TITLE
Parse URDF continuous joint effort/velocity limits

### DIFF
--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -3016,10 +3016,6 @@ void CreateJoint(TiXmlElement *_root,
                       Values2str(1, &_link->parent_joint->limits->lower));
           AddKeyValue(jointAxisLimit, "upper",
                       Values2str(1, &_link->parent_joint->limits->upper));
-          AddKeyValue(jointAxisLimit, "effort",
-                      Values2str(1, &_link->parent_joint->limits->effort));
-          AddKeyValue(jointAxisLimit, "velocity",
-                      Values2str(1, &_link->parent_joint->limits->velocity));
         }
         else if (_link->parent_joint->type != urdf::Joint::CONTINUOUS)
         {
@@ -3041,11 +3037,11 @@ void CreateJoint(TiXmlElement *_root,
                       Values2str(1, &_link->parent_joint->limits->lower));
           AddKeyValue(jointAxisLimit, "upper",
                       Values2str(1, &_link->parent_joint->limits->upper));
-          AddKeyValue(jointAxisLimit, "effort",
-                      Values2str(1, &_link->parent_joint->limits->effort));
-          AddKeyValue(jointAxisLimit, "velocity",
-                      Values2str(1, &_link->parent_joint->limits->velocity));
         }
+        AddKeyValue(jointAxisLimit, "effort",
+                    Values2str(1, &_link->parent_joint->limits->effort));
+        AddKeyValue(jointAxisLimit, "velocity",
+                    Values2str(1, &_link->parent_joint->limits->velocity));
       }
     }
 

--- a/test/integration/urdf_joint_parameters.cc
+++ b/test/integration/urdf_joint_parameters.cc
@@ -65,6 +65,13 @@ TEST(SDFParser, JointAxisParameters)
     ASSERT_TRUE(dynamics->HasElement("friction"));
     EXPECT_DOUBLE_EQ(value, dynamics->Get<double>("damping"));
     EXPECT_DOUBLE_EQ(value, dynamics->Get<double>("friction"));
+
+    EXPECT_TRUE(axis->HasElement("limit"));
+    sdf::ElementPtr limit = axis->GetElement("limit");
+    EXPECT_TRUE(limit->HasElement("effort"));
+    EXPECT_TRUE(limit->HasElement("velocity"));
+    EXPECT_DOUBLE_EQ(value, limit->Get<double>("effort"));
+    EXPECT_DOUBLE_EQ(value, limit->Get<double>("velocity"));
   }
   EXPECT_EQ(bitmask, 0x3u);
 

--- a/test/integration/urdf_joint_parameters.urdf
+++ b/test/integration/urdf_joint_parameters.urdf
@@ -9,6 +9,7 @@
     <parent link="world"/>
     <child link="link0"/>
     <dynamics damping="0.0" friction="0.0" />
+    <limit effort="0.0" velocity="0.0" />
   </joint>
 
   <link name="link0">
@@ -31,6 +32,7 @@
     <parent link="link0"/>
     <child link="link1"/>
     <dynamics damping="1.0" friction="1.0" />
+    <limit effort="1.0" velocity="1.0" />
   </joint>
 
   <link name="link1">


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #683.

## Summary

This fixes parsing of effort and velocity limits for continuous joints in URDF files. A failing test was added in https://github.com/scpeters/sdformat/commit/75e42263bc801fe6a7b15cc0a5fd6b064d9277a6 and fixed in 33e4b4d73df089085506f1b1c47148aa59c8ff6f.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
