### PR TITLE
Added ToElement conversion for Collision, Surface, and Visual

### DIFF
--- a/include/sdf/Collision.hh
+++ b/include/sdf/Collision.hh
@@ -115,6 +115,11 @@ namespace sdf
     /// not been called.
     public: sdf::ElementPtr Element() const;
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// collision.
+    /// \return SDF element pointer with updated collision values.
+    public: sdf::ElementPtr ToElement() const;
+
     /// \brief Give the name of the xml parent of this object, to be used
     /// for resolving poses. This is private and is intended to be called by
     /// Link::SetPoseRelativeToGraph.

--- a/include/sdf/Surface.hh
+++ b/include/sdf/Surface.hh
@@ -87,6 +87,11 @@ namespace sdf
     /// \param[in] _cont The contact object.
     public: void SetContact(const sdf::Contact &_contact);
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// surface.
+    /// \return SDF element pointer with updated surface values.
+    public: sdf::ElementPtr ToElement() const;
+
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)
   };

--- a/include/sdf/Visual.hh
+++ b/include/sdf/Visual.hh
@@ -160,6 +160,11 @@ namespace sdf
     /// \param[in] _laserRetro The lidar reflective intensity.
     public: void SetLaserRetro(double _laserRetro);
 
+    /// \brief Create and return an SDF element filled with data from this
+    /// visual.
+    /// \return SDF element pointer with updated visual values.
+    public: sdf::ElementPtr ToElement() const;
+
     /// \brief Give the name of the xml parent of this object, to be used
     /// for resolving poses. This is private and is intended to be called by
     /// Link::SetPoseRelativeToGraph.

--- a/src/Collision.cc
+++ b/src/Collision.cc
@@ -20,6 +20,7 @@
 #include "sdf/Collision.hh"
 #include "sdf/Error.hh"
 #include "sdf/Geometry.hh"
+#include "sdf/parser.hh"
 #include "sdf/Surface.hh"
 #include "sdf/Types.hh"
 #include "FrameSemantics.hh"
@@ -196,4 +197,30 @@ sdf::SemanticPose Collision::SemanticPose() const
 sdf::ElementPtr Collision::Element() const
 {
   return this->dataPtr->sdf;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Collision::ToElement() const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("collision.sdf", elem);
+
+  elem->GetAttribute("name")->Set(this->Name());
+
+  // Set pose
+  sdf::ElementPtr poseElem = elem->GetElement("pose");
+  if (!this->dataPtr->poseRelativeTo.empty())
+  {
+    poseElem->GetAttribute("relative_to")->Set<std::string>(
+        this->dataPtr->poseRelativeTo);
+  }
+  poseElem->Set<ignition::math::Pose3d>(this->RawPose());
+
+  // Set the geometry
+  elem->InsertElement(this->dataPtr->geom.ToElement());
+
+  // Set the surface
+  elem->InsertElement(this->dataPtr->surface.ToElement());
+
+  return elem;
 }

--- a/src/Collision_TEST.cc
+++ b/src/Collision_TEST.cc
@@ -168,3 +168,35 @@ TEST(DOMcollision, SetSurface)
   ASSERT_NE(nullptr, collision.Surface()->Contact());
   EXPECT_EQ(collision.Surface()->Contact()->CollideBitmask(), 0x2);
 }
+
+/////////////////////////////////////////////////
+TEST(DOMCollision, ToElement)
+{
+  sdf::Collision collision;
+
+  collision.SetName("my-collision");
+
+  sdf::Geometry geom;
+  collision.SetGeom(geom);
+  collision.SetRawPose(ignition::math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3));
+
+  sdf::Surface surface;
+  sdf::Contact contact;
+  contact.SetCollideBitmask(123u);
+  surface.SetContact(contact);
+  collision.SetSurface(surface);
+
+  sdf::ElementPtr elem = collision.ToElement();
+  ASSERT_NE(nullptr, elem);
+
+  sdf::Collision collision2;
+  collision2.Load(elem);
+  const sdf::Surface *surface2 = collision2.Surface();
+
+  EXPECT_EQ(collision.Name(), collision2.Name());
+  EXPECT_EQ(collision.RawPose(), collision2.RawPose());
+  EXPECT_NE(nullptr, collision2.Geom());
+  ASSERT_NE(nullptr, surface2);
+  ASSERT_NE(nullptr, surface2->Contact());
+  EXPECT_EQ(123u, surface2->Contact()->CollideBitmask());
+}

--- a/src/Surface.cc
+++ b/src/Surface.cc
@@ -16,6 +16,7 @@
  */
 
 #include "sdf/Element.hh"
+#include "sdf/parser.hh"
 #include "sdf/Surface.hh"
 #include "sdf/Types.hh"
 #include "sdf/sdf_config.h"
@@ -79,6 +80,7 @@ Errors Contact::Load(ElementPtr _sdf)
         static_cast<uint16_t>(_sdf->Get<unsigned int>("collide_bitmask"));
   }
 
+  // \todo(nkoenig) Parse the remaining collide properties.
   return errors;
 }
 /////////////////////////////////////////////////
@@ -137,6 +139,7 @@ Errors Surface::Load(ElementPtr _sdf)
     errors.insert(errors.end(), err.begin(), err.end());
   }
 
+  // \todo(nkoenig) Parse the remaining surface properties.
   return errors;
 }
 /////////////////////////////////////////////////
@@ -155,4 +158,17 @@ const sdf::Contact *Surface::Contact() const
 void Surface::SetContact(const sdf::Contact &_contact)
 {
   this->dataPtr->contact = _contact;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Surface::ToElement() const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("surface.sdf", elem);
+
+  sdf::ElementPtr contactElem = elem->GetElement("contact");
+  contactElem->GetElement("collide_bitmask")->Set(
+      this->dataPtr->contact.CollideBitmask());
+
+  return elem;
 }

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -17,12 +17,13 @@
 #include <memory>
 #include <string>
 #include <ignition/math/Pose3.hh>
-#include "sdf/Error.hh"
-#include "sdf/Types.hh"
-#include "sdf/Visual.hh"
-#include "sdf/Geometry.hh"
 #include "FrameSemantics.hh"
 #include "ScopedGraph.hh"
+#include "sdf/Error.hh"
+#include "sdf/Geometry.hh"
+#include "sdf/parser.hh"
+#include "sdf/Types.hh"
+#include "sdf/Visual.hh"
 #include "Utils.hh"
 
 using namespace sdf;
@@ -299,4 +300,37 @@ void Visual::SetPoseRelativeToGraph(
     sdf::ScopedGraph<PoseRelativeToGraph> _graph)
 {
   this->dataPtr->poseRelativeToGraph = _graph;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Visual::ToElement() const
+{
+  sdf::ElementPtr elem(new sdf::Element);
+  sdf::initFile("visual.sdf", elem);
+
+  elem->GetAttribute("name")->Set(this->Name());
+
+  // Set pose
+  sdf::ElementPtr poseElem = elem->GetElement("pose");
+  if (!this->dataPtr->poseRelativeTo.empty())
+  {
+    poseElem->GetAttribute("relative_to")->Set<std::string>(
+        this->dataPtr->poseRelativeTo);
+  }
+  poseElem->Set<ignition::math::Pose3d>(this->RawPose());
+
+  // Set the geometry
+  elem->InsertElement(this->dataPtr->geom.ToElement());
+
+  elem->GetElement("cast_shadows")->Set(this->CastShadows());
+  elem->GetElement("laser_retro")->Set(this->LaserRetro());
+  elem->GetElement("transparency")->Set(this->Transparency());
+  elem->GetElement("visibility_flags")->Set(this->VisibilityFlags());
+
+  if (this->dataPtr->material)
+  {
+    elem->InsertElement(this->dataPtr->material->ToElement());
+  }
+
+  return elem;
 }

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -285,3 +285,38 @@ TEST(DOMVisual, SetLaserRetro)
   EXPECT_TRUE(visual.HasLaserRetro());
   EXPECT_DOUBLE_EQ(150, visual.LaserRetro());
 }
+
+/////////////////////////////////////////////////
+TEST(DOMVisual, ToElement)
+{
+  sdf::Visual visual;
+  visual.SetName("my-visual");
+  visual.SetCastShadows(true);
+  visual.SetTransparency(0.2);
+  visual.SetRawPose(ignition::math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3));
+  visual.SetVisibilityFlags(1234u);
+  visual.SetHasLaserRetro(true);
+  visual.SetLaserRetro(1.2);
+
+  sdf::Geometry geom;
+  visual.SetGeom(geom);
+
+  sdf::Material mat;
+  visual.SetMaterial(mat);
+
+  sdf::ElementPtr elem = visual.ToElement();
+  ASSERT_NE(nullptr, elem);
+
+  sdf::Visual visual2;
+  visual2.Load(elem);
+
+  EXPECT_EQ(visual.Name(), visual2.Name());
+  EXPECT_EQ(visual.CastShadows(), visual2.CastShadows());
+  EXPECT_DOUBLE_EQ(visual.Transparency(), visual2.Transparency());
+  EXPECT_EQ(visual.RawPose(), visual2.RawPose());
+  EXPECT_EQ(visual.VisibilityFlags(), visual2.VisibilityFlags());
+  EXPECT_EQ(visual.HasLaserRetro(), visual2.HasLaserRetro());
+  EXPECT_DOUBLE_EQ(visual.LaserRetro(), visual2.LaserRetro());
+  EXPECT_NE(nullptr, visual2.Geom());
+  EXPECT_NE(nullptr, visual2.Material());
+}

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -292,7 +292,7 @@ TEST(DOMVisual, ToElement)
   sdf::Visual visual;
   visual.SetName("my-visual");
   visual.SetCastShadows(true);
-  visual.SetTransparency(0.2);
+  visual.SetTransparency(0.2f);
   visual.SetRawPose(ignition::math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3));
   visual.SetVisibilityFlags(1234u);
   visual.SetHasLaserRetro(true);


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Add `ToElement` conversion function for `Collision`, `Contact`, `Surface`, and `Visual`. There are a lot of fields for Surface and Contact that are currently not parsed, I'm leaving this as future work.

## Test it

Run the tests.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [X] Updated documentation (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**