### PR TITLE
Support URI in the Model DOM

### DIFF
--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -348,8 +348,14 @@ namespace sdf
 
     /// \brief Create and return an SDF element filled with data from this
     /// model.
+    /// \param[in] _useUri When true, the model's URI is used to create an
+    /// SDF `<include>` rather than a `<model>`. The model's URI must be
+    /// first set using the `Model::SetUri` function. If the model's URI is
+    /// empty, then a `<model>` element will be generated. The default is true
+    /// so that URI values are used when ToElement is called from a
+    /// World object.
     /// \return SDF element pointer with updated model values.
-    public: sdf::ElementPtr ToElement() const;
+    public: sdf::ElementPtr ToElement(bool _useUri = true) const;
 
     /// \brief Add a link to the model.
     /// \param[in] _link Link to add.
@@ -377,6 +383,14 @@ namespace sdf
 
     /// \brief Remove all models.
     public: void ClearModels();
+
+    /// \brief Get the URI associated with this model
+    /// \return The model's URI, or empty string if it has not been set.
+    public: std::string Uri() const;
+
+    /// \brief Set the URI associated with this model.
+    /// \param[in] _uri The model's URI.
+    public: void SetUri(const std::string &_uri);
 
     /// \brief Give the scoped PoseRelativeToGraph to be used for resolving
     /// poses. This is private and is intended to be called by Root::Load or

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -348,14 +348,16 @@ namespace sdf
 
     /// \brief Create and return an SDF element filled with data from this
     /// model.
-    /// \param[in] _useUri When true, the model's URI is used to create an
-    /// SDF `<include>` rather than a `<model>`. The model's URI must be
+    /// \param[in] _useIncludeTag When true, the model's URI is used to create
+    /// an SDF `<include>` rather than a `<model>`. The model's URI must be
     /// first set using the `Model::SetUri` function. If the model's URI is
     /// empty, then a `<model>` element will be generated. The default is true
     /// so that URI values are used when ToElement is called from a
-    /// World object.
+    /// World object. Make sure to use `Model::SetUri` even when the model
+    /// is loaded from an `<include>` tag since the parser will
+    /// automatically expand an `<include>` element to a `<model>` element.
     /// \return SDF element pointer with updated model values.
-    public: sdf::ElementPtr ToElement(bool _useUri = true) const;
+    public: sdf::ElementPtr ToElement(bool _useIncludeTag = true) const;
 
     /// \brief Add a link to the model.
     /// \param[in] _link Link to add.

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -808,9 +808,9 @@ void Model::SetUri(const std::string &_uri)
 }
 
 /////////////////////////////////////////////////
-sdf::ElementPtr Model::ToElement(bool _useUri) const
+sdf::ElementPtr Model::ToElement(bool _useIncludeTag) const
 {
-  if (_useUri && !this->dataPtr->uri.empty())
+  if (_useIncludeTag && !this->dataPtr->uri.empty())
   {
     sdf::ElementPtr worldElem(new sdf::Element);
     sdf::initFile("world.sdf", worldElem);
@@ -869,7 +869,7 @@ sdf::ElementPtr Model::ToElement(bool _useUri) const
 
   // Model
   for (const sdf::Model &model : this->dataPtr->models)
-    elem->InsertElement(model.ToElement(_useUri), true);
+    elem->InsertElement(model.ToElement(_useIncludeTag), true);
 
   return elem;
 }

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -826,6 +826,7 @@ sdf::ElementPtr Model::ToElement(bool _useUri) const
     }
     includeElem->GetElement("static")->Set(this->Static());
     includeElem->GetElement("placement_frame")->Set(this->PlacementFrameName());
+
     return includeElem;
   }
 
@@ -868,7 +869,7 @@ sdf::ElementPtr Model::ToElement(bool _useUri) const
 
   // Model
   for (const sdf::Model &model : this->dataPtr->models)
-    elem->InsertElement(model.ToElement(), true);
+    elem->InsertElement(model.ToElement(_useUri), true);
 
   return elem;
 }

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -819,6 +819,13 @@ sdf::ElementPtr Model::ToElement(bool _useUri) const
     includeElem->GetElement("uri")->Set(this->Uri());
     includeElem->GetElement("name")->Set(this->Name());
     includeElem->GetElement("pose")->Set(this->RawPose());
+    if (!this->dataPtr->poseRelativeTo.empty())
+    {
+      includeElem->GetElement("pose")->GetAttribute(
+          "relative_to")->Set<std::string>(this->dataPtr->poseRelativeTo);
+    }
+    includeElem->GetElement("static")->Set(this->Static());
+    includeElem->GetElement("placement_frame")->Set(this->PlacementFrameName());
     return includeElem;
   }
 

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -388,22 +388,23 @@ TEST(DOMModel, Uri)
     sdf::ElementPtr elem = model.ToElement();
     EXPECT_EQ("include", elem->GetName());
 
-    sdf::ElementPtr uriElem = elem->GetElement("uri");
+    sdf::ElementPtr uriElem = elem->FindElement("uri");
     ASSERT_NE(nullptr, uriElem);
     EXPECT_EQ(uri, uriElem->Get<std::string>());
 
-    sdf::ElementPtr nameElem = elem->GetElement("name");
+    sdf::ElementPtr nameElem = elem->FindElement("name");
     ASSERT_NE(nullptr, nameElem);
     EXPECT_EQ(name, nameElem->Get<std::string>());
 
-    sdf::ElementPtr poseElem = elem->GetElement("pose");
+    sdf::ElementPtr poseElem = elem->FindElement("pose");
     ASSERT_NE(nullptr, poseElem);
     EXPECT_EQ(pose, poseElem->Get<ignition::math::Pose3d>());
     EXPECT_EQ("other", poseElem->GetAttribute("relative_to")->GetAsString());
 
-    EXPECT_EQ("link0", elem->GetElement("placement_frame")->Get<std::string>());
+    EXPECT_EQ("link0",
+        elem->FindElement("placement_frame")->Get<std::string>());
 
-    sdf::ElementPtr staticElem = elem->GetElement("static");
+    sdf::ElementPtr staticElem = elem->FindElement("static");
     ASSERT_NE(nullptr, staticElem);
     EXPECT_EQ(true, staticElem->Get<bool>());
   }
@@ -417,7 +418,7 @@ TEST(DOMModel, Uri)
     EXPECT_EQ("model", elem->GetName());
 
     // URI should not exist
-    sdf::ElementPtr uriElem = elem->GetElement("uri");
+    sdf::ElementPtr uriElem = elem->FindElement("uri");
     ASSERT_EQ(nullptr, uriElem);
 
     sdf::ParamPtr nameAttr = elem->GetAttribute("name");
@@ -428,12 +429,12 @@ TEST(DOMModel, Uri)
     ASSERT_NE(nullptr, placementFrameAttr);
     EXPECT_EQ("link0", placementFrameAttr->GetAsString());
 
-    sdf::ElementPtr poseElem = elem->GetElement("pose");
+    sdf::ElementPtr poseElem = elem->FindElement("pose");
     ASSERT_NE(nullptr, poseElem);
     EXPECT_EQ(pose, poseElem->Get<ignition::math::Pose3d>());
     EXPECT_EQ("other", poseElem->GetAttribute("relative_to")->GetAsString());
 
-    sdf::ElementPtr staticElem = elem->GetElement("static");
+    sdf::ElementPtr staticElem = elem->FindElement("static");
     ASSERT_NE(nullptr, staticElem);
     EXPECT_EQ(true, staticElem->Get<bool>());
   }
@@ -466,14 +467,14 @@ TEST(DOMModel, ToElementNestedHasUri)
 
   // Get the child <include> element, which should exist because the nested
   // model has a URI.
-  sdf::ElementPtr includeElem = elem->GetElement("include");
+  sdf::ElementPtr includeElem = elem->FindElement("include");
   ASSERT_NE(nullptr, includeElem);
-  ASSERT_NE(nullptr, includeElem->GetElement("uri"));
-  EXPECT_EQ("child-uri", includeElem->GetElement("uri")->Get<std::string>());
+  ASSERT_NE(nullptr, includeElem->FindElement("uri"));
+  EXPECT_EQ("child-uri", includeElem->FindElement("uri")->Get<std::string>());
 
   // Get the child <model> element, which should exist because one nested
   // model does not have a URI.
-  sdf::ElementPtr modelElem = elem->GetElement("model");
+  sdf::ElementPtr modelElem = elem->FindElement("model");
   ASSERT_NE(nullptr, modelElem);
   EXPECT_EQ("child2", modelElem->GetAttribute("name")->GetAsString());
 }

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -377,6 +377,7 @@ TEST(DOMModel, Uri)
   model.SetRawPose(pose);
   model.SetStatic(true);
   model.SetPlacementFrameName("link0");
+  model.SetPoseRelativeTo("other");
   model.SetUri(uri);
   EXPECT_EQ(uri, model.Uri());
 
@@ -396,6 +397,7 @@ TEST(DOMModel, Uri)
     sdf::ElementPtr poseElem = elem->GetElement("pose");
     ASSERT_NE(nullptr, poseElem);
     EXPECT_EQ(pose, poseElem->Get<ignition::math::Pose3d>());
+    EXPECT_EQ("other", poseElem->GetAttribute("relative_to")->GetAsString());
 
     EXPECT_EQ("link0", elem->GetElement("placement_frame")->Get<std::string>());
 
@@ -427,6 +429,7 @@ TEST(DOMModel, Uri)
     sdf::ElementPtr poseElem = elem->GetElement("pose");
     ASSERT_NE(nullptr, poseElem);
     EXPECT_EQ(pose, poseElem->Get<ignition::math::Pose3d>());
+    EXPECT_EQ("other", poseElem->GetAttribute("relative_to")->GetAsString());
 
     sdf::ElementPtr staticElem = elem->GetElement("static");
     ASSERT_NE(nullptr, staticElem);

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -375,6 +375,8 @@ TEST(DOMModel, Uri)
 
   model.SetName(name);
   model.SetRawPose(pose);
+  model.SetStatic(true);
+  model.SetPlacementFrameName("link0");
   model.SetUri(uri);
   EXPECT_EQ(uri, model.Uri());
 
@@ -394,6 +396,12 @@ TEST(DOMModel, Uri)
     sdf::ElementPtr poseElem = elem->GetElement("pose");
     ASSERT_NE(nullptr, poseElem);
     EXPECT_EQ(pose, poseElem->Get<ignition::math::Pose3d>());
+
+    EXPECT_EQ("link0", elem->GetElement("placement_frame")->Get<std::string>());
+
+    sdf::ElementPtr staticElem = elem->GetElement("static");
+    ASSERT_NE(nullptr, staticElem);
+    EXPECT_EQ(true, staticElem->Get<bool>());
   }
 
   // ToElement NOT using the URI, which should result in a <model>
@@ -412,8 +420,16 @@ TEST(DOMModel, Uri)
     ASSERT_NE(nullptr, nameAttr);
     EXPECT_EQ(name, nameAttr->GetAsString());
 
+    sdf::ParamPtr placementFrameAttr = elem->GetAttribute("placement_frame");
+    ASSERT_NE(nullptr, placementFrameAttr);
+    EXPECT_EQ("link0", placementFrameAttr->GetAsString());
+
     sdf::ElementPtr poseElem = elem->GetElement("pose");
     ASSERT_NE(nullptr, poseElem);
     EXPECT_EQ(pose, poseElem->Get<ignition::math::Pose3d>());
+
+    sdf::ElementPtr staticElem = elem->GetElement("static");
+    ASSERT_NE(nullptr, staticElem);
+    EXPECT_EQ(true, staticElem->Get<bool>());
   }
 }

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -376,6 +376,7 @@ TEST(DOMModel, Uri)
   model.SetName(name);
   model.SetRawPose(pose);
   model.SetUri(uri);
+  EXPECT_EQ(uri, model.Uri());
 
   // ToElement using the URI, which should result in an <include>
   {


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

The SdfGenerator code in Ignition Gazebo has a map that associates URIs to models. In order to use the DOM to generate SDF with model `<include>` elements we need a way to set a model's URI and use the URI in the `ToElement` function.

This PR support setting a model's URI, and updates the ToElement to use the URI. This won't break ABI because the `Model::ToElement` has not been released.

## Test it

Run the tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**