### PR TITLE
USD converter removed spaces

### DIFF
--- a/src/usd/sdf_usd_parser/world.cc
+++ b/src/usd/sdf_usd_parser/world.cc
@@ -32,6 +32,20 @@
 
 namespace usd
 {
+  // TODO(ahcorde): Move this function to common::Util.hh
+  void removeSpaces(std::string &_str)
+  {
+    _str.erase(
+      std::remove_if(
+        _str.begin(),
+        _str.end(),
+        [](unsigned char x)
+        {
+          return std::isspace(x);
+        }),
+      _str.end());
+  }
+
   bool ParseSdfWorld(const sdf::World &_world, pxr::UsdStageRefPtr &_stage,
       const std::string &_path)
   {
@@ -49,7 +63,8 @@ namespace usd
     for (uint64_t i = 0; i < _world.ModelCount(); ++i)
     {
       const auto model = *(_world.ModelByIndex(i));
-      const auto modelPath = std::string(_path + "/" + model.Name());
+      auto modelPath = std::string(_path + "/" + model.Name());
+      removeSpaces(modelPath);
       if (!ParseSdfModel(model, _stage, modelPath, worldPrimPath))
       {
         std::cerr << "Error parsing model [" << model.Name() << "]\n";
@@ -60,7 +75,8 @@ namespace usd
     for (uint64_t i = 0; i < _world.LightCount(); ++i)
     {
       const auto light = *(_world.LightByIndex(i));
-      const auto lightPath = std::string(_path + "/" + light.Name());
+      auto lightPath = std::string(_path + "/" + light.Name());
+      removeSpaces(lightPath);
       if (!ParseSdfLight(light, _stage, lightPath))
       {
         std::cerr << "Error parsing light [" << light.Name() << "]\n";

--- a/src/usd/sdf_usd_parser/world.cc
+++ b/src/usd/sdf_usd_parser/world.cc
@@ -17,6 +17,7 @@
 
 #include "sdf_usd_parser/world.hh"
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

USD does not allow to use spaces in the names

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
