### PR TITLE
DOC: don't mention elements that can't be included

### DIFF
--- a/sdf/1.8/model.sdf
+++ b/sdf/1.8/model.sdf
@@ -44,7 +44,7 @@
 
   <element name="include" required="*">
     <description>
-      Include resources from a URI. This can be used to nest models. Included resources can only contain one 'model', 'light' or 'actor' element. The URI can point to a directory or a file. If the URI is a directory, it must conform to the model database structure (see /tutorials?tut=composition&amp;cat=specification&amp;#defining-models-in-separate-files).
+      Include resources from a URI. This can be used to nest models. The included resource can only contain one 'model' element. The URI can point to a directory or a file. If the URI is a directory, it must conform to the model database structure (see /tutorials?tut=composition&amp;cat=specification&amp;#defining-models-in-separate-files).
     </description>
     <element name="uri" type="string" default="__default__" required="1">
       <description>URI to a resource, such as a model</description>


### PR DESCRIPTION
Closes: https://github.com/ignitionrobotics/sdformat/issues/704

`//model/include` can not include a `//actor` or `//light`. This PR removes them being mentioned in the spec of this element.