### PR TITLE
Check joint parent link names in Model::Load

### DIFF
--- a/src/Model.cc
+++ b/src/Model.cc
@@ -397,9 +397,18 @@ Errors Model::Load(ElementPtr _sdf)
     errors.insert(errors.end(), setPoseRelativeToGraphErrors.begin(),
                                 setPoseRelativeToGraphErrors.end());
   }
+  // Pass graph pointer to joint and check parent names
   for (auto &joint : this->dataPtr->joints)
   {
     joint.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
+    const std::string &parentLinkName = joint.ParentLinkName();
+    if (parentLinkName != "world" && !this->LinkByName(parentLinkName))
+    {
+      errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
+          "parent link with name[" + parentLinkName +
+          "] specified by joint with name[" + joint.Name() +
+          "] not found in model with name[" + this->Name() + "]."});
+    }
   }
   for (auto &frame : this->dataPtr->frames)
   {

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -260,6 +260,17 @@ TEST(check, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     EXPECT_EQ("Valid.\n", output) << output;
   }
 
+  // Check an SDF file with the infinite values for joint axis limits.
+  // This is a valid file.
+  {
+    std::string path = pathBase +"/joint_axis_infinite_limits.sdf";
+
+    // Check joint_axis_infinite_limits.sdf
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf -k " + path + SdfVersion());
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
   // Check an SDF file with the second link specified as the canonical link.
   // This is a valid file.
   {

--- a/test/sdf/joint_axis_infinite_limits.sdf
+++ b/test/sdf/joint_axis_infinite_limits.sdf
@@ -6,6 +6,7 @@
     <link name="link3"/>
     <link name="link4"/>
     <link name="link5"/>
+    <link name="link6"/>
 
     <joint name="default_joint_limits" type="revolute">
       <child>link1</child>

--- a/test/sdf/joint_axis_xyz_normalization.sdf
+++ b/test/sdf/joint_axis_xyz_normalization.sdf
@@ -6,6 +6,7 @@
     <link name="link3"/>
     <link name="link4"/>
     <link name="link5"/>
+    <link name="link6"/>
 
     <joint name="joint1" type="revolute">
       <child>link1</child>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #719 on `sdf10` (a separate fix is needed for `sdf11` and later)

## Summary

As noted in #710, several example files in the `test/sdf/` folder specify non-existent links in the `//joint/parent` element, which violates the spec. I added an `ign sdf --check test/sdf/joint_axis_infinite_limits.sdf` test case in https://github.com/ignitionrobotics/sdformat/commit/b47f9bf650525551c25e1f2729bda0d3008e0526, which properly notes the failure, though the `sdf::Root::Load` call in `INTEGRATION_joint_axis_dom` does not report an error. To detect the error in `sdf::Root::Load`, I added a check in `Model::Load` that `//joint/parent` contains a valid link name and fixed the `test/sdf/` files in https://github.com/ignitionrobotics/sdformat/commit/ce8c0324d095319c5df421bbdf847d9fe230d3d7.

A different fix will be needed in `sdf11` to account for changes in the spec that allow any frame to be named in `//joint/parent`.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [X] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
