### PR TITLE
DOC: only allow one canonical_link attribute

### DIFF
--- a/sdf/1.7/model.sdf
+++ b/sdf/1.7/model.sdf
@@ -11,7 +11,7 @@
     </description>
   </attribute>
 
-  <attribute name="canonical_link" type="string" default="" required="*">
+  <attribute name="canonical_link" type="string" default="" required="0">
     <description>
       The name of the model's canonical link, to which the model's implicit
       coordinate frame is attached. If unset or set to an empty string,

--- a/sdf/1.8/model.sdf
+++ b/sdf/1.8/model.sdf
@@ -11,7 +11,7 @@
     </description>
   </attribute>
 
-  <attribute name="canonical_link" type="string" default="" required="*">
+  <attribute name="canonical_link" type="string" default="" required="0">
     <description>
       The name of the model's canonical link, to which the model's implicit
       coordinate frame is attached. If unset or set to an empty string,


### PR DESCRIPTION
Closes: https://github.com/ignitionrobotics/sdformat/issues/703

Changes `required="*"` to `requires="0"` for `//model/@canonical_link`.