### PR TITLE
Convert Joint DOM to Element

### DIFF
--- a/include/sdf/AirPressure.hh
+++ b/include/sdf/AirPressure.hh
@@ -84,10 +84,10 @@ namespace sdf
     /// \returen True if 'this' != _mag.
     public: bool operator!=(const AirPressure &_air) const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// air pressure sensor.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Altimeter.hh
+++ b/include/sdf/Altimeter.hh
@@ -76,10 +76,10 @@ namespace sdf
     /// \returen True if 'this' != _alt.
     public: bool operator!=(const Altimeter &_alt) const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// altimeter sensor.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -472,10 +472,10 @@ namespace sdf
     /// \return True if the camera has instrinsics values set, false otherwise
     public: bool HasLensIntrinsics() const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// camera.
+    /// \return SDF element pointer with updated camera values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/ForceTorque.hh
+++ b/include/sdf/ForceTorque.hh
@@ -154,10 +154,10 @@ namespace sdf
     /// \returen True if 'this' != _ft.
     public: bool operator!=(const ForceTorque &_ft) const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// force torque sensor.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Imu.hh
+++ b/include/sdf/Imu.hh
@@ -253,10 +253,10 @@ namespace sdf
     /// \returen True if 'this' != _imu.
     public: bool operator!=(const Imu &_imu) const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// imu sensor.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -225,6 +225,11 @@ namespace sdf
     /// \sa bool SensorNameExists(const std::string &_name) const
     public: const Sensor *SensorByName(const std::string &_name) const;
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// joint.
+    /// \return SDF element pointer with updated joint values.
+    public: sdf::ElementPtr ToElement() const;
+
     /// \brief Give the scoped FrameAttachedToGraph to be used for resolving
     /// parent and child link names. This is private and is intended to be
     /// called by Model::Load.

--- a/include/sdf/JointAxis.hh
+++ b/include/sdf/JointAxis.hh
@@ -221,6 +221,12 @@ namespace sdf
     /// not been called.
     public: sdf::ElementPtr Element() const;
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// joint axis.
+    /// \param[in] _index Index of this joint axis
+    /// \return SDF element pointer with updated joint values.
+    public: sdf::ElementPtr ToElement(unsigned int _index = 0u) const;
+
     /// \brief Give the name of the xml parent of this object, to be used
     /// for resolving poses. This is private and is intended to be called by
     /// Link::SetPoseRelativeToGraph.

--- a/include/sdf/Lidar.hh
+++ b/include/sdf/Lidar.hh
@@ -232,10 +232,10 @@ namespace sdf
     /// \return True if 'this' != _lidar.
     public: bool operator!=(const Lidar &_lidar) const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// lidar.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Magnetometer.hh
+++ b/include/sdf/Magnetometer.hh
@@ -85,10 +85,10 @@ namespace sdf
     /// \returen True if 'this' != _mag.
     public: bool operator!=(const Magnetometer &_mag) const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// magnetometer.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Noise.hh
+++ b/include/sdf/Noise.hh
@@ -162,13 +162,10 @@ namespace sdf
     /// not been called.
     public: sdf::ElementPtr Element() const;
 
-    /// \brief Fill the provided _elem with data from this sensor type.
-    /// \param[out] _elem SDF element point to populate
-    /// \param[in] _simpleNoise True if the element should be populated with
-    /// just type, mean, and standard deviation.
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem,
-                bool _simpleNoise = false) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// noise.
+    /// \return SDF element pointer with updated noise values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -203,10 +203,10 @@ namespace sdf
     /// not been called.
     public: sdf::ElementPtr Element() const;
 
-    /// \brief Fill the provided _elem with data from this sensor.
-    /// \param[out] _elem SDF element point to populate
-    /// \return True if successful.
-    public: bool PopulateElement(sdf::ElementPtr _elem) const;
+    /// \brief Create and return an SDF element filled with data from this
+    /// sensor.
+    /// \return SDF element pointer with updated sensor values.
+    public: sdf::ElementPtr ToElement() const;
 
     /// \brief Get the sensor type.
     /// \return The sensor type.

--- a/src/AirPressure.cc
+++ b/src/AirPressure.cc
@@ -17,6 +17,7 @@
 #include <array>
 #include <string>
 #include "sdf/AirPressure.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 
@@ -115,11 +116,16 @@ void AirPressure::SetPressureNoise(const Noise &_noise)
 }
 
 /////////////////////////////////////////////////
-bool AirPressure::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr AirPressure::ToElement() const
 {
-  _elem->GetElement("reference_altitude")->Set<double>(
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("air_pressure.sdf", elem);
+
+  elem->GetElement("reference_altitude")->Set<double>(
       this->ReferenceAltitude());
-  sdf::ElementPtr pressureElem = _elem->GetElement("pressure");
+  sdf::ElementPtr pressureElem = elem->GetElement("pressure");
   sdf::ElementPtr noiseElem = pressureElem->GetElement("noise");
-  return this->dataPtr->noise.PopulateElement(noiseElem);
+  noiseElem->Copy(this->dataPtr->noise.ToElement());
+
+  return elem;
 }

--- a/src/AirPressure_TEST.cc
+++ b/src/AirPressure_TEST.cc
@@ -92,3 +92,42 @@ TEST(DOMAirPressure, Load)
   // The AirPressure::Load function is test more thouroughly in the
   // link_dom.cc integration test.
 }
+
+/////////////////////////////////////////////////
+TEST(DOMAirPressure, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::AirPressure air;
+  sdf::Noise noise;
+  air.SetReferenceAltitude(10.2);
+  noise.SetType(sdf::NoiseType::GAUSSIAN);
+  noise.SetMean(1.2);
+  noise.SetStdDev(2.3);
+  noise.SetBiasMean(4.5);
+  noise.SetBiasStdDev(6.7);
+  noise.SetPrecision(8.9);
+  air.SetPressureNoise(noise);
+
+  sdf::ElementPtr airElem = air.ToElement();
+  EXPECT_NE(nullptr, airElem);
+  EXPECT_EQ(nullptr, air.Element());
+
+  // verify values after loading the element back
+  sdf::AirPressure air2;
+  air2.Load(airElem);
+
+  EXPECT_DOUBLE_EQ(noise.Mean(), air2.PressureNoise().Mean());
+  EXPECT_DOUBLE_EQ(noise.StdDev(), air2.PressureNoise().StdDev());
+  EXPECT_DOUBLE_EQ(noise.BiasMean(), air2.PressureNoise().BiasMean());
+  EXPECT_DOUBLE_EQ(noise.BiasStdDev(), air2.PressureNoise().BiasStdDev());
+  EXPECT_DOUBLE_EQ(noise.Precision(), air2.PressureNoise().Precision());
+  EXPECT_DOUBLE_EQ(10.2, air2.ReferenceAltitude());
+
+  // make changes to DOM and verify ToElement produces updated values
+  air2.SetReferenceAltitude(111);
+  sdf::ElementPtr air2Elem = air2.ToElement();
+  EXPECT_NE(nullptr, air2Elem);
+  sdf::AirPressure air3;
+  air3.Load(air2Elem);
+  EXPECT_DOUBLE_EQ(111.0, air3.ReferenceAltitude());
+}

--- a/src/Altimeter.cc
+++ b/src/Altimeter.cc
@@ -17,6 +17,7 @@
 #include <array>
 #include <string>
 #include "sdf/Altimeter.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 
@@ -129,16 +130,18 @@ bool Altimeter::operator==(const Altimeter &_alt) const
 }
 
 /////////////////////////////////////////////////
-bool Altimeter::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr Altimeter::ToElement() const
 {
-  sdf::ElementPtr verticalPosElem = _elem->GetElement("vertical_position");
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("altimeter.sdf", elem);
+
+  sdf::ElementPtr verticalPosElem = elem->GetElement("vertical_position");
   sdf::ElementPtr verticalPosNoiseElem = verticalPosElem->GetElement("noise");
+  verticalPosNoiseElem->Copy(this->dataPtr->verticalPositionNoise.ToElement());
 
-  sdf::ElementPtr verticalVelElem = _elem->GetElement("vertical_velocity");
+  sdf::ElementPtr verticalVelElem = elem->GetElement("vertical_velocity");
   sdf::ElementPtr verticalVelNoiseElem = verticalVelElem->GetElement("noise");
+  verticalVelNoiseElem->Copy(this->dataPtr->verticalVelocityNoise.ToElement());
 
-  return
-    this->dataPtr->verticalPositionNoise.PopulateElement(verticalPosNoiseElem)
-    &&
-    this->dataPtr->verticalVelocityNoise.PopulateElement(verticalVelNoiseElem);
+  return elem;
 }

--- a/src/Altimeter_TEST.cc
+++ b/src/Altimeter_TEST.cc
@@ -100,3 +100,42 @@ TEST(DOMAltimeter, Load)
   // The Altimeter::Load function is test more thouroughly in the
   // link_dom.cc integration test.
 }
+
+/////////////////////////////////////////////////
+TEST(DOMAltimeter, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::Altimeter alt;
+  sdf::Noise defaultNoise, noise;
+  EXPECT_EQ(defaultNoise, alt.VerticalPositionNoise());
+  EXPECT_EQ(defaultNoise, alt.VerticalVelocityNoise());
+
+  noise.SetType(sdf::NoiseType::GAUSSIAN);
+  noise.SetMean(1.2);
+  noise.SetStdDev(2.3);
+  noise.SetBiasMean(4.5);
+  noise.SetBiasStdDev(6.7);
+  noise.SetPrecision(8.9);
+  alt.SetVerticalPositionNoise(noise);
+  alt.SetVerticalVelocityNoise(noise);
+
+  sdf::ElementPtr altElem = alt.ToElement();
+  EXPECT_NE(nullptr, altElem);
+  EXPECT_EQ(nullptr, alt.Element());
+
+  // verify values after loading the element back
+  sdf::Altimeter alt2;
+  alt2.Load(altElem);
+
+  EXPECT_EQ(noise, alt2.VerticalPositionNoise());
+  EXPECT_EQ(noise, alt2.VerticalVelocityNoise());
+
+  // make changes to DOM and verify ToElement produces updated values
+  noise.SetMean(2.3);
+  alt2.SetVerticalPositionNoise(noise);
+  sdf::ElementPtr alt2Elem = alt2.ToElement();
+  EXPECT_NE(nullptr, alt2Elem);
+  sdf::Altimeter alt3;
+  alt3.Load(alt2Elem);
+  EXPECT_EQ(noise, alt3.VerticalPositionNoise());
+}

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -992,7 +992,13 @@ sdf::ElementPtr Camera::ToElement() const
   sdf::initFile("camera.sdf", elem);
 
   elem->GetAttribute("name")->Set<std::string>(this->Name());
-  elem->GetElement("pose")->Set<ignition::math::Pose3d>(this->RawPose());
+  sdf::ElementPtr poseElem = elem->GetElement("pose");
+  if (!this->dataPtr->poseRelativeTo.empty())
+  {
+    poseElem->GetAttribute("relative_to")->Set<std::string>(
+        this->dataPtr->poseRelativeTo);
+  }
+  poseElem->Set<ignition::math::Pose3d>(this->RawPose());
   elem->GetElement("horizontal_fov")->Set<double>(
       this->HorizontalFov().Radian());
   sdf::ElementPtr imageElem = elem->GetElement("image");
@@ -1015,6 +1021,8 @@ sdf::ElementPtr Camera::ToElement() const
   saveElem->GetAttribute("enabled")->Set<bool>(this->SaveFrames());
   if (this->SaveFrames())
     saveElem->GetElement("path")->Set<std::string>(this->SaveFramesPath());
+  elem->GetElement("visibility_mask")->Set<uint32_t>(
+      this->VisibilityMask());
 
   sdf::ElementPtr noiseElem = elem->GetElement("noise");
   std::string noiseType;

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -16,6 +16,7 @@
 */
 #include <array>
 #include "sdf/Camera.hh"
+#include "sdf/parser.hh"
 #include "Utils.hh"
 
 using namespace sdf;
@@ -985,37 +986,60 @@ bool Camera::HasLensIntrinsics() const
 }
 
 /////////////////////////////////////////////////
-bool Camera::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr Camera::ToElement() const
 {
-  _elem->GetAttribute("name")->Set<std::string>(this->Name());
-  _elem->GetElement("pose")->Set<ignition::math::Pose3d>(this->RawPose());
-  _elem->GetElement("horizontal_fov")->Set<double>(
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("camera.sdf", elem);
+
+  elem->GetAttribute("name")->Set<std::string>(this->Name());
+  elem->GetElement("pose")->Set<ignition::math::Pose3d>(this->RawPose());
+  elem->GetElement("horizontal_fov")->Set<double>(
       this->HorizontalFov().Radian());
-  sdf::ElementPtr imageElem = _elem->GetElement("image");
+  sdf::ElementPtr imageElem = elem->GetElement("image");
   imageElem->GetElement("width")->Set<double>(this->ImageWidth());
   imageElem->GetElement("height")->Set<double>(this->ImageHeight());
   imageElem->GetElement("format")->Set<std::string>(this->PixelFormatStr());
-  sdf::ElementPtr clipElem = _elem->GetElement("clip");
+  sdf::ElementPtr clipElem = elem->GetElement("clip");
   clipElem->GetElement("near")->Set<double>(this->NearClip());
   clipElem->GetElement("far")->Set<double>(this->FarClip());
 
   if (this->dataPtr->hasDepthCamera)
   {
-    sdf::ElementPtr depthElem = _elem->GetElement("depth_camera");
+    sdf::ElementPtr depthElem = elem->GetElement("depth_camera");
     sdf::ElementPtr depthClipElem = depthElem->GetElement("clip");
     depthClipElem->GetElement("near")->Set<double>(this->DepthNearClip());
     depthClipElem->GetElement("far")->Set<double>(this->DepthFarClip());
   }
 
-  sdf::ElementPtr saveElem = _elem->GetElement("save");
+  sdf::ElementPtr saveElem = elem->GetElement("save");
   saveElem->GetAttribute("enabled")->Set<bool>(this->SaveFrames());
   if (this->SaveFrames())
     saveElem->GetElement("path")->Set<std::string>(this->SaveFramesPath());
 
-  sdf::ElementPtr noiseElem = _elem->GetElement("noise");
-  this->dataPtr->imageNoise.PopulateElement(noiseElem, true);
+  sdf::ElementPtr noiseElem = elem->GetElement("noise");
+  std::string noiseType;
+  switch (this->dataPtr->imageNoise.Type())
+  {
+    case sdf::NoiseType::NONE:
+      noiseType = "none";
+      break;
+    case sdf::NoiseType::GAUSSIAN:
+      noiseType = "gaussian";
+      break;
+    case sdf::NoiseType::GAUSSIAN_QUANTIZED:
+      noiseType = "gaussian_quantized";
+      break;
+    default:
+      noiseType = "none";
+  }
 
-  sdf::ElementPtr distortionElem = _elem->GetElement("distortion");
+  // camera does not use noise.sdf description
+  noiseElem->GetElement("type")->Set<std::string>(noiseType);
+  noiseElem->GetElement("mean")->Set<double>(this->dataPtr->imageNoise.Mean());
+  noiseElem->GetElement("stddev")->Set<double>(
+      this->dataPtr->imageNoise.StdDev());
+
+  sdf::ElementPtr distortionElem = elem->GetElement("distortion");
   distortionElem->GetElement("k1")->Set<double>(this->DistortionK1());
   distortionElem->GetElement("k2")->Set<double>(this->DistortionK2());
   distortionElem->GetElement("k3")->Set<double>(this->DistortionK3());
@@ -1024,7 +1048,7 @@ bool Camera::PopulateElement(sdf::ElementPtr _elem) const
   distortionElem->GetElement("center")->Set<ignition::math::Vector2d>(
       this->DistortionCenter());
 
-  sdf::ElementPtr lensElem = _elem->GetElement("lens");
+  sdf::ElementPtr lensElem = elem->GetElement("lens");
   lensElem->GetElement("type")->Set<std::string>(this->LensType());
   lensElem->GetElement("scale_to_hfov")->Set<bool>(this->LensScaleToHfov());
   lensElem->GetElement("cutoff_angle")->Set<double>(
@@ -1053,9 +1077,9 @@ bool Camera::PopulateElement(sdf::ElementPtr _elem) const
 
   if (this->HasSegmentationType())
   {
-    _elem->GetElement("segmentation_type")->Set<std::string>(
+    elem->GetElement("segmentation_type")->Set<std::string>(
         this->SegmentationType());
   }
 
-  return true;
+  return elem;
 }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -211,3 +211,48 @@ TEST(DOMCamera, Construction)
   // The Camera::Load function is tested more thoroughly in the
   // link_dom.cc integration test.
 }
+
+/////////////////////////////////////////////////
+TEST(DOMCamera, ToElement)
+{
+  sdf::Camera cam;
+  cam.SetName("my_camera");
+  EXPECT_EQ("my_camera", cam.Name());
+  cam.SetHorizontalFov(1.45);
+  cam.SetImageWidth(123);
+  cam.SetImageHeight(125);
+  cam.SetPixelFormat(sdf::PixelFormatType::L_INT8);
+  cam.SetNearClip(0.2);
+  cam.SetFarClip(200.2);
+  cam.SetVisibilityMask(123u);
+  cam.SetPoseRelativeTo("/frame");
+  cam.SetSaveFrames(true);
+  cam.SetSaveFramesPath("/tmp");
+
+  sdf::ElementPtr camElem = cam.ToElement();
+  EXPECT_NE(nullptr, camElem);
+  EXPECT_EQ(nullptr, cam.Element());
+
+  // verify values after loading the element back
+  sdf::Camera cam2;
+  cam2.Load(camElem);
+
+  EXPECT_DOUBLE_EQ(1.45, cam2.HorizontalFov().Radian());
+  EXPECT_EQ(123u, cam2.ImageWidth());
+  EXPECT_EQ(125u, cam2.ImageHeight());
+  EXPECT_EQ(sdf::PixelFormatType::L_INT8 , cam2.PixelFormat());
+  EXPECT_DOUBLE_EQ(0.2, cam2.NearClip());
+  EXPECT_DOUBLE_EQ(200.2, cam2.FarClip());
+  EXPECT_EQ(123u, cam2.VisibilityMask());
+  EXPECT_EQ("/frame", cam2.PoseRelativeTo());
+  EXPECT_TRUE(cam2.SaveFrames());
+  EXPECT_EQ("/tmp", cam2.SaveFramesPath());
+
+  // make changes to DOM and verify ToElement produces updated values
+  cam2.SetNearClip(0.33);
+  sdf::ElementPtr cam2Elem = cam2.ToElement();
+  EXPECT_NE(nullptr, cam2Elem);
+  sdf::Camera cam3;
+  cam3.Load(cam2Elem);
+  EXPECT_DOUBLE_EQ(0.33, cam3.NearClip());
+}

--- a/src/ForceTorque.cc
+++ b/src/ForceTorque.cc
@@ -16,6 +16,7 @@
  */
 #include <string>
 #include "sdf/ForceTorque.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 
@@ -279,9 +280,11 @@ void ForceTorque::SetMeasureDirection(
 }
 
 /////////////////////////////////////////////////
-bool ForceTorque::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr ForceTorque::ToElement() const
 {
-  bool result = true;
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("forcetorque.sdf", elem);
+
   std::string frame;
   switch (this->Frame())
   {
@@ -299,7 +302,7 @@ bool ForceTorque::PopulateElement(sdf::ElementPtr _elem) const
       break;
   }
   if (!frame.empty())
-    _elem->GetElement("frame")->Set<std::string>(frame);
+    elem->GetElement("frame")->Set<std::string>(frame);
 
   std::string measureDirection;
   switch (this->MeasureDirection())
@@ -316,40 +319,34 @@ bool ForceTorque::PopulateElement(sdf::ElementPtr _elem) const
   }
   if (!measureDirection.empty())
   {
-    _elem->GetElement("measure_direction")->Set<std::string>(measureDirection);
+    elem->GetElement("measure_direction")->Set<std::string>(measureDirection);
   }
 
-  sdf::ElementPtr forceElem = _elem->GetElement("force");
+  sdf::ElementPtr forceElem = elem->GetElement("force");
   sdf::ElementPtr forceXElem = forceElem->GetElement("x");
   sdf::ElementPtr forceXNoiseElem = forceXElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->forceXNoise.PopulateElement(forceXNoiseElem);
+  forceXNoiseElem->Copy(this->dataPtr->forceXNoise.ToElement());
 
   sdf::ElementPtr forceYElem = forceElem->GetElement("y");
   sdf::ElementPtr forceYNoiseElem = forceYElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->forceYNoise.PopulateElement(forceYNoiseElem);
+  forceYNoiseElem->Copy(this->dataPtr->forceYNoise.ToElement());
 
   sdf::ElementPtr forceZElem = forceElem->GetElement("z");
   sdf::ElementPtr forceZNoiseElem = forceZElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->forceZNoise.PopulateElement(forceZNoiseElem);
+  forceZNoiseElem->Copy(this->dataPtr->forceZNoise.ToElement());
 
-  sdf::ElementPtr torqueElem = _elem->GetElement("torque");
+  sdf::ElementPtr torqueElem = elem->GetElement("torque");
   sdf::ElementPtr torqueXElem = torqueElem->GetElement("x");
   sdf::ElementPtr torqueXNoiseElem = torqueXElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->torqueXNoise.PopulateElement(torqueXNoiseElem);
+  torqueXNoiseElem->Copy(this->dataPtr->torqueXNoise.ToElement());
 
   sdf::ElementPtr torqueYElem = torqueElem->GetElement("y");
   sdf::ElementPtr torqueYNoiseElem = torqueYElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->torqueYNoise.PopulateElement(torqueYNoiseElem);
+  torqueYNoiseElem->Copy(this->dataPtr->torqueYNoise.ToElement());
 
   sdf::ElementPtr torqueZElem = torqueElem->GetElement("z");
   sdf::ElementPtr torqueZNoiseElem = torqueZElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->torqueZNoise.PopulateElement(torqueZNoiseElem);
+  torqueZNoiseElem->Copy(this->dataPtr->torqueZNoise.ToElement());
 
-  return result;
+  return elem;
 }

--- a/src/ForceTorque_TEST.cc
+++ b/src/ForceTorque_TEST.cc
@@ -109,3 +109,53 @@ TEST(DOMForceTorque, Load)
   // The ForceTorque::Load function is tested more thouroughly in the
   // link_dom.cc integration test.
 }
+
+/////////////////////////////////////////////////
+TEST(DOMForceTorque, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::ForceTorque ft;
+  sdf::Noise noise;
+
+  noise.SetType(sdf::NoiseType::GAUSSIAN);
+  noise.SetMean(1.2);
+  noise.SetStdDev(2.3);
+  noise.SetBiasMean(4.5);
+  noise.SetBiasStdDev(6.7);
+  noise.SetPrecision(8.9);
+  ft.SetForceXNoise(noise);
+  ft.SetForceYNoise(noise);
+  ft.SetForceZNoise(noise);
+  ft.SetTorqueXNoise(noise);
+  ft.SetTorqueYNoise(noise);
+  ft.SetTorqueZNoise(noise);
+  ft.SetFrame(sdf::ForceTorqueFrame::PARENT);
+  ft.SetMeasureDirection(sdf::ForceTorqueMeasureDirection::PARENT_TO_CHILD);
+
+  sdf::ElementPtr ftElem = ft.ToElement();
+  EXPECT_NE(nullptr, ftElem);
+  EXPECT_EQ(nullptr, ft.Element());
+
+  // verify values after loading the element back
+  sdf::ForceTorque ft2;
+  ft2.Load(ftElem);
+
+  EXPECT_EQ(noise, ft2.ForceXNoise());
+  EXPECT_EQ(noise, ft2.ForceYNoise());
+  EXPECT_EQ(noise, ft2.ForceZNoise());
+  EXPECT_EQ(noise, ft2.TorqueXNoise());
+  EXPECT_EQ(noise, ft2.TorqueYNoise());
+  EXPECT_EQ(noise, ft2.TorqueZNoise());
+  EXPECT_EQ(sdf::ForceTorqueFrame::PARENT, ft2.Frame());
+  EXPECT_EQ(sdf::ForceTorqueMeasureDirection::PARENT_TO_CHILD,
+      ft2.MeasureDirection());
+
+  // make changes to DOM and verify ToElement produces updated values
+  ft2.SetMeasureDirection(sdf::ForceTorqueMeasureDirection::CHILD_TO_PARENT);
+  sdf::ElementPtr ft2Elem = ft2.ToElement();
+  EXPECT_NE(nullptr, ft2Elem);
+  sdf::ForceTorque ft3;
+  ft3.Load(ft2Elem);
+  EXPECT_EQ(sdf::ForceTorqueMeasureDirection::CHILD_TO_PARENT,
+      ft3.MeasureDirection());
+}

--- a/src/Imu.cc
+++ b/src/Imu.cc
@@ -17,6 +17,7 @@
 #include <array>
 #include <string>
 #include "sdf/Imu.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 
@@ -367,12 +368,13 @@ bool Imu::OrientationEnabled() const
 }
 
 /////////////////////////////////////////////////
-bool Imu::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr Imu::ToElement() const
 {
-  bool result = true;
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("imu.sdf", elem);
 
   sdf::ElementPtr orientationRefFrameElem =
-    _elem->GetElement("orientation_reference_frame");
+    elem->GetElement("orientation_reference_frame");
   orientationRefFrameElem->GetElement("localization")->Set<std::string>(
       this->Localization());
 
@@ -388,40 +390,34 @@ bool Imu::PopulateElement(sdf::ElementPtr _elem) const
   gravDirX->GetAttribute("parent_frame")->Set<std::string>(
       this->GravityDirXParentFrame());
 
-  sdf::ElementPtr angularVelElem = _elem->GetElement("angular_velocity");
+  sdf::ElementPtr angularVelElem = elem->GetElement("angular_velocity");
   sdf::ElementPtr angularVelXElem = angularVelElem->GetElement("x");
   sdf::ElementPtr angularVelXNoiseElem = angularVelXElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->angularVelXNoise.PopulateElement(angularVelXNoiseElem);
+  angularVelXNoiseElem->Copy(this->dataPtr->angularVelXNoise.ToElement());
 
   sdf::ElementPtr angularVelYElem = angularVelElem->GetElement("y");
   sdf::ElementPtr angularVelYNoiseElem = angularVelYElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->angularVelYNoise.PopulateElement(angularVelYNoiseElem);
+  angularVelYNoiseElem->Copy(this->dataPtr->angularVelYNoise.ToElement());
 
   sdf::ElementPtr angularVelZElem = angularVelElem->GetElement("z");
   sdf::ElementPtr angularVelZNoiseElem = angularVelZElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->angularVelZNoise.PopulateElement(angularVelZNoiseElem);
+  angularVelZNoiseElem->Copy(this->dataPtr->angularVelZNoise.ToElement());
 
-  sdf::ElementPtr linearAccElem = _elem->GetElement("linear_acceleration");
+  sdf::ElementPtr linearAccElem = elem->GetElement("linear_acceleration");
   sdf::ElementPtr linearAccXElem = linearAccElem->GetElement("x");
   sdf::ElementPtr linearAccXNoiseElem = linearAccXElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->linearAccelXNoise.PopulateElement(linearAccXNoiseElem);
+  linearAccXNoiseElem->Copy(this->dataPtr->linearAccelXNoise.ToElement());
 
   sdf::ElementPtr linearAccYElem = linearAccElem->GetElement("y");
   sdf::ElementPtr linearAccYNoiseElem = linearAccYElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->linearAccelYNoise.PopulateElement(linearAccYNoiseElem);
+  linearAccYNoiseElem->Copy(this->dataPtr->linearAccelYNoise.ToElement());
 
   sdf::ElementPtr linearAccZElem = linearAccElem->GetElement("z");
   sdf::ElementPtr linearAccZNoiseElem = linearAccZElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->linearAccelZNoise.PopulateElement(linearAccZNoiseElem);
+  linearAccZNoiseElem->Copy(this->dataPtr->linearAccelZNoise.ToElement());
 
-  _elem->GetElement("enable_orientation")->Set<bool>(
+  elem->GetElement("enable_orientation")->Set<bool>(
       this->OrientationEnabled());
 
-  return result;
+  return elem;
 }

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -23,6 +23,7 @@
 #include "sdf/Error.hh"
 #include "sdf/Joint.hh"
 #include "sdf/JointAxis.hh"
+#include "sdf/parser.hh"
 #include "sdf/Sensor.hh"
 #include "sdf/Types.hh"
 #include "FrameSemantics.hh"
@@ -444,4 +445,86 @@ const Sensor *Joint::SensorByName(const std::string &_name) const
     }
   }
   return nullptr;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Joint::ToElement() const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("joint.sdf", elem);
+
+  elem->GetAttribute("name")->Set<std::string>(this->Name());
+  sdf::ElementPtr poseElem = elem->GetElement("pose");
+  if (!this->dataPtr->poseRelativeTo.empty())
+  {
+    poseElem->GetAttribute("relative_to")->Set<std::string>(
+        this->dataPtr->poseRelativeTo);
+  }
+  poseElem->Set<ignition::math::Pose3d>(this->RawPose());
+
+  std::string jointType = "invalid";
+  switch (this->Type())
+  {
+    case JointType::BALL:
+      jointType = "ball";
+      break;
+    case JointType::CONTINUOUS:
+      jointType = "continuous";
+      break;
+    case JointType::FIXED:
+      jointType = "fixed";
+      break;
+    case JointType::PRISMATIC:
+      jointType = "prismatic";
+      break;
+    case JointType::GEARBOX:
+      jointType = "gearbox";
+      break;
+    case JointType::REVOLUTE:
+      jointType = "revolute";
+      break;
+    case JointType::REVOLUTE2:
+      jointType = "revolute2";
+      break;
+    case JointType::SCREW:
+      jointType = "screw";
+      break;
+    case JointType::UNIVERSAL:
+      jointType = "universal";
+      break;
+    default:
+      break;
+  }
+
+  elem->GetAttribute("type")->Set<std::string>(jointType);
+  elem->GetElement("parent")->Set<std::string>(this->ParentLinkName());
+  elem->GetElement("child")->Set<std::string>(this->ChildLinkName());
+  for (unsigned int i = 0u; i < 2u; ++i)
+  {
+    const JointAxis *axis =  this->Axis(i);
+    if (!axis)
+      break;
+
+    std::string axisElemName = "axis";
+    if (i > 0u)
+      axisElemName += std::to_string(i+1);
+    sdf::ElementPtr axisElem = elem->GetElement(axisElemName);
+    axisElem->Copy(axis->ToElement(i));
+  }
+
+  for (uint64_t i = 0u; i < this->SensorCount(); ++i)
+  {
+    const Sensor *sensor = this->SensorByIndex(i);
+    if (!sensor)
+      continue;
+    sdf::ElementPtr sensorElem = elem->GetElement("sensor");
+    sensorElem->Copy(sensor->ToElement());
+  }
+
+  if (this->Type() == JointType::SCREW)
+    elem->GetElement("thread_pitch")->Set<double>(this->ThreadPitch());
+
+  // gearbox_ratio, gearbox_reference_box, and physcs elements are not yet
+  // supported.
+  return elem;
 }

--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -387,8 +387,16 @@ sdf::ElementPtr JointAxis::ToElement(unsigned int _index) const
   sdf::ElementPtr axisElem = elem->GetElement(axisElemName);
   sdf::ElementPtr xyzElem = axisElem->GetElement("xyz");
   xyzElem->Set<ignition::math::Vector3d>(this->Xyz());
-  xyzElem->GetAttribute("expressed_in")->Set<std::string>(
-      this->XyzExpressedIn());
+  if (!this->XyzExpressedIn().empty())
+  {
+    xyzElem->GetAttribute("expressed_in")->Set<std::string>(
+        this->XyzExpressedIn());
+  }
+  else if (this->dataPtr->useParentModelFrame)
+  {
+     xyzElem->GetAttribute("expressed_in")->Set<std::string>(
+        "__model__");
+  }
   sdf::ElementPtr dynElem = axisElem->GetElement("dynamics");
   dynElem->GetElement("damping")->Set<double>(this->Damping());
   dynElem->GetElement("friction")->Set<double>(this->Friction());

--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -23,6 +23,7 @@
 #include "sdf/Assert.hh"
 #include "sdf/Error.hh"
 #include "sdf/JointAxis.hh"
+#include "sdf/parser.hh"
 #include "FrameSemantics.hh"
 #include "ScopedGraph.hh"
 #include "Utils.hh"
@@ -372,4 +373,36 @@ Errors JointAxis::ResolveXyz(
 sdf::ElementPtr JointAxis::Element() const
 {
   return this->dataPtr->sdf;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr JointAxis::ToElement(unsigned int _index) const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("joint.sdf", elem);
+
+  std::string axisElemName = "axis";
+  if (_index > 0u)
+    axisElemName += std::to_string(_index + 1);
+  sdf::ElementPtr axisElem = elem->GetElement(axisElemName);
+  sdf::ElementPtr xyzElem = axisElem->GetElement("xyz");
+  xyzElem->Set<ignition::math::Vector3d>(this->Xyz());
+  xyzElem->GetAttribute("expressed_in")->Set<std::string>(
+      this->XyzExpressedIn());
+  sdf::ElementPtr dynElem = axisElem->GetElement("dynamics");
+  dynElem->GetElement("damping")->Set<double>(this->Damping());
+  dynElem->GetElement("friction")->Set<double>(this->Friction());
+  dynElem->GetElement("spring_reference")->Set<double>(
+      this->SpringReference());
+  dynElem->GetElement("spring_stiffness")->Set<double>(
+      this->SpringStiffness());
+
+  sdf::ElementPtr limitElem = axisElem->GetElement("limit");
+  limitElem->GetElement("lower")->Set<double>(this->Lower());
+  limitElem->GetElement("upper")->Set<double>(this->Upper());
+  limitElem->GetElement("effort")->Set<double>(this->Effort());
+  limitElem->GetElement("velocity")->Set<double>(this->MaxVelocity());
+  limitElem->GetElement("stiffness")->Set<double>(this->Stiffness());
+  limitElem->GetElement("dissipation")->Set<double>(this->Dissipation());
+  return axisElem;
 }

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -15,6 +15,7 @@
  *
  */
 #include "sdf/Lidar.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 using namespace ignition;
@@ -368,9 +369,12 @@ bool Lidar::operator!=(const Lidar &_lidar) const
 }
 
 /////////////////////////////////////////////////
-bool Lidar::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr Lidar::ToElement() const
 {
-  sdf::ElementPtr scanElem = _elem->GetElement("scan");
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("lidar.sdf", elem);
+
+  sdf::ElementPtr scanElem = elem->GetElement("scan");
   sdf::ElementPtr horElem = scanElem->GetElement("horizontal");
   horElem->GetElement("samples")->Set<double>(this->HorizontalScanSamples());
   horElem->GetElement("resolution")->Set<double>(
@@ -389,12 +393,34 @@ bool Lidar::PopulateElement(sdf::ElementPtr _elem) const
   vertElem->GetElement("max_angle")->Set<double>(
       this->VerticalScanMaxAngle().Radian());
 
-  sdf::ElementPtr rangeElem = _elem->GetElement("range");
+  sdf::ElementPtr rangeElem = elem->GetElement("range");
   rangeElem->GetElement("min")->Set<double>(this->RangeMin());
   rangeElem->GetElement("max")->Set<double>(this->RangeMax());
   rangeElem->GetElement("resolution")->Set<double>(
       this->RangeResolution());
 
-  sdf::ElementPtr noiseElem = _elem->GetElement("noise");
-  return this->dataPtr->lidarNoise.PopulateElement(noiseElem, true);
+  sdf::ElementPtr noiseElem = elem->GetElement("noise");
+  std::string noiseType;
+  switch (this->dataPtr->lidarNoise.Type())
+  {
+    case sdf::NoiseType::NONE:
+      noiseType = "none";
+      break;
+    case sdf::NoiseType::GAUSSIAN:
+      noiseType = "gaussian";
+      break;
+    case sdf::NoiseType::GAUSSIAN_QUANTIZED:
+      noiseType = "gaussian_quantized";
+      break;
+    default:
+      noiseType = "none";
+  }
+
+  // lidar does not use noise.sdf description
+  noiseElem->GetElement("type")->Set<std::string>(noiseType);
+  noiseElem->GetElement("mean")->Set<double>(this->dataPtr->lidarNoise.Mean());
+  noiseElem->GetElement("stddev")->Set<double>(
+      this->dataPtr->lidarNoise.StdDev());
+
+  return elem;
 }

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -118,3 +118,55 @@ TEST(DOMLidar, Load)
   // The Lidar::Load function is tested more thouroughly in the
   // link_dom.cc integration test.
 }
+
+/////////////////////////////////////////////////
+TEST(DOMLidar, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::Lidar lidar;
+  lidar.SetHorizontalScanSamples(123);
+  lidar.SetHorizontalScanResolution(0.45);
+  lidar.SetHorizontalScanMinAngle(ignition::math::Angle(0.67));
+  lidar.SetHorizontalScanMaxAngle(ignition::math::Angle(0.89));
+  lidar.SetVerticalScanSamples(98);
+  lidar.SetVerticalScanResolution(0.76);
+  lidar.SetVerticalScanMinAngle(ignition::math::Angle(0.54));
+  lidar.SetVerticalScanMaxAngle(ignition::math::Angle(0.321));
+  lidar.SetRangeMin(1.2);
+  lidar.SetRangeMax(3.4);
+  lidar.SetRangeResolution(5.6);
+
+  sdf::Noise noise;
+  noise.SetMean(6.5);
+  noise.SetStdDev(3.79);
+  lidar.SetLidarNoise(noise);
+
+  sdf::ElementPtr lidarElem = lidar.ToElement();
+  EXPECT_NE(nullptr, lidarElem);
+  EXPECT_EQ(nullptr, lidar.Element());
+
+  // verify values after loading the element back
+  sdf::Lidar lidar2;
+  lidar2.Load(lidarElem);
+
+  EXPECT_EQ(123u, lidar2.HorizontalScanSamples());
+  EXPECT_DOUBLE_EQ(0.45, lidar2.HorizontalScanResolution());
+  EXPECT_DOUBLE_EQ(0.67, *(lidar2.HorizontalScanMinAngle()));
+  EXPECT_DOUBLE_EQ(0.89, *(lidar2.HorizontalScanMaxAngle()));
+  EXPECT_EQ(98u, lidar2.VerticalScanSamples());
+  EXPECT_DOUBLE_EQ(0.76, lidar2.VerticalScanResolution());
+  EXPECT_DOUBLE_EQ(0.54, *(lidar2.VerticalScanMinAngle()));
+  EXPECT_DOUBLE_EQ(0.321, *(lidar2.VerticalScanMaxAngle()));
+  EXPECT_DOUBLE_EQ(1.2, lidar2.RangeMin());
+  EXPECT_DOUBLE_EQ(3.4, lidar2.RangeMax());
+  EXPECT_DOUBLE_EQ(5.6, lidar2.RangeResolution());
+  EXPECT_EQ(noise, lidar2.LidarNoise());
+
+  // make changes to DOM and verify ToElement produces updated values
+  lidar2.SetHorizontalScanSamples(111u);
+  sdf::ElementPtr lidar2Elem = lidar2.ToElement();
+  EXPECT_NE(nullptr, lidar2Elem);
+  sdf::Lidar lidar3;
+  lidar3.Load(lidar2Elem);
+  EXPECT_EQ(111u, lidar3.HorizontalScanSamples());
+}

--- a/src/Magnetometer.cc
+++ b/src/Magnetometer.cc
@@ -17,6 +17,7 @@
 #include <array>
 #include <string>
 #include "sdf/Magnetometer.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 
@@ -132,26 +133,25 @@ bool Magnetometer::operator==(const Magnetometer &_mag) const
 }
 
 /////////////////////////////////////////////////
-bool Magnetometer::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr Magnetometer::ToElement() const
 {
-  bool result = true;
-  sdf::ElementPtr magnetometerXElem = _elem->GetElement("x");
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("magnetometer.sdf", elem);
+
+  sdf::ElementPtr magnetometerXElem = elem->GetElement("x");
   sdf::ElementPtr magnetometerXNoiseElem =
     magnetometerXElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->noise[0].PopulateElement(magnetometerXNoiseElem);
+  magnetometerXNoiseElem->Copy(this->dataPtr->noise[0].ToElement());
 
-  sdf::ElementPtr magnetometerYElem = _elem->GetElement("y");
+  sdf::ElementPtr magnetometerYElem = elem->GetElement("y");
   sdf::ElementPtr magnetometerYNoiseElem =
     magnetometerYElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->noise[1].PopulateElement(magnetometerYNoiseElem);
+  magnetometerYNoiseElem->Copy(this->dataPtr->noise[1].ToElement());
 
-  sdf::ElementPtr magnetometerZElem = _elem->GetElement("z");
+  sdf::ElementPtr magnetometerZElem = elem->GetElement("z");
   sdf::ElementPtr magnetometerZNoiseElem =
     magnetometerZElem->GetElement("noise");
-  result = result &&
-    this->dataPtr->noise[2].PopulateElement(magnetometerZNoiseElem);
+  magnetometerZNoiseElem->Copy(this->dataPtr->noise[2].ToElement());
 
-  return result;
+  return elem;
 }

--- a/src/Magnetometer_TEST.cc
+++ b/src/Magnetometer_TEST.cc
@@ -111,3 +111,42 @@ TEST(DOMMagnetometer, Load)
   // The Magnetometer::Load function is test more thouroughly in the
   // link_dom.cc integration test.
 }
+
+/////////////////////////////////////////////////
+TEST(DOMMagnetometer, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::Magnetometer mag;
+  sdf::Noise defaultNoise, noise;
+  noise.SetType(sdf::NoiseType::GAUSSIAN);
+  noise.SetMean(1.2);
+  noise.SetStdDev(2.3);
+  noise.SetBiasMean(4.5);
+  noise.SetBiasStdDev(6.7);
+  noise.SetPrecision(8.9);
+  mag.SetXNoise(noise);
+  mag.SetYNoise(noise);
+  mag.SetZNoise(noise);
+
+  sdf::ElementPtr magElem = mag.ToElement();
+  EXPECT_NE(nullptr, magElem);
+  EXPECT_EQ(nullptr, mag.Element());
+
+  // verify values after loading the element back
+  sdf::Magnetometer mag2;
+  mag2.Load(magElem);
+
+  EXPECT_EQ(noise, mag2.XNoise());
+  EXPECT_EQ(noise, mag2.YNoise());
+  EXPECT_EQ(noise, mag2.ZNoise());
+
+  // make changes to DOM and verify ToElement produces updated values
+  noise.SetBiasMean(11.22);
+  mag2.SetXNoise(noise);
+  sdf::ElementPtr mag2Elem = mag2.ToElement();
+  EXPECT_NE(nullptr, mag2Elem);
+  sdf::Magnetometer mag3;
+  mag3.Load(mag2Elem);
+  EXPECT_EQ(noise, mag3.XNoise());
+  EXPECT_NE(noise, mag.XNoise());
+}

--- a/src/Magnetometer_TEST.cc
+++ b/src/Magnetometer_TEST.cc
@@ -117,7 +117,7 @@ TEST(DOMMagnetometer, ToElement)
 {
   // test calling ToElement on a DOM object constructed without calling Load
   sdf::Magnetometer mag;
-  sdf::Noise defaultNoise, noise;
+  sdf::Noise noise;
   noise.SetType(sdf::NoiseType::GAUSSIAN);
   noise.SetMean(1.2);
   noise.SetStdDev(2.3);

--- a/src/Noise.cc
+++ b/src/Noise.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include "sdf/Noise.hh"
+#include "sdf/parser.hh"
 #include "sdf/Types.hh"
 
 using namespace sdf;
@@ -250,8 +251,11 @@ bool Noise::operator==(const Noise &_noise) const
 }
 
 /////////////////////////////////////////////////
-bool Noise::PopulateElement(sdf::ElementPtr _elem, bool _simpleNoise) const
+sdf::ElementPtr Noise::ToElement() const
 {
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("noise.sdf", elem);
+
   std::string noiseType;
   switch (this->Type())
   {
@@ -267,26 +271,18 @@ bool Noise::PopulateElement(sdf::ElementPtr _elem, bool _simpleNoise) const
     default:
       noiseType = "none";
   }
-  // camera and lidar <noise> does not have type attribute
-  if (!_simpleNoise)
-    _elem->GetAttribute("type")->Set<std::string>(noiseType);
-  else
-    _elem->GetElement("type")->Set<std::string>(noiseType);
-
-  _elem->GetElement("mean")->Set<double>(this->Mean());
-  _elem->GetElement("stddev")->Set<double>(this->StdDev());
+  elem->GetAttribute("type")->Set<std::string>(noiseType);
+  elem->GetElement("mean")->Set<double>(this->Mean());
+  elem->GetElement("stddev")->Set<double>(this->StdDev());
 
   // camera and lidar <noise> does not have the sdf params below
-  if (!_simpleNoise)
-  {
-    _elem->GetElement("bias_mean")->Set<double>(this->BiasMean());
-    _elem->GetElement("bias_stddev")->Set<double>(this->BiasStdDev());
-    _elem->GetElement("dynamic_bias_stddev")->Set<double>(
-      this->DynamicBiasStdDev());
-    _elem->GetElement("dynamic_bias_correlation_time")->Set<double>(
-        this->DynamicBiasCorrelationTime());
-    _elem->GetElement("precision")->Set<double>(this->Precision());
-  }
+  elem->GetElement("bias_mean")->Set<double>(this->BiasMean());
+  elem->GetElement("bias_stddev")->Set<double>(this->BiasStdDev());
+  elem->GetElement("dynamic_bias_stddev")->Set<double>(
+    this->DynamicBiasStdDev());
+  elem->GetElement("dynamic_bias_correlation_time")->Set<double>(
+      this->DynamicBiasCorrelationTime());
+  elem->GetElement("precision")->Set<double>(this->Precision());
 
-  return true;
+  return elem;
 }

--- a/src/Noise_TEST.cc
+++ b/src/Noise_TEST.cc
@@ -219,3 +219,43 @@ TEST(DOMNoise, Load)
   EXPECT_TRUE(errors.empty());
   EXPECT_DOUBLE_EQ(10.2, noise.DynamicBiasCorrelationTime());
 }
+
+/////////////////////////////////////////////////
+TEST(DOMNoise, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::Noise noise;
+  noise.SetType(sdf::NoiseType::GAUSSIAN);
+  noise.SetMean(1.2);
+  noise.SetStdDev(2.3);
+  noise.SetBiasMean(4.5);
+  noise.SetBiasStdDev(6.7);
+  noise.SetPrecision(8.9);
+  noise.SetDynamicBiasStdDev(9.1);
+  noise.SetDynamicBiasCorrelationTime(19.12);
+
+  sdf::ElementPtr noiseElem = noise.ToElement();
+  EXPECT_NE(nullptr, noiseElem);
+  EXPECT_EQ(nullptr, noise.Element());
+
+  // verify values after loading the element back
+  sdf::Noise noise2;
+  noise2.Load(noiseElem);
+
+  EXPECT_EQ(sdf::NoiseType::GAUSSIAN, noise2.Type());
+  EXPECT_DOUBLE_EQ(1.2, noise2.Mean());
+  EXPECT_DOUBLE_EQ(2.3, noise2.StdDev());
+  EXPECT_DOUBLE_EQ(4.5, noise2.BiasMean());
+  EXPECT_DOUBLE_EQ(6.7, noise2.BiasStdDev());
+  EXPECT_DOUBLE_EQ(8.9, noise2.Precision());
+  EXPECT_DOUBLE_EQ(9.1, noise2.DynamicBiasStdDev());
+  EXPECT_DOUBLE_EQ(19.12, noise2.DynamicBiasCorrelationTime());
+
+  // make changes to DOM and verify ToElement produces updated values
+  noise2.SetPrecision(0.1234);
+  sdf::ElementPtr noise2Elem = noise2.ToElement();
+  EXPECT_NE(nullptr, noise2Elem);
+  sdf::Noise noise3;
+  noise3.Load(noise2Elem);
+  EXPECT_DOUBLE_EQ(0.1234, noise3.Precision());
+}

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -680,7 +680,14 @@ sdf::ElementPtr Sensor::ToElement() const
 
   elem->GetAttribute("type")->Set<std::string>(this->TypeStr());
   elem->GetAttribute("name")->Set<std::string>(this->Name());
-  elem->GetElement("pose")->Set<ignition::math::Pose3d>(this->RawPose());
+  sdf::ElementPtr poseElem = elem->GetElement("pose");
+  if (!this->dataPtr->poseRelativeTo.empty())
+  {
+    poseElem->GetAttribute("relative_to")->Set<std::string>(
+        this->dataPtr->poseRelativeTo);
+  }
+  poseElem->Set<ignition::math::Pose3d>(this->RawPose());
+
   elem->GetElement("topic")->Set<std::string>(this->Topic());
   elem->GetElement("update_rate")->Set<double>(this->UpdateRate());
   elem->GetElement("enable_metrics")->Set<double>(this->EnableMetrics());

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -28,6 +28,7 @@
 #include "sdf/Imu.hh"
 #include "sdf/Magnetometer.hh"
 #include "sdf/Lidar.hh"
+#include "sdf/parser.hh"
 #include "sdf/Sensor.hh"
 #include "sdf/Types.hh"
 #include "FrameSemantics.hh"
@@ -672,66 +673,71 @@ Imu *Sensor::ImuSensor()
 }
 
 /////////////////////////////////////////////////
-bool Sensor::PopulateElement(sdf::ElementPtr _elem) const
+sdf::ElementPtr Sensor::ToElement() const
 {
-  _elem->GetAttribute("type")->Set<std::string>(this->TypeStr());
-  _elem->GetAttribute("name")->Set<std::string>(this->Name());
-  _elem->GetElement("pose")->Set<ignition::math::Pose3d>(this->RawPose());
-  _elem->GetElement("topic")->Set<std::string>(this->Topic());
-  _elem->GetElement("update_rate")->Set<double>(this->UpdateRate());
-  _elem->GetElement("enable_metrics")->Set<double>(this->EnableMetrics());
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("sensor.sdf", elem);
+
+  elem->GetAttribute("type")->Set<std::string>(this->TypeStr());
+  elem->GetAttribute("name")->Set<std::string>(this->Name());
+  elem->GetElement("pose")->Set<ignition::math::Pose3d>(this->RawPose());
+  elem->GetElement("topic")->Set<std::string>(this->Topic());
+  elem->GetElement("update_rate")->Set<double>(this->UpdateRate());
+  elem->GetElement("enable_metrics")->Set<double>(this->EnableMetrics());
 
   // air pressure
   if (this->Type() == sdf::SensorType::AIR_PRESSURE &&
       this->dataPtr->airPressure)
   {
-    sdf::ElementPtr airPressureElem = _elem->GetElement("air_pressure");
-    return this->dataPtr->airPressure->PopulateElement(airPressureElem);
+    sdf::ElementPtr airPressureElem = elem->GetElement("air_pressure");
+    airPressureElem->Copy(this->dataPtr->airPressure->ToElement());
   }
   // altimeter
   else if (this->Type() == sdf::SensorType::ALTIMETER &&
       this->dataPtr->altimeter)
   {
-    sdf::ElementPtr altimeterElem = _elem->GetElement("altimeter");
-    return this->dataPtr->altimeter->PopulateElement(altimeterElem);
+    sdf::ElementPtr altimeterElem = elem->GetElement("altimeter");
+    altimeterElem->Copy(this->dataPtr->altimeter->ToElement());
   }
   // camera, depth, thermal, segmentation
   else if (this->CameraSensor())
   {
-    sdf::ElementPtr cameraElem = _elem->GetElement("camera");
-    return this->dataPtr->camera->PopulateElement(cameraElem);
+    sdf::ElementPtr cameraElem = elem->GetElement("camera");
+    cameraElem->Copy(this->dataPtr->camera->ToElement());
   }
   // force torque
   else if (this->Type() == sdf::SensorType::FORCE_TORQUE  &&
       this->dataPtr->forceTorque)
   {
-    sdf::ElementPtr forceTorqueElem = _elem->GetElement("force_torque");
-    return this->dataPtr->forceTorque->PopulateElement(forceTorqueElem);
+    sdf::ElementPtr forceTorqueElem = elem->GetElement("force_torque");
+    forceTorqueElem->Copy(this->dataPtr->forceTorque->ToElement());
   }
   // imu
   else if (this->Type() == sdf::SensorType::IMU && this->dataPtr->imu)
   {
-    sdf::ElementPtr imuElem = _elem->GetElement("imu");
-    return this->dataPtr->imu->PopulateElement(imuElem);
+    sdf::ElementPtr imuElem = elem->GetElement("imu");
+    imuElem->Copy(this->dataPtr->imu->ToElement());
   }
   // lidar, gpu_lidar
   else if ((this->Type() == sdf::SensorType::GPU_LIDAR ||
             this->Type() == sdf::SensorType::LIDAR) &&
            this->dataPtr->lidar)
   {
-    sdf::ElementPtr rayElem = (_elem->HasElement("ray")) ?
-        _elem->GetElement("ray") : _elem->GetElement("lidar");
-    return this->dataPtr->lidar->PopulateElement(rayElem);
+    sdf::ElementPtr rayElem = (elem->HasElement("ray")) ?
+        elem->GetElement("ray") : elem->GetElement("lidar");
+    rayElem->Copy(this->dataPtr->lidar->ToElement());
   }
   // magnetometer
   else if (this->Type() == sdf::SensorType::MAGNETOMETER &&
       this->dataPtr->magnetometer)
   {
-    sdf::ElementPtr magnetometerElem = _elem->GetElement("magnetometer");
-    return this->dataPtr->magnetometer->PopulateElement(magnetometerElem);
+    sdf::ElementPtr magnetometerElem = elem->GetElement("magnetometer");
+    magnetometerElem->Copy(this->dataPtr->magnetometer->ToElement());
   }
-
-  std::cout << "Conversion of sensor type: [" << this->TypeStr() << "] from "
-    << "SDF DOM to Element is not supported yet." << std::endl;
-  return false;
+  else
+  {
+    std::cout << "Conversion of sensor type: [" << this->TypeStr() << "] from "
+      << "SDF DOM to Element is not supported yet." << std::endl;
+  }
+  return elem;
 }

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -500,3 +500,46 @@ TEST(DOMSensor, MutableSensors)
         sensor.NavSatSensor()->HorizontalPositionNoise().Mean(), 2.0);
   }
 }
+
+/////////////////////////////////////////////////
+TEST(DOMSensor, ToElement)
+{
+  // test calling ToElement on a DOM object constructed without calling Load
+  sdf::Sensor sensor;
+  sensor.SetName("my_sensor");
+  sensor.SetRawPose(ignition::math::Pose3d(1, 2, 3, 0, 0, 0));
+  sensor.SetType(sdf::SensorType::MAGNETOMETER);
+  sensor.SetPoseRelativeTo("a_frame");
+  sensor.SetUpdateRate(0.123);
+
+  sdf::Noise noise;
+  noise.SetMean(0.1);
+  sdf::Magnetometer mag;
+  mag.SetXNoise(noise);
+  sensor.SetMagnetometerSensor(mag);
+
+  sdf::ElementPtr sensorElem = sensor.ToElement();
+  EXPECT_NE(nullptr, sensorElem);
+  EXPECT_EQ(nullptr, sensor.Element());
+
+  // verify values after loading the element back
+  sdf::Sensor sensor2;
+  sensor2.Load(sensorElem);
+
+  EXPECT_EQ("my_sensor", sensor2.Name());
+  EXPECT_EQ(sdf::SensorType::MAGNETOMETER, sensor2.Type());
+  EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, 0, 0), sensor2.RawPose());
+  EXPECT_EQ("a_frame", sensor2.PoseRelativeTo());
+  ASSERT_TRUE(nullptr != sensor2.MagnetometerSensor());
+  EXPECT_DOUBLE_EQ(mag.XNoise().Mean(),
+                   sensor2.MagnetometerSensor()->XNoise().Mean());
+  EXPECT_DOUBLE_EQ(0.123, sensor2.UpdateRate());
+
+  // make changes to DOM and verify ToElement produces updated values
+  sensor2.SetUpdateRate(1.23);
+  sdf::ElementPtr sensor2Elem = sensor2.ToElement();
+  EXPECT_NE(nullptr, sensor2Elem);
+  sdf::Sensor sensor3;
+  sensor3.Load(sensor2Elem);
+  EXPECT_DOUBLE_EQ(1.23, sensor3.UpdateRate());
+}

--- a/test/integration/sdf_dom_conversion.cc
+++ b/test/integration/sdf_dom_conversion.cc
@@ -22,7 +22,9 @@
 #include "sdf/Altimeter.hh"
 #include "sdf/Camera.hh"
 #include "sdf/Element.hh"
+#include "sdf/ForceTorque.hh"
 #include "sdf/Imu.hh"
+#include "sdf/Joint.hh"
 #include "sdf/Lidar.hh"
 #include "sdf/Light.hh"
 #include "sdf/Link.hh"
@@ -530,4 +532,71 @@ TEST(SDFDomConversion, Lights)
         dirLight->Specular());
     EXPECT_EQ(ignition::math::Vector3d(4.0, 5.0, 6.0), dirLight->Direction());
   }
+}
+
+//////////////////////////////////////////////////
+TEST(SDFDomConversion, Joints)
+{
+  // this test loads the joint_sensors.sdf test file, then
+  // 1) converts each type of sensor DOM to Element
+  // 2) loads the Element back to DOM,
+  // 3) verify the values
+  // Some of the verification code is adapted from joint_dom.cc
+  const std::string testFile =
+      sdf::testing::TestFile("sdf", "joint_sensors.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  for (auto e : errors)
+    std::cout << e << std::endl;
+  EXPECT_TRUE(errors.empty());
+
+  // Get the first model
+  const sdf::Model *model = root.Model();
+  ASSERT_NE(nullptr, model);
+
+  // Get joint
+  const sdf::Joint *j = model->JointByName("joint");
+  ASSERT_NE(nullptr, j);
+
+  // convert to sdf element and load it back
+  sdf::ElementPtr jointElem = j->ToElement();
+  auto joint = std::make_unique<sdf::Joint>();
+  joint->Load(jointElem);
+  ASSERT_NE(nullptr, joint);
+  EXPECT_EQ("joint", joint->Name());
+  EXPECT_EQ(1u, joint->SensorCount());
+
+  EXPECT_EQ("link1", joint->ParentLinkName());
+  EXPECT_EQ("link2", joint->ChildLinkName());
+  EXPECT_EQ(sdf::JointType::FIXED, joint->Type());
+
+  // Get the force_torque sensor
+  const sdf::Sensor *forceTorqueSensor =
+    joint->SensorByName("force_torque_sensor");
+  ASSERT_NE(nullptr, forceTorqueSensor);
+  EXPECT_EQ("force_torque_sensor", forceTorqueSensor->Name());
+  EXPECT_EQ(sdf::SensorType::FORCE_TORQUE, forceTorqueSensor->Type());
+  EXPECT_EQ(ignition::math::Pose3d(10, 11, 12, 0, 0, 0),
+      forceTorqueSensor->RawPose());
+  auto forceTorqueSensorObj = forceTorqueSensor->ForceTorqueSensor();
+  ASSERT_NE(nullptr, forceTorqueSensorObj);
+  EXPECT_EQ(sdf::ForceTorqueFrame::PARENT, forceTorqueSensorObj->Frame());
+  EXPECT_EQ(sdf::ForceTorqueMeasureDirection::PARENT_TO_CHILD,
+      forceTorqueSensorObj->MeasureDirection());
+
+  EXPECT_DOUBLE_EQ(0.0, forceTorqueSensorObj->ForceXNoise().Mean());
+  EXPECT_DOUBLE_EQ(0.1, forceTorqueSensorObj->ForceXNoise().StdDev());
+  EXPECT_DOUBLE_EQ(1.0, forceTorqueSensorObj->ForceYNoise().Mean());
+  EXPECT_DOUBLE_EQ(1.1, forceTorqueSensorObj->ForceYNoise().StdDev());
+  EXPECT_DOUBLE_EQ(2.0, forceTorqueSensorObj->ForceZNoise().Mean());
+  EXPECT_DOUBLE_EQ(2.1, forceTorqueSensorObj->ForceZNoise().StdDev());
+
+  EXPECT_DOUBLE_EQ(3.0, forceTorqueSensorObj->TorqueXNoise().Mean());
+  EXPECT_DOUBLE_EQ(3.1, forceTorqueSensorObj->TorqueXNoise().StdDev());
+  EXPECT_DOUBLE_EQ(4.0, forceTorqueSensorObj->TorqueYNoise().Mean());
+  EXPECT_DOUBLE_EQ(4.1, forceTorqueSensorObj->TorqueYNoise().StdDev());
+  EXPECT_DOUBLE_EQ(5.0, forceTorqueSensorObj->TorqueZNoise().Mean());
+  EXPECT_DOUBLE_EQ(5.1, forceTorqueSensorObj->TorqueZNoise().StdDev());
 }

--- a/test/integration/sdf_dom_conversion.cc
+++ b/test/integration/sdf_dom_conversion.cc
@@ -60,11 +60,8 @@ TEST(SDFDomConversion, Sensors)
   // altimeter
   {
     const sdf::Sensor *sensor = link->SensorByIndex(0);
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto altimeterSensor = std::make_unique<sdf::Sensor>();
     altimeterSensor->Load(sensorElem);
 
@@ -85,11 +82,8 @@ TEST(SDFDomConversion, Sensors)
   // camera
   {
     const sdf::Sensor *sensor = link->SensorByName("camera_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto cameraSensor = std::make_unique<sdf::Sensor>();
     cameraSensor->Load(sensorElem);
 
@@ -140,11 +134,8 @@ TEST(SDFDomConversion, Sensors)
   // depth
   {
     const sdf::Sensor *sensor = link->SensorByName("depth_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto depthSensor = std::make_unique<sdf::Sensor>();
     depthSensor->Load(sensorElem);
 
@@ -161,11 +152,8 @@ TEST(SDFDomConversion, Sensors)
   // rgbd
   {
     const sdf::Sensor *sensor = link->SensorByName("rgbd_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto rgbdSensor = std::make_unique<sdf::Sensor>();
     rgbdSensor->Load(sensorElem);
 
@@ -183,11 +171,8 @@ TEST(SDFDomConversion, Sensors)
   // thermal
   {
     const sdf::Sensor *sensor = link->SensorByName("thermal_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto thermalSensor = std::make_unique<sdf::Sensor>();
     thermalSensor->Load(sensorElem);
 
@@ -205,11 +190,8 @@ TEST(SDFDomConversion, Sensors)
   // segmentation
   {
     const sdf::Sensor *sensor = link->SensorByName("segmentation_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto segmentationSensor = std::make_unique<sdf::Sensor>();
     segmentationSensor->Load(sensorElem);
 
@@ -229,11 +211,8 @@ TEST(SDFDomConversion, Sensors)
   // force torque
   {
     const sdf::Sensor *sensor = link->SensorByName("force_torque_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto forceTorqueSensor = std::make_unique<sdf::Sensor>();
     forceTorqueSensor->Load(sensorElem);
 
@@ -248,11 +227,8 @@ TEST(SDFDomConversion, Sensors)
   // gpu lidar
   {
     const sdf::Sensor *sensor = link->SensorByName("gpu_lidar_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto gpuLidarSensor = std::make_unique<sdf::Sensor>();
     gpuLidarSensor->Load(sensorElem);
 
@@ -283,11 +259,8 @@ TEST(SDFDomConversion, Sensors)
   // imu
   {
     const sdf::Sensor *sensor = link->SensorByName("imu_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto imuSensor = std::make_unique<sdf::Sensor>();
     imuSensor->Load(sensorElem);
 
@@ -353,11 +326,8 @@ TEST(SDFDomConversion, Sensors)
   // magnetometer
   {
     const sdf::Sensor *sensor = link->SensorByName("magnetometer_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto magnetometerSensor = std::make_unique<sdf::Sensor>();
     magnetometerSensor->Load(sensorElem);
 
@@ -381,11 +351,8 @@ TEST(SDFDomConversion, Sensors)
   // air pressure
   {
     const sdf::Sensor *sensor = link->SensorByName("air_pressure_sensor");
-    sdf::ElementPtr sensorElem(new sdf::Element);
-    sdf::initFile("sensor.sdf", sensorElem);
-
     // convert to sdf element and load it back
-    sensor->PopulateElement(sensorElem);
+    sdf::ElementPtr sensorElem = sensor->ToElement();
     auto airPressureSensor = std::make_unique<sdf::Sensor>();
     airPressureSensor->Load(sensorElem);
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Adds `ToElement()` function to convert `Joint` and `JointAxis` DOM to `sdf::ElementPtr`

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
