### PR TITLE
Backport imu enable_orientation field to sdf6

### DIFF
--- a/sdf/1.6/imu.sdf
+++ b/sdf/1.6/imu.sdf
@@ -118,4 +118,8 @@
     </element>
   </element>
 
+  <element name="enable_orientation" type="bool" default="true" required="0">
+    <description>Some IMU sensors rely on external filters to produce orientation estimates. True to generate and output orientation data, false to disable orientation data generation.</description>
+  </element>
+
 </element>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

backport of #651 to to keep the 1.6 spec consistent. There are no DOM classes in this branch so the relevant changes are not backported.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
