### PR TITLE
Remove empty //inertial/pose/@relative_to during 1_7->1.8 conversion

### DIFF
--- a/sdf/1.8/1_7.convert
+++ b/sdf/1.8/1_7.convert
@@ -6,4 +6,10 @@
     </convert>
   </convert>
 
+  <convert descendant_name="inertial">
+    <convert name="pose">
+      <remove_empty attribute="relative_to" />
+    </convert>
+  </convert>
+
 </convert> <!-- End SDF -->

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -645,7 +645,7 @@ void Converter::Add(tinyxml2::XMLElement *_elem, tinyxml2::XMLElement *_addElem)
 /////////////////////////////////////////////////
 void Converter::Remove(tinyxml2::XMLElement *_elem,
                        tinyxml2::XMLElement *_removeElem,
-                       bool _removeEmpty)
+                       bool _removeOnlyEmpty)
 {
   SDF_ASSERT(_elem != NULL, "SDF element is NULL");
   SDF_ASSERT(_removeElem != NULL, "remove element is NULL");
@@ -663,7 +663,7 @@ void Converter::Remove(tinyxml2::XMLElement *_elem,
   if (attributeName)
   {
     const char * attributeValue = _elem->Attribute(attributeName);
-    if (!_removeEmpty || (attributeValue && strlen(attributeValue) == 0))
+    if (!_removeOnlyEmpty || (attributeValue && strlen(attributeValue) == 0))
     {
       _elem->DeleteAttribute(attributeName);
     }
@@ -675,7 +675,8 @@ void Converter::Remove(tinyxml2::XMLElement *_elem,
     while (childElem)
     {
       auto nextSibling = childElem->NextSiblingElement(elementName);
-      if (!_removeEmpty || (childElem->NoChildren() && !childElem->GetText()))
+      if (!_removeOnlyEmpty ||
+          (childElem->NoChildren() && !childElem->GetText()))
       {
         _elem->DeleteChild(childElem);
       }

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -675,8 +675,8 @@ void Converter::Remove(tinyxml2::XMLElement *_elem,
     while (childElem)
     {
       auto nextSibling = childElem->NextSiblingElement(elementName);
-      if (!_removeOnlyEmpty ||
-          (childElem->NoChildren() && !childElem->GetText()))
+      if (!_removeOnlyEmpty || (!childElem->FirstAttribute() &&
+          childElem->NoChildren() && !childElem->GetText()))
       {
         _elem->DeleteChild(childElem);
       }

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -663,7 +663,7 @@ void Converter::Remove(tinyxml2::XMLElement *_elem,
   if (attributeName)
   {
     const char * attributeValue = _elem->Attribute(attributeName);
-    if (!_removeEmpty || (attributeValue && attributeValue[0] == '\0'))
+    if (!_removeEmpty || (attributeValue && strlen(attributeValue) == 0))
     {
       _elem->DeleteAttribute(attributeName);
     }
@@ -707,12 +707,12 @@ void Converter::Map(tinyxml2::XMLElement *_elem, tinyxml2::XMLElement *_mapElem)
   const char *fromNameStr = fromConvertElem->Attribute("name");
   const char *toNameStr = toConvertElem->Attribute("name");
 
-  if (!fromNameStr || fromNameStr[0] == '\0')
+  if (!fromNameStr || strlen(fromNameStr) == 0)
   {
     sdferr << "Map: <from> element requires a non-empty name attribute.\n";
     return;
   }
-  if (!toNameStr || toNameStr[0] == '\0')
+  if (!toNameStr || strlen(toNameStr) == 0)
   {
     sdferr << "Map: <to> element requires a non-empty name attribute.\n";
     return;

--- a/src/Converter.hh
+++ b/src/Converter.hh
@@ -102,8 +102,8 @@ namespace sdf
     /// \param[in] _elem The element from which data may be removed.
     /// \param[in] _removeElem The metadata about what to remove.
     /// \param[in] _removeOnlyEmpty If true, only remove an attribute
-    /// containing an empty string or elements that contain no value nor
-    /// child elements (though possibly attributes).
+    /// containing an empty string or elements that contain neither value nor
+    /// child elements nor attributes.
     private: static void Remove(tinyxml2::XMLElement *_elem,
                                 tinyxml2::XMLElement *_removeElem,
                                 bool _removeOnlyEmpty = false);

--- a/src/Converter.hh
+++ b/src/Converter.hh
@@ -100,9 +100,11 @@ namespace sdf
 
     /// \brief Remove an element.
     /// \param[in] _elem The element that has the _removeElem child.
-    /// \param[in] _removeElem The element to remove.
+    /// \param[in] _removeElem The metadata about what to remove.
+    /// \param[in] _removeEmpty If true, only remove empty nodes.
     private: static void Remove(tinyxml2::XMLElement *_elem,
-                                tinyxml2::XMLElement *_removeElem);
+                                tinyxml2::XMLElement *_removeElem,
+                                bool _removeEmpty = false);
 
     /// \brief Unflatten an element (conversion from SDFormat <= 1.7 to 1.8)
     /// \param[in] _elem The element to unflatten

--- a/src/Converter.hh
+++ b/src/Converter.hh
@@ -98,13 +98,15 @@ namespace sdf
     private: static void Add(tinyxml2::XMLElement *_elem,
                              tinyxml2::XMLElement *_addElem);
 
-    /// \brief Remove an element.
-    /// \param[in] _elem The element that has the _removeElem child.
+    /// \brief Remove an attribute or elements.
+    /// \param[in] _elem The element from which data may be removed.
     /// \param[in] _removeElem The metadata about what to remove.
-    /// \param[in] _removeEmpty If true, only remove empty nodes.
+    /// \param[in] _removeOnlyEmpty If true, only remove an attribute
+    /// containing an empty string or elements that contain no value nor
+    /// child elements (though possibly attributes).
     private: static void Remove(tinyxml2::XMLElement *_elem,
                                 tinyxml2::XMLElement *_removeElem,
-                                bool _removeEmpty = false);
+                                bool _removeOnlyEmpty = false);
 
     /// \brief Unflatten an element (conversion from SDFormat <= 1.7 to 1.8)
     /// \param[in] _elem The element to unflatten

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -50,6 +50,7 @@ std::string getRepeatedXmlString()
          << "  <elemB attrB='B'>"
          << "    <elemC attrC='C' attrEmpty=''>"
          << "      <elemD></elemD>"
+         << "      <elemD attrD='D'></elemD>"
          << "      <elemD>D</elemD>"
          << "      <elemD>D</elemD>"
          << "      <elemD>D</elemD>"
@@ -668,8 +669,17 @@ TEST(Converter, RemoveEmptyElement)
   EXPECT_NE(nullptr, convertedElem->FirstChildElement("elemC"));
   convertedElem = convertedElem->FirstChildElement("elemC");
   ASSERT_NE(nullptr, convertedElem);
+
   auto elemD = convertedElem->FirstChildElement("elemD");
-  ASSERT_NE(elemD, nullptr);
+  ASSERT_NE(nullptr, elemD);
+
+  // first <elemD/> should have an attribute but no value
+  EXPECT_EQ(nullptr, elemD->GetText());
+  ASSERT_NE(nullptr, elemD->Attribute("attrD"));
+  EXPECT_EQ("D", std::string(elemD->Attribute("attrD")));
+
+  // subsequent <elemD/> should have value "D"
+  elemD = elemD->NextSiblingElement("elemD");
   while (elemD)
   {
     std::string elemValue = elemD->GetText();
@@ -724,8 +734,18 @@ TEST(Converter, RemoveEmptyDescendantElement)
   EXPECT_NE(nullptr, convertedElem->FirstChildElement("elemC"));
   convertedElem = convertedElem->FirstChildElement("elemC");
   ASSERT_NE(nullptr, convertedElem);
+
+
   auto elemD = convertedElem->FirstChildElement("elemD");
-  ASSERT_NE(elemD, nullptr);
+  ASSERT_NE(nullptr, elemD);
+
+  // first <elemD/> should have an attribute but no value
+  EXPECT_EQ(nullptr, elemD->GetText());
+  ASSERT_NE(nullptr, elemD->Attribute("attrD"));
+  EXPECT_EQ("D", std::string(elemD->Attribute("attrD")));
+
+  // subsequent <elemD/> should have value "D"
+  elemD = elemD->NextSiblingElement("elemD");
   while (elemD)
   {
     std::string elemValue = elemD->GetText();

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -48,7 +48,8 @@ std::string getRepeatedXmlString()
   std::stringstream stream;
   stream << "<elemA attrA='A'>"
          << "  <elemB attrB='B'>"
-         << "    <elemC attrC='C'>"
+         << "    <elemC attrC='C' attrEmpty=''>"
+         << "      <elemD></elemD>"
          << "      <elemD>D</elemD>"
          << "      <elemD>D</elemD>"
          << "      <elemD>D</elemD>"
@@ -618,6 +619,118 @@ TEST(Converter, RemoveDescendantElement)
   ASSERT_TRUE(convertedElem == nullptr);
 }
 
+////////////////////////////////////////////////////
+/// Ensure that Converter::Remove function is working
+/// Test removing empty elements only
+TEST(Converter, RemoveEmptyElement)
+{
+  // Set up an xml string for testing
+  std::string xmlString = getRepeatedXmlString();
+
+  // Verify the xml
+  tinyxml2::XMLDocument xmlDoc;
+  xmlDoc.Parse(xmlString.c_str());
+  tinyxml2::XMLElement *childElem =  xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemA");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemB");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemC");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemD");
+
+  // Test removing empty elements
+  // Set up a convert file
+  std::stringstream convertStream;
+  convertStream << "<convert name='elemA'>"
+                << "  <convert name='elemB'>"
+                << "    <convert name='elemC'>"
+                << "      <remove_empty element='elemD'/>"
+                << "    </convert>"
+                << "  </convert>"
+                << "</convert>";
+  tinyxml2::XMLDocument convertXmlDoc;
+  convertXmlDoc.Parse(convertStream.str().c_str());
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
+  EXPECT_STREQ(convertedElem->Name(), "elemA");
+  convertedElem = convertedElem->FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
+  EXPECT_STREQ(convertedElem->Name(), "elemB");
+  EXPECT_NE(nullptr, convertedElem->FirstChildElement("elemC"));
+  convertedElem = convertedElem->FirstChildElement("elemC");
+  ASSERT_NE(nullptr, convertedElem);
+  auto elemD = convertedElem->FirstChildElement("elemD");
+  ASSERT_NE(elemD, nullptr);
+  while (elemD)
+  {
+    std::string elemValue = elemD->GetText();
+    EXPECT_EQ(elemValue, "D");
+    elemD = elemD->NextSiblingElement("elemD");
+  }
+}
+
+////////////////////////////////////////////////////
+/// Ensure that Converter::Remove function is working with descendant_name
+/// Test removing empty elements only
+TEST(Converter, RemoveEmptyDescendantElement)
+{
+  // Set up an xml string for testing
+  std::string xmlString = getRepeatedXmlString();
+
+  // Verify the xml
+  tinyxml2::XMLDocument xmlDoc;
+  xmlDoc.Parse(xmlString.c_str());
+  tinyxml2::XMLElement *childElem =  xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemA");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemB");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemC");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemD");
+
+  // Test removing empty elements
+  // Set up a convert file
+  std::stringstream convertStream;
+  convertStream << "<convert name='elemA'>"
+                << "  <convert descendant_name='elemC'>"
+                << "    <remove_empty element='elemD'/>"
+                << "  </convert>"
+                << "</convert>";
+  tinyxml2::XMLDocument convertXmlDoc;
+  convertXmlDoc.Parse(convertStream.str().c_str());
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  tinyxml2::XMLElement *convertedElem = xmlDoc.FirstChildElement();
+
+  EXPECT_STREQ(convertedElem->Name(), "elemA");
+  convertedElem = convertedElem->FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
+  EXPECT_STREQ(convertedElem->Name(), "elemB");
+  EXPECT_NE(nullptr, convertedElem->FirstChildElement("elemC"));
+  convertedElem = convertedElem->FirstChildElement("elemC");
+  ASSERT_NE(nullptr, convertedElem);
+  auto elemD = convertedElem->FirstChildElement("elemD");
+  ASSERT_NE(elemD, nullptr);
+  while (elemD)
+  {
+    std::string elemValue = elemD->GetText();
+    EXPECT_EQ(elemValue, "D");
+    elemD = elemD->NextSiblingElement("elemD");
+  }
+}
+
+////////////////////////////////////////////////////
 TEST(Converter, RemoveDescendantNestedElement)
 {
   // Set up an xml string for testing
@@ -673,6 +786,7 @@ TEST(Converter, RemoveDescendantNestedElement)
 
   EXPECT_STREQ(xmlDocOut.CStr(), expectedXmlDocOut.CStr());
 }
+
 ////////////////////////////////////////////////////
 /// Ensure that Converter ignores descendants of <plugin> or namespaced elements
 TEST(Converter, DescendantIgnorePluginOrNamespacedElements)
@@ -805,7 +919,7 @@ TEST(Converter, RemoveAttr)
   ASSERT_NE(nullptr, childElem);
   EXPECT_STREQ(childElem->Name(), "elemD");
 
-  // Test adding element
+  // Test removing attrC attributes
   // Set up a convert file
   std::stringstream convertStream;
   convertStream << "<convert name='elemA'>"
@@ -828,6 +942,59 @@ TEST(Converter, RemoveAttr)
   convertedElem = convertedElem->FirstChildElement("elemC");
   ASSERT_NE(nullptr, convertedElem);
   EXPECT_TRUE(convertedElem->Attribute("attrC") == nullptr);
+  convertedElem = convertedElem->FirstChildElement("elemD");
+  ASSERT_NE(nullptr, convertedElem);
+}
+
+////////////////////////////////////////////////////
+/// Ensure that Converter::Remove function is working
+/// Test removing empty attributes only
+TEST(Converter, RemoveEmptyAttr)
+{
+  // Set up an xml string for testing
+  std::string xmlString = getRepeatedXmlString();
+
+  // Verify the xml
+  tinyxml2::XMLDocument xmlDoc;
+  xmlDoc.Parse(xmlString.c_str());
+  tinyxml2::XMLElement *childElem =  xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemA");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemB");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemC");
+  childElem = childElem->FirstChildElement();
+  ASSERT_NE(nullptr, childElem);
+  EXPECT_STREQ(childElem->Name(), "elemD");
+
+  // Test adding element
+  // Set up a convert file
+  std::stringstream convertStream;
+  convertStream << "<convert name='elemA'>"
+                << "  <convert name='elemB'>"
+                << "    <convert name='elemC'>"
+                << "      <remove_empty attribute='attrC'/>"
+                << "      <remove_empty attribute='attrEmpty'/>"
+                << "    </convert>"
+                << "  </convert>"
+                << "</convert>";
+  tinyxml2::XMLDocument convertXmlDoc;
+  convertXmlDoc.Parse(convertStream.str().c_str());
+  sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
+
+  tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
+  EXPECT_STREQ(convertedElem->Name(), "elemA");
+  convertedElem = convertedElem->FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
+  EXPECT_STREQ(convertedElem->Name(), "elemB");
+  EXPECT_NE(nullptr, convertedElem->FirstChildElement("elemC"));
+  convertedElem = convertedElem->FirstChildElement("elemC");
+  ASSERT_NE(nullptr, convertedElem);
+  EXPECT_NE(nullptr, convertedElem->Attribute("attrC"));
+  EXPECT_EQ(nullptr, convertedElem->Attribute("attrEmpty"));
   convertedElem = convertedElem->FirstChildElement("elemD");
   ASSERT_NE(nullptr, convertedElem);
 }

--- a/src/Converter_TEST.cc
+++ b/src/Converter_TEST.cc
@@ -559,6 +559,7 @@ TEST(Converter, RemoveElement)
   sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
   EXPECT_STREQ(convertedElem->Name(), "elemA");
   convertedElem = convertedElem->FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -607,6 +608,7 @@ TEST(Converter, RemoveDescendantElement)
   sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
 
   tinyxml2::XMLElement *convertedElem = xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
 
   EXPECT_STREQ(convertedElem->Name(), "elemA");
   convertedElem = convertedElem->FirstChildElement();
@@ -658,6 +660,7 @@ TEST(Converter, RemoveEmptyElement)
   sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
 
   tinyxml2::XMLElement *convertedElem =  xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
   EXPECT_STREQ(convertedElem->Name(), "elemA");
   convertedElem = convertedElem->FirstChildElement();
   ASSERT_NE(nullptr, convertedElem);
@@ -712,6 +715,7 @@ TEST(Converter, RemoveEmptyDescendantElement)
   sdf::Converter::Convert(&xmlDoc, &convertXmlDoc);
 
   tinyxml2::XMLElement *convertedElem = xmlDoc.FirstChildElement();
+  ASSERT_NE(nullptr, convertedElem);
 
   EXPECT_STREQ(convertedElem->Name(), "elemA");
   convertedElem = convertedElem->FirstChildElement();

--- a/test/sdf/model_frame_relative_to_joint.sdf
+++ b/test/sdf/model_frame_relative_to_joint.sdf
@@ -3,6 +3,9 @@
   <model name="model_frame_relative_to_joint">
     <link name="P">
       <pose>1 0 0 0 0 0</pose>
+      <inertial>
+        <pose relative_to="">0 0 0 0 0 0</pose>
+      </inertial>
       <collision name="P1">
         <pose>0 0 10 0 0 0</pose>
         <geometry>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes warnings when loading models from 1.7 or earlier with `//inertial/pose/@relative_to`, part of https://github.com/ignitionrobotics/ign-gazebo/issues/1056

## Summary

The `//inertial/pose/@relative_to` attribute was removed from the 1.8 spec in 93f8c56b6a9c889500db17654fcb83c2f825c598, which causes warnings when loading a file from 1.7 or earlier that contains this attribute. This PR removes this attribute during conversion from 1.7 -> 1.8 if the attribute is empty, which should silence many of the warnings, while retaining those warnings that may require action from the user.

I added an empty attribute to a `test/sdf` file in https://github.com/ignitionrobotics/sdformat/pull/720/commits/34d95879c2e620ed10df69515e4ad211746f6031, which causes a warning that causes `UNIT_ign_TEST` to fail. The failure is fixed by new functionality in the `Converter` class, which allows removal of empty attributes or elements.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
