### PR TITLE
🌐 Parse spherical coordinates

### DIFF
--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -18,6 +18,7 @@
 #define SDF_WORLD_HH_
 
 #include <string>
+#include <ignition/math/SphericalCoordinates.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/utils/ImplPtr.hh>
 
@@ -135,6 +136,16 @@ namespace sdf
     /// \param[in] _mag The new magnetic field vector.
     /// \sa SphericalCoordinates
     public: void SetMagneticField(const ignition::math::Vector3d &_mag);
+
+    /// \brief Get the spherical coordinates for the world origin.
+    /// \return Spherical coordinates.
+    public: const ignition::math::SphericalCoordinates &SphericalCoordinates()
+        const;
+
+    /// \brief Set the spherical coordinates for the world origin.
+    /// \param[in] _coord The new coordinates for the world origin.
+    public: void SetSphericalCoordinates(
+        const ignition::math::SphericalCoordinates &_coord);
 
     /// \brief Get the number of models that are immediate (not nested) children
     /// of this World object.

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -17,6 +17,7 @@
 #ifndef SDF_WORLD_HH_
 #define SDF_WORLD_HH_
 
+#include <optional>
 #include <string>
 #include <ignition/math/SphericalCoordinates.hh>
 #include <ignition/math/Vector3.hh>
@@ -138,9 +139,9 @@ namespace sdf
     public: void SetMagneticField(const ignition::math::Vector3d &_mag);
 
     /// \brief Get the spherical coordinates for the world origin.
-    /// \return Spherical coordinates.
-    public: const ignition::math::SphericalCoordinates &SphericalCoordinates()
-        const;
+    /// \return Spherical coordinates or null if not defined.
+    public: const ignition::math::SphericalCoordinates *
+        SphericalCoordinates() const;
 
     /// \brief Set the spherical coordinates for the world origin.
     /// \param[in] _coord The new coordinates for the world origin.

--- a/sdf/1.9/spherical_coordinates.sdf
+++ b/sdf/1.9/spherical_coordinates.sdf
@@ -12,15 +12,9 @@
     <description>
       This field identifies how Gazebo world frame is aligned in Geographical
       sense.  The final Gazebo world frame orientation is obtained by rotating
-      a frame aligned with following notation by the field heading_deg (Note
-      that heading_deg corresponds to positive yaw rotation in the NED frame,
-      so it's inverse specifies positive Z-rotation in ENU or NWU).
+      a frame aligned with following notation by the field heading_deg.
       Options are:
         - ENU (East-North-Up)
-        - NED (North-East-Down)
-        - NWU (North-West-Up)
-      For example, world frame specified by setting world_orientation="ENU"
-      and heading_deg=-90° is effectively equivalent to NWU with heading of 0°.
     </description>
   </element>
   <element name="latitude_deg" type="double" default="0.0" required="1">
@@ -46,12 +40,10 @@
   <element name="heading_deg" type="double" default="0.0" required="1">
     <description>
       Heading offset of gazebo reference frame, measured as angle between
-      Gazebo world frame and the world_frame_orientation type (ENU/NED/NWU).
-      Rotations about the downward-vector (e.g. North to East) are positive.
-      The direction of rotation is chosen to be consistent with compass
-      heading convention (e.g. 0 degrees points North and 90 degrees
-      points East, positive rotation indicates counterclockwise rotation
-      when viewed from top-down direction).
+      Gazebo world frame and the world_frame_orientation type.
+      The direction of rotation follows the right-hand rule, so a positive
+      angle indicates clockwise rotation when viewed from top-down. Note
+      that this is not consistent with compass heading convention.
       The angle is specified in degrees.
     </description>
   </element>

--- a/sdf/1.9/spherical_coordinates.sdf
+++ b/sdf/1.9/spherical_coordinates.sdf
@@ -42,7 +42,7 @@
       Heading offset of gazebo reference frame, measured as angle between
       Gazebo world frame and the world_frame_orientation type.
       The direction of rotation follows the right-hand rule, so a positive
-      angle indicates clockwise rotation when viewed from top-down. Note
+      angle indicates clockwise rotation (from east to north) when viewed from top-down. Note
       that this is not consistent with compass heading convention.
       The angle is specified in degrees.
     </description>

--- a/src/World.cc
+++ b/src/World.cc
@@ -74,10 +74,8 @@ class sdf::World::Implementation
            ignition::math::Vector3d(5.5645e-6, 22.8758e-6, -42.3884e-6);
 
   /// \brief Spherical coordinates
-  public: ignition::math::SphericalCoordinates sphericalCoordinates =
-      ignition::math::SphericalCoordinates(
-      ignition::math::SphericalCoordinates::SurfaceType::EARTH_WGS84,
-      0.0, 0.0, 0.0, 0.0);
+  public: std::optional<ignition::math::SphericalCoordinates>
+      sphericalCoordinates;
 
   /// \brief The models specified in this world.
   public: std::vector<Model> models;
@@ -426,9 +424,10 @@ void World::SetAtmosphere(const sdf::Atmosphere &_atmosphere)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::SphericalCoordinates &World::SphericalCoordinates() const
+const ignition::math::SphericalCoordinates *
+    World::SphericalCoordinates() const
 {
-  return this->dataPtr->sphericalCoordinates;
+  return optionalToPointer(this->dataPtr->sphericalCoordinates);
 }
 
 /////////////////////////////////////////////////
@@ -774,6 +773,7 @@ Errors World::Implementation::LoadSphericalCoordinates(
   }
 
   // Create coordinates
+  this->sphericalCoordinates.emplace();
   this->sphericalCoordinates =
       ignition::math::SphericalCoordinates(surfaceModel, latitude, longitude,
       elevation, heading);

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -100,8 +100,9 @@ TEST(DOMWorld, CopyConstructor)
 
   ASSERT_TRUE(nullptr != world.Atmosphere());
   EXPECT_DOUBLE_EQ(0.1, world.Atmosphere()->Pressure());
+  ASSERT_TRUE(nullptr != world.SphericalCoordinates());
   EXPECT_EQ(ignition::math::SphericalCoordinates::EARTH_WGS84,
-      world.SphericalCoordinates().Surface());
+      world.SphericalCoordinates()->Surface());
   EXPECT_EQ("test_audio_device", world.AudioDevice());
   EXPECT_EQ(ignition::math::Vector3d::UnitX, world.Gravity());
 

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -81,6 +81,7 @@ TEST(DOMWorld, CopyConstructor)
   world.SetAtmosphere(atmosphere);
   world.SetAudioDevice("test_audio_device");
   world.SetGravity({1, 0, 0});
+  world.SetSphericalCoordinates(ignition::math::SphericalCoordinates());
 
   sdf::Gui gui;
   gui.SetFullscreen(true);
@@ -99,6 +100,8 @@ TEST(DOMWorld, CopyConstructor)
 
   ASSERT_TRUE(nullptr != world.Atmosphere());
   EXPECT_DOUBLE_EQ(0.1, world.Atmosphere()->Pressure());
+  EXPECT_EQ(ignition::math::SphericalCoordinates::EARTH_WGS84,
+      world.SphericalCoordinates().Surface());
   EXPECT_EQ("test_audio_device", world.AudioDevice());
   EXPECT_EQ(ignition::math::Vector3d::UnitX, world.Gravity());
 

--- a/test/integration/world_dom.cc
+++ b/test/integration/world_dom.cc
@@ -107,13 +107,14 @@ TEST(DOMWorld, Load)
   EXPECT_DOUBLE_EQ(4.3, atmosphere->TemperatureGradient());
   EXPECT_DOUBLE_EQ(43.1, atmosphere->Pressure());
 
-  const auto &sphericalCoords = world->SphericalCoordinates();
+  const auto *sphericalCoords = world->SphericalCoordinates();
+  ASSERT_NE(nullptr, sphericalCoords);
   EXPECT_EQ(ignition::math::SphericalCoordinates::EARTH_WGS84,
-      sphericalCoords.Surface());
-  EXPECT_DOUBLE_EQ(-22.9, sphericalCoords.LatitudeReference().Degree());
-  EXPECT_DOUBLE_EQ(-43.2, sphericalCoords.LongitudeReference().Degree());
-  EXPECT_DOUBLE_EQ(100, sphericalCoords.ElevationReference());
-  EXPECT_DOUBLE_EQ(90, sphericalCoords.HeadingOffset().Degree());
+      sphericalCoords->Surface());
+  EXPECT_DOUBLE_EQ(-22.9, sphericalCoords->LatitudeReference().Degree());
+  EXPECT_DOUBLE_EQ(-43.2, sphericalCoords->LongitudeReference().Degree());
+  EXPECT_DOUBLE_EQ(100, sphericalCoords->ElevationReference());
+  EXPECT_DOUBLE_EQ(90, sphericalCoords->HeadingOffset().Degree());
 
   const sdf::Gui *gui = world->Gui();
   ASSERT_NE(nullptr, gui);

--- a/test/integration/world_dom.cc
+++ b/test/integration/world_dom.cc
@@ -107,6 +107,14 @@ TEST(DOMWorld, Load)
   EXPECT_DOUBLE_EQ(4.3, atmosphere->TemperatureGradient());
   EXPECT_DOUBLE_EQ(43.1, atmosphere->Pressure());
 
+  const auto &sphericalCoords = world->SphericalCoordinates();
+  EXPECT_EQ(ignition::math::SphericalCoordinates::EARTH_WGS84,
+      sphericalCoords.Surface());
+  EXPECT_DOUBLE_EQ(-22.9, sphericalCoords.LatitudeReference().Degree());
+  EXPECT_DOUBLE_EQ(-43.2, sphericalCoords.LongitudeReference().Degree());
+  EXPECT_DOUBLE_EQ(100, sphericalCoords.ElevationReference());
+  EXPECT_DOUBLE_EQ(90, sphericalCoords.HeadingOffset().Degree());
+
   const sdf::Gui *gui = world->Gui();
   ASSERT_NE(nullptr, gui);
   ASSERT_NE(nullptr, gui->Element());

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -18,6 +18,14 @@
       <pressure>43.1</pressure>
       <temperature_gradient>4.3</temperature_gradient>
     </atmosphere>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>-22.9</latitude_deg>
+      <longitude_deg>-43.2</longitude_deg>
+      <elevation>100</elevation>
+      <heading_deg>90</heading_deg>
+    </spherical_coordinates>
     <gui fullscreen="true">
     </gui>
     <scene>


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/981

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Leverage `ignition::math::SphericalCoordinates` to hold the `<spherical_coordinates>` element.

Mismatches between the SDF spec and the `ign-math` class:

* `world_frame_orientation`: that tag was never used by Gazebo (and maybe no other simulators either?). See discussion in https://github.com/ignitionrobotics/ign-gazebo/issues/981#issuecomment-912173312. I updated the docs to mention only ENU is supported for now. The idea is that we update the docs as support for other conventions is added to `math::SphericalCoordinates`.
* `heading_deg`: the docs say that the heading should be counter-clockwise, but according to the tests I added in https://github.com/ignitionrobotics/ign-math/pull/235/, I believe that's never been the case? It's also possible that I misunderstood something.

I should point out that `ignition::math::SphericalCoordinates` provides conversion and lookup functions that may not be as accurate or flexible as those provided by libraries such as `proj`. As far as SDFormat is concerned, that class is being used mainly as storage for the data, and downstream applications may choose to use the functions built into `ign-math` or use 3rd party applications to perform computation.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

~~I'm working on an Ignition Gazebo PR that uses this, stay tuned! For now, look at the added tests :slightly_smiling_face:~~

Used here: https://github.com/ignitionrobotics/ign-gazebo/pull/1008

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
