### PR TITLE
Added equality operator to Light DOM

### DIFF
--- a/include/sdf/Light.hh
+++ b/include/sdf/Light.hh
@@ -273,6 +273,20 @@ namespace sdf
     /// \return SDF element pointer with updated light values.
     public: sdf::ElementPtr ToElement() const;
 
+    /// Return true if this light object has the same property values as the
+    /// provided light object.
+    /// \param[in] _light Light object to compare against.
+    /// \return True if this light object has the same property values as
+    /// the provided _light object, false otherwise.
+    public: bool operator==(const Light &_light) const;
+
+    /// Return true if this light object has different property values from the
+    /// provided light object.
+    /// \param[in] _light Light object to compare against.
+    /// \return True if this light object has different property values from the
+    /// provided light object.
+    public: bool operator!=(const Light &_light) const;
+
     /// \brief Allow Link::SetPoseRelativeToGraph or World::Load to call
     /// SetXmlParentName and SetPoseRelativeToGraph,
     /// but Link::SetPoseRelativeToGraph is a private function, so we need

--- a/src/Light.cc
+++ b/src/Light.cc
@@ -16,6 +16,7 @@
 */
 #include <string>
 #include <ignition/math/Pose3.hh>
+#include <ignition/math/Helpers.hh>
 #include "sdf/Error.hh"
 #include "sdf/Light.hh"
 #include "sdf/parser.hh"
@@ -504,4 +505,34 @@ sdf::ElementPtr Light::ToElement() const
       this->SpotOuterAngle().Radian());
   spotElem->GetElement("falloff")->Set<double>(this->SpotFalloff());
   return elem;
+}
+
+//////////////////////////////////////////////////
+bool Light::operator==(const Light &_light) const
+{
+  return this->Name() == _light.Name() &&
+    this->Type() == _light.Type() &&
+    this->RawPose() == _light.RawPose() &&
+    this->CastShadows() == _light.CastShadows() &&
+    ignition::math::equal(this->Intensity(),  _light.Intensity()) &&
+    this->Diffuse() == _light.Diffuse() &&
+    this->Specular() == _light.Specular() &&
+    ignition::math::equal(this->AttenuationRange(),
+                          _light.AttenuationRange()) &&
+    ignition::math::equal(this->LinearAttenuationFactor(),
+                          _light.LinearAttenuationFactor()) &&
+    ignition::math::equal(this->ConstantAttenuationFactor(),
+                          _light.ConstantAttenuationFactor()) &&
+    ignition::math::equal(this->QuadraticAttenuationFactor(),
+                          _light.QuadraticAttenuationFactor()) &&
+    this->Direction() == _light.Direction() &&
+    this->SpotInnerAngle() == _light.SpotInnerAngle() &&
+    this->SpotOuterAngle() == _light.SpotOuterAngle() &&
+    ignition::math::equal(this->SpotFalloff(), _light.SpotFalloff());
+}
+
+//////////////////////////////////////////////////
+bool Light::operator!=(const Light &_light) const
+{
+  return !(*this == _light);
 }

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -142,6 +142,9 @@ TEST(DOMLight, CopyConstructor)
   EXPECT_EQ(ignition::math::Angle(3.3), light2.SpotOuterAngle());
   EXPECT_DOUBLE_EQ(0.9, light2.SpotFalloff());
   EXPECT_DOUBLE_EQ(1.7, light2.Intensity());
+
+  EXPECT_TRUE(light == light2);
+  EXPECT_FALSE(light != light2);
 }
 
 /////////////////////////////////////////////////
@@ -183,6 +186,9 @@ TEST(DOMLight, CopyAssignmentOperator)
   EXPECT_EQ(ignition::math::Angle(3.3), light2.SpotOuterAngle());
   EXPECT_DOUBLE_EQ(0.9, light2.SpotFalloff());
   EXPECT_DOUBLE_EQ(1.7, light2.Intensity());
+
+  EXPECT_TRUE(light == light2);
+  EXPECT_FALSE(light != light2);
 }
 
 /////////////////////////////////////////////////
@@ -283,6 +289,15 @@ TEST(DOMLight, CopyAssignmentAfterMove)
 
   EXPECT_EQ("light2", light1.Name());
   EXPECT_EQ("light1", light2.Name());
+
+  // light1 and light2 have different names, they should be equal.
+  EXPECT_FALSE(light1 == light2);
+  EXPECT_TRUE(light1 != light2);
+
+  // Now they should be equal
+  light1.SetName("light1");
+  EXPECT_TRUE(light1 == light2);
+  EXPECT_FALSE(light1 != light2);
 }
 
 /////////////////////////////////////////////////
@@ -375,4 +390,7 @@ TEST(DOMLight, ToElement)
   sdf::Light light3;
   light3.Load(light2Elem);
   EXPECT_FALSE(light3.CastShadows());
+
+  EXPECT_FALSE(light == light2);
+  EXPECT_TRUE(light != light2);
 }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

In `Ignition Gazebo` the following line requires equality operators for a component, so I've added an equality operator.

```
std::vector<Entity> lights = _ecm.EntitiesByComponents(components::ParentEntity(_entity), components::Light());
```

## Test it

Run the tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**