### PR TITLE
Backport cmake/test fixes to sdf6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
-## SDFormat 6.0
+## libsdformat 6.0
 
-### SDFormat 6.3.1 (2021-07-06)
+### libsdformat 6.3.1 (2021-07-06)
 
 1. Fix flattening logic for nested model names
     * [Pull request 597](https://github.com/osrf/sdformat/pull/597)
@@ -8,7 +8,7 @@
 1. Translate poses of nested models inside other nested models
     * [Pull request 596](https://github.com/osrf/sdformat/pull/596)
 
-### SDFormat 6.3.0 (2021-06-21)
+### libsdformat 6.3.0 (2021-06-21)
 
 1. Move recursiveSameTypeUniqueNames from ign.cc to parser.cc and make public.
     * [Pull request 580](https://github.com/osrf/sdformat/pull/580)
@@ -16,7 +16,7 @@
 1. Parse rpyOffset as radians
     * [Pull request 497](https://github.com/osrf/sdformat/pull/497)
 
-1. Parse urdf files to sdf 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
+1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
     * [BitBucket pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
@@ -34,7 +34,7 @@
 1. Converter: remove all matching elements specified by `<remove>` tag.
     * [BitBucket pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
 
-### SDFormat 6.2.0 (2019-01-17)
+### libsdformat 6.2.0 (2019-01-17)
 
 1. Add geometry for sonar collision shape
     * [BitBucket pull request 495](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/495)
@@ -46,15 +46,15 @@
     * [BitBucket pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
 
 
-### SDFormat 6.1.0 (2018-10-04)
+### libsdformat 6.1.0 (2018-10-04)
 
 1. Add collision\_detector to dart physics config
     * [BitBucket pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
 
-1. Fix Windows support for SDFormat6
+1. Fix Windows support for libsdformat6
     * [BitBucket pull request 401](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/401)
 
-1. root.sdf: default sdf version 1.6
+1. root.sdf: default SDFormat version 1.6
     * [BitBucket pull request 425](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/425)
 
 1. parser\_urdf: print value of highstop instead of pointer address
@@ -64,7 +64,7 @@
     * [BitBucket pull request 402](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/402)
 
 
-### SDFormat 6.0.0 (2018-01-25)
+### libsdformat 6.0.0 (2018-01-25)
 
 1. SDF DOM: Added a document object model.
     * [BitBucket pull request 387](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/387)
@@ -97,69 +97,69 @@
 1. Deprecated sdf::Color, and switch to use ignition::math::Color
     * [BitBucket pull request 330](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/330)
 
-## SDFormat 5.x
+## libsdformat 5.x
 
-### SDFormat 5.x.x (2017-xx-xx)
+### libsdformat 5.x.x (2017-xx-xx)
 
-### SDFormat 5.3.0 (2017-11-13)
+### libsdformat 5.3.0 (2017-11-13)
 
 1. Added wrapper around root SDF for an SDF element
-    * [BitBucket pull request 378](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/378)
-    * [BitBucket pull request 372](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/372)
+    * [BitBucket pull request 378](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/378)
+    * [BitBucket pull request 372](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/372)
 
 1. Add ODE parallelization parameters: threaded islands and position correction
-    * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/380)
+    * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
 
 1. surface.sdf: expand documentation of friction and slip coefficients
-    * [BitBucket pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/343)
+    * [BitBucket pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/343)
 
 1. Add preserveFixedJoint option to the URDF parser
-    * [BitBucket pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/352)
+    * [BitBucket pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/352)
 
 1. Add light as child of link
-    * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/373)
+    * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/373)
 
-### SDFormat 5.2.0 (2017-08-03)
+### libsdformat 5.2.0 (2017-08-03)
 
 1. Added a block for DART-specific physics properties.
     * [BitBucket pull request 369](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/369)
 
 1. Fix parser to read plugin child elements within an `<include>`
-    * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/350)
+    * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/350)
 
-1. Choosing models with more recent sdf version with `<include>` tag
-    * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/291)
+1. Choosing models with more recent SDFormat version with `<include>` tag
+    * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
 1. Added `<category_bitmask>` to 1.6 surface contact parameters
-    * [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/318)
+    * [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/318)
 
 1. Support light insertion in state
-    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/325)
+    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/325)
 
 1. Case insensitive boolean strings
-    * [BitBucket pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/322)
+    * [BitBucket pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/322)
 
 1. Enable coverage testing
-    * [BitBucket pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/317)
+    * [BitBucket pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/317)
 
 1. Add `friction_model` parameter to ode solver
-    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
-    * [Gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522)
+    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
+    * [Gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/1522)
 
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
-    * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/292)
+    * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/292)
 
-### SDFormat 5.1.0 (2017-02-22)
+### libsdformat 5.1.0 (2017-02-22)
 
 1. Fixed `sdf::convertFile` and `sdf::convertString` always converting to latest version
     * [BitBucket pull request 320](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/320)
-1. Added back the ability to set sdf version at runtime
+1. Added back the ability to set SDFormat version at runtime
     * [BitBucket pull request 307](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/307)
 
-### SDFormat 5.0.0 (2017-01-25)
+### libsdformat 5.0.0 (2017-01-25)
 
-1. Removed SDFormat 4 deprecations
+1. Removed libsdformat 4 deprecations
     * [BitBucket pull request 295](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/295)
 
 1. Added an example
@@ -182,11 +182,11 @@
 1. Simplifier way of retrieving a value from SDF using Get
     * [BitBucket pull request 285](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/285)
 
-## SDFormat 4.0
+## libsdformat 4.0
 
-### SDFormat 4.x.x (2017-xx-xx)
+### libsdformat 4.x.x (2017-xx-xx)
 
-### SDFormat 4.4.0 (2017-10-26)
+### libsdformat 4.4.0 (2017-10-26)
 
 1. Add ODE parallelization parameters: threaded islands and position correction
     * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
@@ -200,7 +200,7 @@
 1. Add light as child of link
     * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/373)
 
-### SDFormat 4.3.2 (2017-07-19)
+### libsdformat 4.3.2 (2017-07-19)
 
 1. Add documentation for `Element::GetFirstElement()` and `Element::GetNextElement()`
     * [BitBucket pull request 341](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/341)
@@ -208,15 +208,15 @@
 1. Fix parser to read plugin child elements within an `<include>`
     * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/350)
 
-### SDFormat 4.3.1 (2017-03-24)
+### libsdformat 4.3.1 (2017-03-24)
 
 1. Fix segmentation Fault in `sdf::getBestSupportedModelVersion`
     * [BitBucket pull request 327](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/327)
     * [Issue 152](https://github.com/osrf/sdformat/issues/152)
 
-### SDFormat 4.3.0 (2017-03-20)
+### libsdformat 4.3.0 (2017-03-20)
 
-1. Choosing models with more recent sdf version with `<include>` tag
+1. Choosing models with more recent SDFormat version with `<include>` tag
     * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
@@ -245,7 +245,7 @@
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
     * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/292)
 
-### SDFormat 4.2.0 (2016-10-10)
+### libsdformat 4.2.0 (2016-10-10)
 
 1. Added tag to specify ODE friction model.
     * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
@@ -256,7 +256,7 @@
 1. Added IMU orientation specification to SDF.
     * [BitBucket pull request 284](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/284)
 
-### SDFormat 4.1.1 (2016-07-08)
+### libsdformat 4.1.1 (2016-07-08)
 
 1. Added documentation and animation to `<actor>` element.
     * [BitBucket pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/280)
@@ -264,7 +264,7 @@
 1. Added tag to specify initial joint position
     * [BitBucket pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/279)
 
-### SDFormat 4.1.0 (2016-04-01)
+### libsdformat 4.1.0 (2016-04-01)
 
 1. Added SDF conversion functions to parser including sdf::convertFile and sdf::convertString.
     * [BitBucket pull request 266](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/266)
@@ -272,7 +272,7 @@
 1. Added an upload script
     * [BitBucket pull request 256](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/256)
 
-### SDFormat 4.0.0 (2015-01-12)
+### libsdformat 4.0.0 (2015-01-12)
 
 1. Boost pointers and boost::function in the public API have been replaced
    by their std::equivalents (C++11 standard)
@@ -296,18 +296,18 @@
     * [BitBucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/243)
     * [BitBucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
 
-## SDFormat 3.0
+## libsdformat 3.0
 
-### SDFormat 3.X.X (201X-XX-XX)
+### libsdformat 3.X.X (201X-XX-XX)
 
 1. Improve precision of floating point parameters
     * [BitBucket pull request 273](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/273)
     * [BitBucket pull request 276](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/276)
 
-### SDFormat 3.7.0 (2015-11-20)
+### libsdformat 3.7.0 (2015-11-20)
 
 1. Add spring pass through for sdf3
-    * [Design document](https://github.com/osrf/gazebo_design/pull-requests/23)
+    * [Design document](https://osrf-migration.github.io/osrf-others-gh-pages/#!/osrf/gazebo_design/pull-requests/23)
     * [BitBucket pull request 242](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/242)
 
 1. Support frame specification in SDF
@@ -316,7 +316,7 @@
 1. Remove boost from SDFExtension
     * [BitBucket pull request 229](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/229)
 
-### SDFormat 3.6.0 (2015-10-27)
+### libsdformat 3.6.0 (2015-10-27)
 
 1. Add light state
     * [BitBucket pull request 227](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/227)
@@ -325,21 +325,21 @@
 1. Fix links in API documentation
     * [BitBucket pull request 231](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/231)
 
-### SDFormat 3.5.0 (2015-10-07)
+### libsdformat 3.5.0 (2015-10-07)
 
 1. Camera lens description (Replaces #213)
     * [BitBucket pull request 215](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/215)
 1. Fix shared pointer reference loop in Element and memory leak (#104)
     * [BitBucket pull request 230](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/230)
 
-### SDFormat 3.4.0 (2015-10-05)
+### libsdformat 3.4.0 (2015-10-05)
 
 1. Support nested model states
     * [BitBucket pull request 223](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/223)
 1. Cleaner way to set SDF_PATH for tests
     * [BitBucket pull request 226](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/226)
 
-### SDFormat 3.3.0 (2015-09-15)
+### libsdformat 3.3.0 (2015-09-15)
 
 1. Windows Boost linking errors
     * [BitBucket pull request 206](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/206)
@@ -350,7 +350,7 @@
 1. Torsional friction default surface radius not infinity
     * [BitBucket pull request 217](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/217)
 
-### SDFormat 3.2.2 (2015-08-24)
+### libsdformat 3.2.2 (2015-08-24)
 
 1. Added battery element (contribution from Olivier Crave)
     * [BitBucket pull request #204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/204)
@@ -359,17 +359,17 @@
 1. Allow Visual Studio 2015
     * [BitBucket pull request #208](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/208)
 
-### SDFormat 3.1.1 (2015-08-03)
+### libsdformat 3.1.1 (2015-08-03)
 
 1. Fix tinyxml linking error
     * [BitBucket pull request #209](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/209)
 
-### SDFormat 3.1.0 (2015-08-02)
+### libsdformat 3.1.0 (2015-08-02)
 
 1. Added logical camera sensor to SDF
     * [BitBucket pull request #207](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/207)
 
-### SDFormat 3.0.0 (2015-07-24)
+### libsdformat 3.0.0 (2015-07-24)
 
 1. Added battery to SDF
     * [BitBucket pull request 204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/204)
@@ -409,7 +409,7 @@
     * [BitBucket pull request 147](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/147)
     * [Issue 60](https://github.com/osrf/sdformat/issues/60)
 
-## SDFormat 2.x
+## libsdformat 2.x
 
 1. rename cfm_damping --> implicit_spring_damper
     * [BitBucket pull request 59](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/59)
@@ -421,7 +421,7 @@
     * [BitBucket pull request 64](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/64)
 1. `<use_true_size>` element used by DEM heightmaps
     * [BitBucket pull request 67](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/67)
-1. Do not export urdf symbols in sdformat 1.4
+1. Do not export urdf symbols in SDFormat 1.4
     * [BitBucket pull request 75](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/75)
 1. adding deformable properties per issue #32
     * [BitBucket pull request 78](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/78)
@@ -436,7 +436,7 @@
     * [Gazebo issue 494](https://github.com/osrf/gazebo/issues/494)
 1. Implement SDF_PROTOCOL_VERSION (issue #51)
     * [BitBucket pull request 90](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/90)
-1. Port sdformat to compile on Windows (MSVC)
+1. Port libsdformat to compile on Windows (MSVC)
     * [BitBucket pull request 101](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/101)
 1. Separate material properties in material.sdf
     * [BitBucket pull request 104](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/104)
@@ -462,7 +462,7 @@
     * [BitBucket pull request 127](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/127)
 1. Backport magnetometer
     * [BitBucket pull request 128](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/128)
-1. Add flag for MOI rescaling to sdf 1.4
+1. Add flag for MOI rescaling to SDFormat 1.4
     * [BitBucket pull request 121](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/121)
 1. Parse urdf joint friction parameters, add corresponding test
     * [BitBucket pull request 129](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/129)
@@ -487,9 +487,9 @@
 1. Backport fix for latin locales (pull request #147)
     * [BitBucket pull request 150](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/150)
 
-## SDFormat 1.4
+## libsdformat 1.4
 
-### SDFormat 1.4.8 (2013-09-06)
+### libsdformat 1.4.8 (2013-09-06)
 
 1. Fix inertia transformations when reducing fixed joints in URDF
     * [BitBucket pull request 48](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/48/fix-for-issue-22-reducing-inertia-across/diff)
@@ -499,12 +499,12 @@
     * [BitBucket pull request 46](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/46/convert-a-few-more-sdfwarns-to-sdflog-fix/diff)
     * [Commit](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/commits/b15d5a1ecc57abee6691618d02d59bbc3d1b84dc)
 
-### SDFormat 1.4.7 (2013-08-22)
+### libsdformat 1.4.7 (2013-08-22)
 
 1. Direct console messages to std_err
     * [BitBucket pull request 44](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/44/fix-19-direct-all-messages-to-std_err)
 
-### SDFormat 1.4.6 (2013-08-20)
+### libsdformat 1.4.6 (2013-08-20)
 
 1. Add tags for GPS sensor and sensor noise
     * [BitBucket pull request 36](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/36/gps-sensor-sensor-noise-and-spherical)
@@ -522,7 +522,7 @@
     * [BitBucket pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/38/add-provide_feedback-for-bullet-joint)
 1. Various bug, style and test fixes
 
-### SDFormat 1.4.5 (2013-07-23)
+### libsdformat 1.4.5 (2013-07-23)
 
 1. Deprecated Gazebo's internal SDF code
 1. Use templatized Get functions for retrieving values from SDF files

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -98,7 +98,7 @@ endif()
 ################################################
 # Find the Python interpreter for running the
 # check_test_ran.py script
-find_package(PythonInterp QUIET)
+find_package(PythonInterp 3 QUIET)
 
 ################################################
 # Find psutil python package for memory tests

--- a/include/sdf/CMakeLists.txt
+++ b/include/sdf/CMakeLists.txt
@@ -18,8 +18,7 @@ set (headers
 
 set (sdf_headers "" CACHE INTERNAL "SDF headers" FORCE)
 foreach (hdr ${headers})
-  APPEND_TO_CACHED_STRING(sdf_headers
-    "SDF Headers" "#include <sdf/${hdr}>\n")
+  set(sdf_headers "${sdf_headers}#include <sdf/${hdr}>\n")
 endforeach()
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/sdf.hh.in
                 ${CMAKE_CURRENT_BINARY_DIR}/sdf.hh)

--- a/test/integration/element_memory_leak.cc
+++ b/test/integration/element_memory_leak.cc
@@ -71,7 +71,7 @@ const std::string sdfString(
 
 const std::string getMemInfoPath =
   sdf::filesystem::append(PROJECT_SOURCE_PATH, "tools", "get_mem_info.py");
-const std::string pythonMeminfo("python " + getMemInfoPath);
+const std::string pythonMeminfo("python3 " + getMemInfoPath);
 
 int getMemoryUsage()
 {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes issues on `sdf6` branch when built on Ubuntu 20.04, as exposed by testing for https://github.com/ignition-tooling/release-tools/pull/565 and backports terminology fixes in Changelog

## Summary

There is a cmake warning and test failure when building `sdf6` on Ubuntu 20.04:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat6-focal-amd64&build=1)](https://build.osrfoundation.org/job/sdformat-ci-sdformat6-focal-amd64/1/) https://build.osrfoundation.org/job/sdformat-ci-sdformat6-focal-amd64/1/

These have already been fixed in later versions of `libsdformat`:

* `https://github.com/ignitionrobotics/sdformat/pull/328` test failure was fixed in https://github.com/ignitionrobotics/sdformat/pull/328
* `Value of sdf_headers contained a newline` cmake warning was fixed by https://github.com/ignitionrobotics/sdformat/pull/276/commits/0c972bd022229b3d91be6a95f55763120fd04821 that was squashed in #276

Also, I back ported the use of `libsdformat` and `SDFormat` in the Changelog

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
