### PR TITLE
Fix documentation on Euler angle convention

### DIFF
--- a/sdf/1.9/pose.sdf
+++ b/sdf/1.9/pose.sdf
@@ -1,7 +1,7 @@
 <!-- Pose -->
 <element name="pose" type="pose" default="0 0 0   0 0 0" required="0">
   <description>
-    A pose (x, y, z, r, p, y) expressed in the frame named by @relative_to. The first three components (x, y, z) represent the position of the element's origin (in the @relative_to frame) and the last three components (roll, pitch, yaw) represent the orientation of the element as a sequence of intrinsic Euler rotations.
+    A pose (x, y, z, r, p, y) expressed in the frame named by @relative_to. The first three components (x, y, z) represent the position of the element's origin (in the @relative_to frame) and the last three components (roll, pitch, yaw) represent the orientation of the element as a sequence of extrinsic X-Y-Z Euler rotations. See https://sdformat.org/tutorials?tut=specify_pose.
   </description>
 
   <attribute name="relative_to" type="string" default="" required="0">

--- a/sdf/1.9/pose.sdf
+++ b/sdf/1.9/pose.sdf
@@ -1,7 +1,7 @@
 <!-- Pose -->
 <element name="pose" type="pose" default="0 0 0   0 0 0" required="0">
   <description>
-    A pose (x, y, z, r, p, y) expressed in the frame named by @relative_to. The first three components (x, y, z) represent the position of the element's origin (in the @relative_to frame) and the last three components (roll, pitch, yaw) represent the orientation of the element as a sequence of extrinsic X-Y-Z Euler rotations. See https://sdformat.org/tutorials?tut=specify_pose.
+    A pose (x, y, z, r, p, y) expressed in the frame named by @relative_to. The first three components (x, y, z) represent the position of the element's origin (in the @relative_to frame) and the last three components (roll, pitch, yaw) represent the orientation of the element as a sequence of extrinsic X-Y-Z Euler rotations. See http://sdformat.org/tutorials?tut=specify_pose.
   </description>
 
   <attribute name="relative_to" type="string" default="" required="0">

--- a/sdf/1.9/pose.sdf
+++ b/sdf/1.9/pose.sdf
@@ -1,7 +1,7 @@
 <!-- Pose -->
 <element name="pose" type="pose" default="0 0 0   0 0 0" required="0">
   <description>
-    A pose (x, y, z, r, p, y) expressed in the frame named by @relative_to. The first three components (x, y, z) represent the position of the element's origin (in the @relative_to frame) and the last three components (roll, pitch, yaw) represent the orientation of the element as a sequence of extrinsic X-Y-Z Euler rotations. See http://sdformat.org/tutorials?tut=specify_pose.
+    A pose (x, y, z, r, p, y) expressed in the frame named by @relative_to. The first three components (x, y, z) represent the position of the element's origin (in the @relative_to frame) and the last three components (roll, pitch, yaw) represent the orientation of the element as a sequence of Euler rotations. See http://sdformat.org/tutorials?tut=specify_pose.
   </description>
 
   <attribute name="relative_to" type="string" default="" required="0">


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The convention stated in the pose.sdf spec was different from the one documented in http://sdformat.org/tutorials?tut=specify_pose.

\cc @FirefoxMetzger 

## Checklist
- [x] Signed all commits for DCO
- ~[ ] Added tests~
- [x] Updated documentation (as needed)
- ~[ ] Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**