### PR TITLE
Do not automatically remove //axis/initial_position

### DIFF
--- a/sdf/1.9/1_8.convert
+++ b/sdf/1.9/1_8.convert
@@ -1,12 +1,2 @@
 <convert name="sdf">
-
-<!-- Remove //axis/initial_position and //axis2/initial_position -->
-  <convert descendant_name="joint">
-    <convert name="axis">
-      <remove element="initial_position"/>
-    </convert>
-    <convert name="axis2">
-      <remove element="initial_position"/>
-    </convert>
-  </convert>
 </convert> <!-- End SDF -->

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -802,6 +802,35 @@ TEST(Parser, MissingRequiredElement)
   EXPECT_EQ(errors[0].LineNumber().value(), 7);
 }
 
+TEST(Parser, ElementRemovedAfterDeprecation)
+{
+  const std::string testString = R"(<?xml version="1.0" ?>
+    <sdf version="1.9">
+      <model name="test_model">
+        <link name="link_0"/>
+        <link name="link_1"/>
+        <joint name="joint" type="revolute">
+          <parent>link_0</parent>
+          <child>link_1</child>
+          <axis>
+            <initial_position>0.1</initial_position> <!-- Removed in 1.9 -->
+          </axis>
+        </joint>
+      </model>
+    </sdf>)";
+
+  sdf::Errors errors;
+  sdf::SDFPtr sdf = InitSDF();
+  sdf::ParserConfig config;
+  config.SetUnrecognizedElementsPolicy(sdf::EnforcementPolicy::ERR);
+  sdf::readString(testString, config, sdf, errors);
+
+  ASSERT_NE(errors.size(), 0u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ELEMENT_INCORRECT_TYPE);
+  ASSERT_TRUE(errors[0].LineNumber().has_value());
+  EXPECT_EQ(errors[0].LineNumber().value(), 10);
+}
+
 /////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)

--- a/test/integration/joint_axis_dom.cc
+++ b/test/integration/joint_axis_dom.cc
@@ -108,10 +108,6 @@ TEST(DOMJointAxis, Complete)
 
   EXPECT_DOUBLE_EQ(10.6, axis->SpringStiffness());
   EXPECT_DOUBLE_EQ(0.0, axis2->SpringStiffness());
-
-  // Ensure that //axis/initial_position is removed during conversion
-  EXPECT_FALSE(axis->Element()->HasElement("initial_position"));
-  EXPECT_FALSE(axis2->Element()->HasElement("initial_position"));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This allows the parser to emit a warning or an error if users still have `//axis/initial_position` in their SDFormat files.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
