### PR TITLE
Check joint parent/child names in Root::Load

### DIFF
--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -388,6 +388,15 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool checkJointParentChildLinkNames(const sdf::Root *_root);
 
+  /// \brief Check that all joints in contained models specify parent
+  /// and child link names that match the names of sibling links.
+  /// This checks recursively and should check the files exhaustively
+  /// rather than terminating early when the first error is found.
+  /// \param[in] _root SDF Root object to check recursively.
+  /// \param[out] _errors Detected errors will be appended to this variable.
+  SDFORMAT_VISIBLE
+  void checkJointParentChildLinkNames(const sdf::Root *_root, Errors &_errors);
+
   /// \brief For the world and each model, check that the attached_to graphs
   /// build without errors and have no cycles.
   /// Confirm that following directed edges from each vertex in the graph

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -159,7 +159,7 @@ Errors Joint::Load(ElementPtr _sdf)
   {
     errors.push_back({ErrorCode::JOINT_PARENT_SAME_AS_CHILD,
         "Joint with name[" + this->dataPtr->name +
-        "] must specify different link names for "
+        "] must specify different frame names for "
         "parent and child, while [" + this->dataPtr->childLinkName +
         "] was specified for both."});
   }

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -325,6 +325,10 @@ Errors Root::Load(SDFPtr _sdf, const ParserConfig &_config)
     }
   }
 
+  // Check that Joint parent and child names resolve to valid and
+  // different frames.
+  checkJointParentChildLinkNames(this, errors);
+
   return errors;
 }
 

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -257,7 +257,7 @@ TEST(check, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     std::string output =
       custom_exec_str(IgnCommand() + " sdf -k " + path + SdfVersion());
     EXPECT_NE(output.find("Joint with name[joint] must "
-                          "specify different link names for parent and child, "
+                          "specify different frame names for parent and child, "
                           "while [link] was specified for both."),
               std::string::npos) << output;
   }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -322,6 +322,17 @@ TEST(check, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     EXPECT_EQ("Valid.\n", output) << output;
   }
 
+  // Check an SDF file with the infinite values for joint axis limits.
+  // This is a valid file.
+  {
+    std::string path = pathBase +"/joint_axis_infinite_limits.sdf";
+
+    // Check joint_axis_infinite_limits.sdf
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf -k " + path + SdfVersion());
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
   // Check an SDF file with the second link specified as the canonical link.
   // This is a valid file.
   {

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -218,7 +218,7 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
   auto errors = root.Load(testFile);
   for (auto e : errors)
     std::cout << e << std::endl;
-  ASSERT_EQ(7u, errors.size());
+  ASSERT_EQ(10u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
@@ -549,7 +549,7 @@ TEST(DOMJoint, LoadInvalidChild)
   for (auto e : errors)
     std::cout << e << std::endl;
   EXPECT_FALSE(errors.empty());
-  EXPECT_EQ(6u, errors.size());
+  EXPECT_EQ(8u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
@@ -564,6 +564,8 @@ TEST(DOMJoint, LoadInvalidChild)
   // errors[3]
   // errors[4]
   // errors[5]
+  // errors[6]
+  // errors[7]
 }
 
 /////////////////////////////////////////////////
@@ -584,7 +586,7 @@ TEST(DOMJoint, LoadLinkJointSameName17Invalid)
   for (auto e : errors)
     std::cout << e << std::endl;
   EXPECT_FALSE(errors.empty());
-  EXPECT_EQ(7u, errors.size());
+  EXPECT_EQ(9u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::DUPLICATE_NAME);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(

--- a/test/sdf/joint_axis_infinite_limits.sdf
+++ b/test/sdf/joint_axis_infinite_limits.sdf
@@ -6,6 +6,7 @@
     <link name="link3"/>
     <link name="link4"/>
     <link name="link5"/>
+    <link name="link6"/>
 
     <joint name="default_joint_limits" type="revolute">
       <child>link1</child>

--- a/test/sdf/joint_axis_xyz_normalization.sdf
+++ b/test/sdf/joint_axis_xyz_normalization.sdf
@@ -6,6 +6,7 @@
     <link name="link3"/>
     <link name="link4"/>
     <link name="link5"/>
+    <link name="link6"/>
 
     <joint name="joint1" type="revolute">
       <child>link1</child>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #719 for `sdf11`, similar to #726

## Summary

As noted in #710, several example files in the `test/sdf/` folder specify non-existent links in the `//joint/parent` element, which violates the spec. I added an `ign sdf --check test/sdf/joint_axis_infinite_limits.sdf` test case in https://github.com/ignitionrobotics/sdformat/commit/893f2c8eb51a741bdbcaffa45d35d40a7441c334, which properly notes the failure, though the `sdf::Root::Load` call in `INTEGRATION_joint_axis_dom` does not report an error. To detect the error in `sdf::Root::Load`, I first added a version of `checkJointParentChildLinkNames` that outputs an `sdf::Errors` to `parser.hh` (49b432b) and then call that function from `Root::Load` (1d21294). This goes beyond the change in #726 by checking that each joint's parent and child frames resolve correctly. Finally, I fixed the `test/sdf/` files in 08ac2b9 and made a minor fix to an error message in 628f382.

This will likely reduce coverage due to redundancy in our error checking.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [X] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
