### PR TITLE
Fix world-complete.sdf and add particle_scatter_ratio to v1.8

### DIFF
--- a/sdf/1.8/particle_emitter.sdf
+++ b/sdf/1.8/particle_emitter.sdf
@@ -104,6 +104,17 @@
     </description>
   </element>
 
+  <element name="particle_scatter_ratio" type="float" default="0.65" required="0">
+    <description>
+    This is used to determine the ratio of particles that will be detected
+    by sensors. Increasing the ratio means there is a higher chance of
+    particles reflecting and interfering with depth sensing, making the
+    emitter appear more dense. Decreasing the ratio decreases the chance
+    of particles reflecting and interfering with depth sensing, making it
+    appear less dense.
+    </description>
+  </element>
+
   <include filename="pose.sdf" required="0"/>
   <include filename="material.sdf" required="0"/>
 </element>

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.8">
   <world name="default">
     <physics name="my_physics" type="bullet">
       <max_step_size>0.1</max_step_size>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #670 

As discussed in #670 this PR bumps the SDF version of the test to 1.8 to allow using the //light/intensity element. It also adds the //particle_emitter/particle_scatter_ratio to v1.8 which appears to have been forgotten in the forward port.

**Note to maintainers**: Remember to use **Squash-Merge**
