### PR TITLE
Added ToElement conversion for physics and atmosphere

### DIFF
--- a/include/sdf/Atmosphere.hh
+++ b/include/sdf/Atmosphere.hh
@@ -95,6 +95,11 @@ namespace sdf
     /// \return True if this instance equals the given atmosphere.
     public: bool operator==(const Atmosphere &_atmosphere);
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// atmosphere.
+    /// \return SDF element pointer with updated atmosphere values.
+    public: sdf::ElementPtr ToElement() const;
+
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)
   };

--- a/include/sdf/Physics.hh
+++ b/include/sdf/Physics.hh
@@ -103,13 +103,13 @@ namespace sdf
     public: void SetRealTimeFactor(const double _factor);
 
     /// \brief Get the maximum number of contacts allowed between two
-    /// entities. This value can be over ridden by a max_contacts element in a
+    /// entities. This value can be overridden by a max_contacts element in a
     /// collision element.
     /// \return Maximum number of contacts.
     public: int MaxContacts() const;
 
     /// \brief Set the maximum number of contacts allowed between two
-    /// entities. This value can be over ridden by a max_contacts element in a
+    /// entities. This value can be overridden by a max_contacts element in a
     /// collision element.
     /// \param[in] _maxContacts Maximum number of contacts.
     public: void SetMaxContacts(int _maxContacts);

--- a/include/sdf/Physics.hh
+++ b/include/sdf/Physics.hh
@@ -102,6 +102,23 @@ namespace sdf
     /// \param[in] _factor The target real time factor.
     public: void SetRealTimeFactor(const double _factor);
 
+    /// \brief Get the maximum number of contacts allowed between two
+    /// entities. This value can be over ridden by a max_contacts element in a
+    /// collision element.
+    /// \return Maximum number of contacts.
+    public: int MaxContacts() const;
+
+    /// \brief Set the maximum number of contacts allowed between two
+    /// entities. This value can be over ridden by a max_contacts element in a
+    /// collision element.
+    /// \param[in] _maxContacts Maximum number of contacts.
+    public: void SetMaxContacts(int _maxContacts);
+
+    /// \brief Create and return an SDF element filled with data from this
+    /// physics.
+    /// \return SDF element pointer with updated physics values.
+    public: sdf::ElementPtr ToElement() const;
+
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)
   };

--- a/src/Atmosphere.cc
+++ b/src/Atmosphere.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <ignition/math/Helpers.hh>
 #include "sdf/Atmosphere.hh"
+#include "sdf/parser.hh"
 
 using namespace sdf;
 
@@ -143,4 +144,18 @@ bool Atmosphere::operator==(const Atmosphere &_atmosphere)
                           _atmosphere.dataPtr->temperatureGradient) &&
     ignition::math::equal(this->dataPtr->pressure,
                           _atmosphere.dataPtr->pressure);
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Atmosphere::ToElement() const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("atmosphere.sdf", elem);
+
+  elem->GetAttribute("type")->Set("adiabatic");
+  elem->GetElement("temperature")->Set(this->Temperature().Kelvin());
+  elem->GetElement("pressure")->Set(this->Pressure());
+  elem->GetElement("temperature_gradient")->Set(this->TemperatureGradient());
+
+  return elem;
 }

--- a/src/Atmosphere_TEST.cc
+++ b/src/Atmosphere_TEST.cc
@@ -16,6 +16,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <ignition/math/Temperature.hh>
 #include <ignition/math/Vector3.hh>
 #include "sdf/World.hh"
 
@@ -129,4 +130,26 @@ TEST(DOMAtmosphere, CopyAssignmentAfterMove)
 
   EXPECT_DOUBLE_EQ(200.0, atmosphere1.Temperature().Kelvin());
   EXPECT_DOUBLE_EQ(100.0, atmosphere2.Temperature().Kelvin());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMAtmosphere, ToElement)
+{
+  sdf::Atmosphere atmosphere;
+  atmosphere.SetType(sdf::AtmosphereType::ADIABATIC);
+  atmosphere.SetTemperature(ignition::math::Temperature(123));
+  atmosphere.SetTemperatureGradient(1.34);
+  atmosphere.SetPressure(2.65);
+
+  sdf::ElementPtr elem = atmosphere.ToElement();
+  ASSERT_NE(nullptr, elem);
+
+  sdf::Atmosphere atmosphere2;
+  atmosphere2.Load(elem);
+
+  // verify values after loading the element back
+  EXPECT_EQ(atmosphere.Temperature(), atmosphere2.Temperature());
+  EXPECT_DOUBLE_EQ(atmosphere.TemperatureGradient(),
+      atmosphere2.TemperatureGradient());
+  EXPECT_DOUBLE_EQ(atmosphere.Pressure(), atmosphere2.Pressure());
 }

--- a/src/Physics.cc
+++ b/src/Physics.cc
@@ -16,6 +16,7 @@
 */
 #include <ignition/math/Vector3.hh>
 
+#include "sdf/parser.hh"
 #include "sdf/Physics.hh"
 #include "Utils.hh"
 
@@ -41,6 +42,9 @@ class sdf::Physics::Implementation
 
   /// \brief Desired realtime factor.
   public: double rtf {1.0};
+
+  /// \brief Maximum number of contacts allowed between two entities.
+  public: int maxContacts{20};
 };
 
 /////////////////////////////////////////////////
@@ -113,6 +117,9 @@ Errors Physics::Load(sdf::ElementPtr _sdf)
   }
   this->dataPtr->rtf = doublePair.first;
 
+  this->dataPtr->maxContacts =
+    _sdf->Get<int>("max_contacts", this->dataPtr->maxContacts).first;
+
   return errors;
 }
 
@@ -180,4 +187,35 @@ double Physics::RealTimeFactor() const
 void Physics::SetRealTimeFactor(const double _factor)
 {
   this->dataPtr->rtf = _factor;
+}
+
+/////////////////////////////////////////////////
+int Physics::MaxContacts() const
+{
+  return this->dataPtr->maxContacts;
+}
+
+/////////////////////////////////////////////////
+void Physics::SetMaxContacts(int _maxContacts)
+{
+  this->dataPtr->maxContacts = _maxContacts;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Physics::ToElement() const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("physics.sdf", elem);
+
+  elem->GetAttribute("name")->Set(this->Name());
+  elem->GetAttribute("default")->Set(this->IsDefault());
+  elem->GetAttribute("type")->Set(this->EngineType());
+
+  elem->GetElement("max_step_size")->Set(this->MaxStepSize());
+  elem->GetElement("real_time_factor")->Set(this->RealTimeFactor());
+  elem->GetElement("max_contacts")->Set(this->MaxContacts());
+
+  /// \todo(nkoenig) Support engine specific parameters.
+
+  return elem;
 }

--- a/src/Physics_TEST.cc
+++ b/src/Physics_TEST.cc
@@ -105,3 +105,29 @@ TEST(DOMPhysics, CopyAssignmentAfterMove)
   EXPECT_EQ("physics2", physics1.Name());
   EXPECT_EQ("physics1", physics2.Name());
 }
+
+/////////////////////////////////////////////////
+TEST(DOMPhysics, ToElement)
+{
+  sdf::Physics physics;
+  physics.SetName("my-bullet-engine");
+  physics.SetDefault(true);
+  physics.SetEngineType("bullet");
+  physics.SetMaxStepSize(0.1);
+  physics.SetRealTimeFactor(20.4);
+  physics.SetMaxContacts(42);
+
+  sdf::ElementPtr elem = physics.ToElement();
+  ASSERT_NE(nullptr, elem);
+
+  sdf::Physics physics2;
+  physics2.Load(elem);
+
+  // verify values after loading the element back
+  EXPECT_EQ(physics.Name(), physics2.Name());
+  EXPECT_EQ(physics.IsDefault(), physics2.IsDefault());
+  EXPECT_EQ(physics.EngineType(), physics2.EngineType());
+  EXPECT_DOUBLE_EQ(physics.MaxStepSize(), physics2.MaxStepSize());
+  EXPECT_DOUBLE_EQ(physics.RealTimeFactor(), physics2.RealTimeFactor());
+  EXPECT_EQ(physics.MaxContacts(), physics2.MaxContacts());
+}


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Adds `ToElement` conversions for the `Physics` and `Atmosphere` DOM objects.

## Test it

 Run the tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**