### PR TITLE
Remove outdated deprecation note from parser_urdf.hh

### DIFF
--- a/src/parser_urdf.hh
+++ b/src/parser_urdf.hh
@@ -33,10 +33,6 @@ namespace sdf
   //
 
   /// \brief URDF to SDF converter
-  ///
-  /// This is now deprecated for external usage and will be removed in the next
-  /// major version of libsdformat. Instead, consider using `sdf::readFile` or
-  /// `sdf::readString`, which automatically convert URDF to SDF.
   class URDF2SDF
   {
     /// \brief constructor


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Addresses https://github.com/ignitionrobotics/sdformat/pull/736#issuecomment-961279140

## Summary
The discussion held in https://github.com/ignitionrobotics/sdformat/pull/736#issuecomment-961279140 pointed out that the `URDF2SDF` is actually not deprecated and is a private header that is needed, so I have removed the deprecation note from the class' header file.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**