### PR TITLE
SDF to USD (main)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ find_package(pxr REQUIRED)
 
 include_directories(${PXR_INCLUDE_DIRS})
 set(sources ${sources}
+  # source files for parsing from USD to SDF
   usd/usd_parser/parser_usd.cc
   usd/usd_parser/physics.cc
   usd/usd_parser/joints.cc
@@ -105,6 +106,12 @@ set(sources ${sources}
   usd/usd_parser/links.cc
   usd/usd_parser/sensors.cc
   usd/usd_parser/utils.cc
+  # source files for parsing from SDF to USD
+  usd/sdf_parser/geometry.cc
+  usd/sdf_parser/link.cc
+  usd/sdf_parser/model.cc
+  usd/sdf_parser/visual.cc
+  usd/sdf_parser/world.cc
 )
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/usd)
 

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -43,6 +43,8 @@ file(GENERATE
 # Install the ruby command line library in an unversioned location.
 install(FILES ${cmd_script_generated} DESTINATION lib/ruby/ignition)
 
+#===============================================================================
+# USD -> SDF converter
 add_executable(sdfconverter
   sdfconverter.cpp
 )
@@ -59,4 +61,23 @@ install(
   ${gui_executable}
   DESTINATION
   ${BIN_INSTALL_DIR}
+)
+
+#===============================================================================
+# SDF -> USD converter
+add_executable(usdConverter
+  usdConverter.cc
+)
+
+target_link_libraries(usdConverter
+  PUBLIC
+    ignition-common${IGN_COMMON_VER}::graphics
+    ${sdf_target}
+)
+
+install(
+  TARGETS
+    usdConverter
+  DESTINATION
+    ${BIN_INSTALL_DIR}
 )

--- a/src/cmd/usdConverter.cc
+++ b/src/cmd/usdConverter.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/sdf.hh"
+// TODO(adlarkin) verify that this line works (using usd/ as prefix)
+#include "usd/sdf_parser/world.hh"
+
+int main(int argc, const char* argv[])
+{
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << argv[0] << " <sdf-path> <usd-path>\n";
+    return -1;
+  }
+
+  sdf::Root root;
+  auto errors = root.Load(argv[1]);
+  if (!errors.empty())
+  {
+    std::cerr << "Errors encountered:\n";
+    for (const auto &e : errors)
+      std::cout << e << "\n";
+    return -2;
+  }
+
+  // only support SDF files with exactly 1 world for now
+  if (root.WorldCount() != 1u)
+  {
+    std::cerr << argv[1] << " does not have exactly 1 world.\n";
+    return -3;
+  }
+
+  auto world = root.WorldByIndex(0u);
+  if (!world)
+  {
+    std::cerr << "Error retrieving the world from " << argv[1] << "\n";
+    return -4;
+  }
+
+  auto stage = pxr::UsdStage::CreateInMemory();
+
+  const auto worldPath = std::string("/" + world->Name());
+  if (!usd::ParseSdfWorld(*world, stage, worldPath))
+  {
+    std::cerr << "Error parsing world [" << world->Name() << "]\n";
+    return -5;
+  }
+
+  if (!stage->GetRootLayer()->Export(argv[2]))
+  {
+    std::cerr << "Issue saving USD to " << argv[2] << "\n";
+    return -6;
+  }
+}

--- a/src/usd/sdf_parser/geometry.cc
+++ b/src/usd/sdf_parser/geometry.cc
@@ -15,9 +15,6 @@
  *
 */
 
-#ifndef SDF_PARSER_GEOMETRY_HH_
-#define SDF_PARSER_GEOMETRY_HH_
-
 #include "geometry.hh"
 
 #include <iostream>
@@ -97,5 +94,3 @@ bool ParseSdfGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stag
 
   return typeParsed;
 }
-
-#endif

--- a/src/usd/sdf_parser/geometry.cc
+++ b/src/usd/sdf_parser/geometry.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_GEOMETRY_HH_
+#define SDF_PARSER_GEOMETRY_HH_
+
+#include "geometry.hh"
+
+#include <iostream>
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Geometry.hh"
+
+namespace usd
+{
+  bool ParseSdfBoxGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path)
+  {
+    // TODO(adlarkin) finish this
+    return false;
+  }
+
+  bool ParseSdfCylinderGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path)
+  {
+    // TODO(adlarkin) finish this
+    return false;
+  }
+
+  bool ParseSdfSphereGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path)
+  {
+    // TODO(adlarkin) finish this
+    return false;
+  }
+
+  bool ParseSdfMeshGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path)
+  {
+    // TODO(adlarkin) finish this
+    return false;
+  }
+
+  bool ParseSdfCapsuleGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path)
+  {
+    // TODO(adlarkin) finish this
+    return false;
+  }
+}
+
+using namespace usd;
+
+bool ParseSdfGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+    const std::string &_path)
+{
+  bool typeParsed = false;
+  switch (_geometry.Type())
+  {
+    case sdf::GeometryType::BOX:
+      typeParsed = ParseSdfBoxGeometry(_geometry, _stage, _path);
+      break;
+    case sdf::GeometryType::CYLINDER:
+      typeParsed = ParseSdfCylinderGeometry(_geometry, _stage, _path);
+      break;
+    case sdf::GeometryType::SPHERE:
+      typeParsed = ParseSdfSphereGeometry(_geometry, _stage, _path);
+      break;
+    case sdf::GeometryType::MESH:
+      typeParsed = ParseSdfMeshGeometry(_geometry, _stage, _path);
+      break;
+    case sdf::GeometryType::CAPSULE:
+      typeParsed = ParseSdfCapsuleGeometry(_geometry, _stage, _path);
+      break;
+    case sdf::GeometryType::PLANE:
+    case sdf::GeometryType::ELLIPSOID:
+    case sdf::GeometryType::HEIGHTMAP:
+    default:
+      std::cerr << "Geometry type is either invalid or not supported.\n";
+  }
+
+  return typeParsed;
+}
+
+#endif

--- a/src/usd/sdf_parser/geometry.hh
+++ b/src/usd/sdf_parser/geometry.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_GEOMETRY_HH_
+#define SDF_PARSER_GEOMETRY_HH_
+
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Geometry.hh"
+
+namespace usd
+{
+  /// \brief Parse an SDF geometry into a USD stage.
+  /// \param[in] _geometry The SDF geometry to parse.
+  /// \param[in] _stage The stage that should contain the USD representation
+  /// of _geometry.
+  /// \param[in] _path The USD path of the parsed geometry in _stage, which must be
+  /// a valid USD path.
+  /// \return True if _geometry was succesfully parsed into _stage with a path of
+  /// _path. False otherwise.
+  bool ParseSdfGeometry(const sdf::Geometry &_geometry, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path);
+}
+
+#endif

--- a/src/usd/sdf_parser/link.cc
+++ b/src/usd/sdf_parser/link.cc
@@ -15,9 +15,6 @@
  *
 */
 
-#ifndef SDF_PARSER_LINK_HH_
-#define SDF_PARSER_LINK_HH_
-
 #include "link.hh"
 
 #include <string>
@@ -51,5 +48,3 @@ bool ParseSdfLink(const sdf::Link &_link, pxr::UsdStageRefPtr &_stage,
   }
   return true;
 }
-
-#endif

--- a/src/usd/sdf_parser/link.cc
+++ b/src/usd/sdf_parser/link.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_LINK_HH_
+#define SDF_PARSER_LINK_HH_
+
+#include "link.hh"
+
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Link.hh"
+#include "usd/sdf_parser/visual.hh"
+
+using namespace usd;
+
+bool ParseSdfLink(const sdf::Link &_link, pxr::UsdStageRefPtr &_stage,
+    const std::string &_path)
+{
+  // TODO(adlarkin) finish parsing link. It will look something like this
+  // (this does not cover all elements of a link that need to be parsed):
+  //  * ParseSdfVisual
+  //  * ParseSdfCollision
+  //  * ParseSdfSensor
+
+  // parse all of the link's visuals and convert them to USD
+  for (uint64_t i = 0; i < _link.VisualCount(); ++i)
+  {
+    const auto visual = *(_link.VisualByIndex(i));
+    const auto visualPath = std::string(_path + "/" + visual.Name());
+    if (!ParseSdfVisual(visual, _stage, visualPath))
+    {
+      std::cerr << "Error parsing visual [" << visual.Name() << "]\n.";
+      return false;
+    }
+  }
+  return true;
+}
+
+#endif

--- a/src/usd/sdf_parser/link.hh
+++ b/src/usd/sdf_parser/link.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_LINK_HH_
+#define SDF_PARSER_LINK_HH_
+
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Link.hh"
+
+namespace usd
+{
+  /// \brief Parse an SDF link into a USD stage.
+  /// \param[in] _link The SDF link to parse.
+  /// \param[in] _stage The stage that should contain the USD representation
+  /// of _link.
+  /// \param[in] _path The USD path of the parsed link in _stage, which must be
+  /// a valid USD path.
+  /// \return True if _link was succesfully parsed into _stage with a path of
+  /// _path. False otherwise.
+  bool ParseSdfLink(const sdf::Link &_link, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path);
+}
+
+#endif

--- a/src/usd/sdf_parser/model.cc
+++ b/src/usd/sdf_parser/model.cc
@@ -15,9 +15,6 @@
  *
 */
 
-#ifndef SDF_PARSER_MODEL_HH_
-#define SDF_PARSER_MODEL_HH_
-
 #include "model.hh"
 
 #include <iostream>
@@ -52,5 +49,3 @@ bool ParseSdfModel(const sdf::Model &_model, pxr::UsdStageRefPtr &_stage,
 
   return true;
 }
-
-#endif

--- a/src/usd/sdf_parser/model.cc
+++ b/src/usd/sdf_parser/model.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_MODEL_HH_
+#define SDF_PARSER_MODEL_HH_
+
+#include "model.hh"
+
+#include <iostream>
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Model.hh"
+#include "usd/sdf_parser/link.hh"
+
+using namespace usd;
+
+bool ParseSdfModel(const sdf::Model &_model, pxr::UsdStageRefPtr &_stage,
+    const std::string &_path)
+{
+  // TODO(adlarkin) finish parsing model. It will look something like this
+  // (this does not cover parsing all elements of a model):
+  //  * ParseSdfLink
+  //  * ParseSdfJoint
+
+  // parse all of the model's links and convert them to USD
+  for (uint64_t i = 0; i < _model.LinkCount(); ++i)
+  {
+    const auto link = *(_model.LinkByIndex(i));
+    const auto linkPath = std::string(_path + "/" + link.Name());
+    if (!ParseSdfLink(link, _stage, linkPath))
+    {
+      std::cerr << "Error parsing link [" << link.Name() << "]\n.";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#endif

--- a/src/usd/sdf_parser/model.hh
+++ b/src/usd/sdf_parser/model.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_MODEL_HH_
+#define SDF_PARSER_MODEL_HH_
+
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Model.hh"
+
+namespace usd
+{
+  /// \brief Parse an SDF model into a USD stage.
+  /// \param[in] _model The SDF model to parse.
+  /// \param[in] _stage The stage that should contain the USD representation
+  /// of _model.
+  /// \param[in] _path The USD path of the parsed model in _stage, which must be
+  /// a valid USD path.
+  /// \return True if _model was succesfully parsed into _stage with a path of
+  /// _path. False otherwise.
+  bool ParseSdfModel(const sdf::Model &_model, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path);
+}
+
+#endif

--- a/src/usd/sdf_parser/visual.cc
+++ b/src/usd/sdf_parser/visual.cc
@@ -15,9 +15,6 @@
  *
 */
 
-#ifndef SDF_PARSER_VISUAL_HH_
-#define SDF_PARSER_VISUAL_HH_
-
 #include "visual.hh"
 
 #include <iostream>
@@ -44,5 +41,3 @@ bool ParseSdfVisual(const sdf::Visual &_visual, pxr::UsdStageRefPtr &_stage,
 
   return true;
 }
-
-#endif

--- a/src/usd/sdf_parser/visual.cc
+++ b/src/usd/sdf_parser/visual.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_VISUAL_HH_
+#define SDF_PARSER_VISUAL_HH_
+
+#include "visual.hh"
+
+#include <iostream>
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Visual.hh"
+#include "usd/sdf_parser/geometry.hh"
+
+using namespace usd;
+
+bool ParseSdfVisual(const sdf::Visual &_visual, pxr::UsdStageRefPtr &_stage,
+    const std::string &_path)
+{
+  const auto geometry = *(_visual.Geom());
+  const auto geometryPath = std::string(_path + "/geometry");
+  if (!ParseSdfGeometry(geometry, _stage, geometryPath))
+  {
+    std::cerr << "Error parsing geometry attached to visual ["
+              << _visual.Name() << "]\n";
+    return false;
+  }
+
+  return true;
+}
+
+#endif

--- a/src/usd/sdf_parser/visual.hh
+++ b/src/usd/sdf_parser/visual.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_VISUAL_HH_
+#define SDF_PARSER_VISUAL_HH_
+
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/Visual.hh"
+
+namespace usd
+{
+  /// \brief Parse an SDF visual into a USD stage.
+  /// \param[in] _visual The SDF visual to parse.
+  /// \param[in] _stage The stage that should contain the USD representation
+  /// of _visual.
+  /// \param[in] _path The USD path of the parsed visual in _stage, which must be
+  /// a valid USD path.
+  /// \return True if _visual was succesfully parsed into _stage with a path of
+  /// _path. False otherwise.
+  bool ParseSdfVisual(const sdf::Visual &_visual, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path);
+}
+
+#endif

--- a/src/usd/sdf_parser/world.cc
+++ b/src/usd/sdf_parser/world.cc
@@ -15,9 +15,6 @@
  *
 */
 
-#ifndef SDF_PARSER_WORLD_HH_
-#define SDF_PARSER_WORLD_HH_
-
 #include "world.hh"
 
 #include <iostream>
@@ -49,5 +46,3 @@ bool ParseSdfWorld(const sdf::World &_world, pxr::UsdStageRefPtr &_stage,
 
   return true;
 }
-
-#endif

--- a/src/usd/sdf_parser/world.cc
+++ b/src/usd/sdf_parser/world.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_WORLD_HH_
+#define SDF_PARSER_WORLD_HH_
+
+#include "world.hh"
+
+#include <iostream>
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/World.hh"
+#include "usd/sdf_parser/model.hh"
+
+using namespace usd;
+
+bool ParseSdfWorld(const sdf::World &_world, pxr::UsdStageRefPtr &_stage,
+    const std::string &_path)
+{
+  // parse all of the world's models and convert them to USD
+  for (uint64_t i = 0; i < _world.ModelCount(); ++i)
+  {
+    const auto model = *(_world.ModelByIndex(i));
+    const auto modelPath = std::string(_path + "/" + model.Name());
+    if (!ParseSdfModel(model, _stage, modelPath))
+    {
+      std::cerr << "Error parsing model [" << model.Name() << "]\n.";
+      return false;
+    }
+  }
+
+  // TODO(adlarkin) finish parsing other elements in _world
+
+  return true;
+}
+
+#endif

--- a/src/usd/sdf_parser/world.hh
+++ b/src/usd/sdf_parser/world.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_PARSER_WORLD_HH_
+#define SDF_PARSER_WORLD_HH_
+
+#include <string>
+
+#include <pxr/usd/usd/stage.h>
+
+#include "sdf/World.hh"
+
+namespace usd
+{
+  /// \brief Parse an SDF world into a USD stage.
+  /// \param[in] _world The SDF world to parse.
+  /// \param[in] _stage The stage that should contain the USD representation
+  /// of _world.
+  /// \param[in] _path The USD path of the parsed world in _stage, which must be
+  /// a valid USD path.
+  /// \return True if _world was succesfully parsed into _stage with a path of
+  /// _path. False otherwise.
+  bool ParseSdfWorld(const sdf::World &_world, pxr::UsdStageRefPtr &_stage,
+      const std::string &_path);
+}
+
+#endif


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

# 🎉 New feature

## Summary
This builds on top of #736 to add the functionality for converting SDF to [USD](https://graphics.pixar.com/usd/release/index.html) (this is similar to #762, but #762 is a standalone PR that targets `sdf12` instead of building on #736 - I've been having linking issues with the build, so I am trying to see if building on top of #763 will help solve these issues or not).

This PR uses #736 **_BEFORE_** CGAL was added, because #736 uses CGAL version 5, which requires ubuntu focal if you want to use the binaries (ubuntu bionic uses CGAL 4). So, to make this PR compatible with bionic and focal, it builds off of the last commit in #736 before CGAL was added: https://github.com/ignitionrobotics/sdformat/pull/736/commits/163637abe6559d213d1dba98fc1fb3a2b2ea04a0.

## Test it
Like #762, there are linking errors with the tests at the moment, so you can build without tests (use `-DBUILD_TESTING=OFF` when invoking `cmake`). I also see a build error which seems to be related to #736:
```
[ 98%] Building CXX object src/cmd/CMakeFiles/sdfconverter.dir/sdfconverter.cpp.o
/usd_sdf/src/sdformat/src/cmd/sdfconverter.cpp:20:10: fatal error: ignition/utils/cli/CLI.hpp: No such file or directory
 #include <ignition/utils/cli/CLI.hpp>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

There's also linking errors for the `usdConverter` executable:
```
[100%] Linking CXX executable usdConverter
CMakeFiles/usdConverter.dir/usdConverter.cc.o: In function `main':
/usd_sdf/src/sdformat/src/cmd/usdConverter.cc:61: undefined reference to `usd::ParseSdfWorld(sdf::v13::World const&, pxrInternal_v0_21__pxrReserved__::TfRefPtr<pxrInternal_v0_21__pxrReserved__::UsdStage>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
../libsdformat13.so.13.0.0~pre1: undefined reference to `usd::ParseSdfModel(sdf::v13::Model const&, pxrInternal_v0_21__pxrReserved__::TfRefPtr<pxrInternal_v0_21__pxrReserved__::UsdStage>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
../libsdformat13.so.13.0.0~pre1: undefined reference to `usd::ParseSdfVisual(sdf::v13::Visual const&, pxrInternal_v0_21__pxrReserved__::TfRefPtr<pxrInternal_v0_21__pxrReserved__::UsdStage>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
../libsdformat13.so.13.0.0~pre1: undefined reference to `usd::ParseSdfGeometry(sdf::v13::Geometry const&, pxrInternal_v0_21__pxrReserved__::TfRefPtr<pxrInternal_v0_21__pxrReserved__::UsdStage>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
../libsdformat13.so.13.0.0~pre1: undefined reference to `usd::ParseSdfLink(sdf::v13::Link const&, pxrInternal_v0_21__pxrReserved__::TfRefPtr<pxrInternal_v0_21__pxrReserved__::UsdStage>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
src/cmd/CMakeFiles/usdConverter.dir/build.make:160: recipe for target 'src/cmd/usdConverter' failed
make[2]: *** [src/cmd/usdConverter] Error 1
CMakeFiles/Makefile2:402: recipe for target 'src/cmd/CMakeFiles/usdConverter.dir/all' failed
make[1]: *** [src/cmd/CMakeFiles/usdConverter.dir/all] Error 2
Makefile:165: recipe for target 'all' failed
make: *** [all] Error 2
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**