### PR TITLE
Fix/include pose degrees

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1405,15 +1405,6 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           {
             sdf::ElementPtr poseElem = topLevelElem->GetElement("pose");
 
-            if (poseElemXml->GetText())
-            {
-              poseElem->GetValue()->SetFromString(poseElemXml->GetText());
-            }
-            else
-            {
-              poseElem->GetValue()->Reset();
-            }
-
             const char *relativeTo = poseElemXml->Attribute("relative_to");
             if (relativeTo)
             {
@@ -1422,6 +1413,27 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             else
             {
               poseElem->GetAttribute("relative_to")->Reset();
+            }
+
+            const char *degrees = poseElemXml->Attribute("degrees");
+            {
+              if (degrees)
+              {
+                poseElem->GetAttribute("degrees")->SetFromString(degrees);
+              }
+              else
+              {
+                poseElem->GetAttribute("degrees")->Reset();
+              }
+            }
+
+            if (poseElemXml->GetText())
+            {
+              poseElem->GetValue()->SetFromString(poseElemXml->GetText());
+            }
+            else
+            {
+              poseElem->GetValue()->Reset();
             }
           }
 

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -504,10 +504,47 @@ std::string findFileCb(const std::string &_input)
 }
 
 //////////////////////////////////////////////////
-TEST(Pose1_9, IncludePose)
+TEST(Pose1_9, IncludePoseInModelString)
 {
   using Pose = ignition::math::Pose3d;
-  
+
+  sdf::setFindCallback(findFileCb);
+
+  std::ostringstream stream;
+  stream
+      << "<sdf version='1.9'>"
+      << "  <model name='parent'>"
+      << "    <include>"
+      << "      <uri>box</uri>"
+      << "      <pose degrees='true'>0 10 0 90 0 0</pose>"
+      << "    </include>"
+      << "  </model>"
+      << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  sdf::Errors errors;
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed, errors));
+  ASSERT_TRUE(errors.empty()) << errors;
+
+  sdf::Root root;
+  errors = root.Load(sdfParsed);
+  ASSERT_TRUE(errors.empty()) << errors;
+
+  auto model = root.Model();
+  ASSERT_NE(nullptr, model);
+
+  auto boxModel = model->ModelByName("box");
+  ASSERT_NE(nullptr, boxModel);
+  EXPECT_EQ(Pose(0, 10, 0, IGN_DTOR(90), IGN_DTOR(0), IGN_DTOR(0)),
+      boxModel->RawPose());
+}
+
+//////////////////////////////////////////////////
+TEST(Pose1_9, IncludePoseInWorld)
+{
+  using Pose = ignition::math::Pose3d;
+
   sdf::setFindCallback(findFileCb);
   const std::string testFile = sdf::testing::TestFile(
       "sdf", "include_pose_1_9.sdf");

--- a/test/integration/pose_1_9_sdf.cc
+++ b/test/integration/pose_1_9_sdf.cc
@@ -496,3 +496,34 @@ TEST(Pose1_9, ToStringAfterChangingDegreeAttribute)
   EXPECT_PRED2(contains, elemStr, "degrees='0'");
   EXPECT_PRED2(contains, elemStr, "0.4 0.5 0.6");
 }
+
+//////////////////////////////////////////////////
+std::string findFileCb(const std::string &_input)
+{
+  return sdf::testing::TestFile("integration", "model", _input);
+}
+
+//////////////////////////////////////////////////
+TEST(Pose1_9, IncludePose)
+{
+  using Pose = ignition::math::Pose3d;
+  
+  sdf::setFindCallback(findFileCb);
+  const std::string testFile = sdf::testing::TestFile(
+      "sdf", "include_pose_1_9.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  ASSERT_TRUE(errors.empty()) << errors;
+  EXPECT_EQ(SDF_PROTOCOL_VERSION, root.Version());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  ASSERT_EQ("model_name", model->Name());
+  EXPECT_EQ(Pose(0, 10, 0, IGN_DTOR(90), IGN_DTOR(0), IGN_DTOR(0)),
+            model->RawPose());
+}

--- a/test/sdf/include_pose_1_9.sdf
+++ b/test/sdf/include_pose_1_9.sdf
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<sdf version='1.9'>
+<world name='test_world'>
+  <include>
+    <uri>box</uri>
+    <name>model_name</name>
+
+    <!--<pose>0 10 0 1.570796326794895 0 0</pose>-->
+    <pose degrees="true">0 10 0 90 0 0</pose>
+
+  </include>
+</world>
+</sdf>


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #696

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Pose in include tags are parsed in a single `readXml` call, instead of recursively. Added parsing logic for attribute `degrees` alongside `relative_to`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**