### PR TITLE
Fix loading nested include with custom attributes

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1373,6 +1373,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF, Errors &_errors)
   }
 
   _includeSDF->ClearElements();
+  _includeSDF->RemoveAllAttributes();
   readString(str, _includeSDF, _errors);
 
   elem = _includeSDF->GetElement("model")->GetFirstElement();

--- a/test/integration/model/model_with_custom_elements/model.config
+++ b/test/integration/model/model_with_custom_elements/model.config
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<model>
+  <name>model_with_custom_elements</name>
+  <sdf version="1.7">model.sdf</sdf>
+</model>

--- a/test/integration/model/model_with_custom_elements/model.sdf
+++ b/test/integration/model/model_with_custom_elements/model.sdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<sdf version="1.7" xmlns:mysim="http://example.org/mysim/schema">
+  <model name="M1">
+    <link name="L1" mysim:custom_attr_str="A" mysim:custom_attr_int="5" />
+    <link name="L2" />
+    <joint name="J1" type="revolute">
+      <parent>L1</parent>
+      <child>L2</child>
+    </joint>
+
+    <model name="M2">
+      <link name="L1" mysim:custom_attr_str="B">
+        <mysim:transmission name="simple_trans">
+          <mysim:type>transmission_interface/SimpleTransmission</mysim:type>
+          <mysim:joint name="J1">
+            <mysim:hardwareInterface>EffortJointInterface</mysim:hardwareInterface>
+          </mysim:joint>
+        </mysim:transmission>
+      </link>
+    </model>
+  </model>
+</sdf>

--- a/test/integration/sdf_custom.cc
+++ b/test/integration/sdf_custom.cc
@@ -123,14 +123,29 @@ TEST(SDFParser, ReloadCustomElements)
       model2->Element()->FindElement("mysim:transmission");
   ASSERT_NE(nullptr, customElem1);
   ASSERT_NE(nullptr, customElem2);
-  EXPECT_EQ(customElem1->ToString(""), customElem2->ToString(""));
+
+  const std::string customElemStr =
+R"(<mysim:transmission name='simple_trans'>
+  <mysim:type>transmission_interface/SimpleTransmission</mysim:type>
+  <mysim:joint name='J1'>
+    <mysim:hardwareInterface>EffortJointInterface</mysim:hardwareInterface>
+  </mysim:joint>
+</mysim:transmission>
+)";
+  EXPECT_EQ(customElemStr, customElem1->ToString(""));
+  EXPECT_EQ(customElemStr, customElem2->ToString(""));
+
   sdf::ElementPtr customDesc1 =
       world1->Element()->FindElement("mysim:description");
   sdf::ElementPtr customDesc2 =
       world2->Element()->FindElement("mysim:description");
   ASSERT_NE(nullptr, customDesc1);
   ASSERT_NE(nullptr, customDesc2);
-  EXPECT_EQ(customDesc1->ToString(""), customDesc2->ToString(""));
+
+  const std::string customDescStr =
+    "<mysim:description>Description of this world</mysim:description>\n";
+  EXPECT_EQ(customDescStr, customDesc1->ToString(""));
+  EXPECT_EQ(customDescStr, customDesc2->ToString(""));
 }
 
 /////////////////////////////////////////////////
@@ -184,8 +199,11 @@ R"(<sdf version='1.7'>
   const sdf::Link *model12link2 = model12->LinkByIndex(0);
   ASSERT_NE(nullptr, model11link1);
   ASSERT_NE(nullptr, model12link2);
-  EXPECT_EQ(model11link1->Element()->ToString(""),
-            model12link2->Element()->ToString(""));
+
+  const std::string linkCustomAttrStr =
+    "<link name='L1' mysim:custom_attr_str='A' mysim:custom_attr_int='5'/>\n";
+  EXPECT_EQ(linkCustomAttrStr, model11link1->Element()->ToString(""));
+  EXPECT_EQ(linkCustomAttrStr, model12link2->Element()->ToString(""));
 
   // //model[@name=M1]/model[@name=M2]
   const sdf::Model *model21 = model11->ModelByIndex(0);
@@ -202,6 +220,16 @@ R"(<sdf version='1.7'>
   EXPECT_EQ(model21link1->Element()->ToString(""),
             model22link2->Element()->ToString(""));
 
+  // check custom attributes
+  sdf::ParamPtr param1 =
+      model21link1->Element()->GetAttribute("mysim:custom_attr_str");
+  sdf::ParamPtr param2 =
+      model22link2->Element()->GetAttribute("mysim:custom_attr_str");
+  ASSERT_NE(nullptr, param1);
+  ASSERT_NE(nullptr, param2);
+  EXPECT_EQ("B", param1->GetAsString());
+  EXPECT_EQ("B", param2->GetAsString());
+
   // //model[@name=M1]/model[@name=M2]/link[@name=L1]/mysim:transmission
   sdf::ElementPtr customElem1 =
       model21link1->Element()->FindElement("mysim:transmission");
@@ -209,7 +237,17 @@ R"(<sdf version='1.7'>
       model22link2->Element()->FindElement("mysim:transmission");
   ASSERT_NE(nullptr, customElem1);
   ASSERT_NE(nullptr, customElem2);
-  EXPECT_EQ(customElem1->ToString(""), customElem2->ToString(""));
+
+  const std::string customElemStr =
+R"(<mysim:transmission name='simple_trans'>
+  <mysim:type>transmission_interface/SimpleTransmission</mysim:type>
+  <mysim:joint name='J1'>
+    <mysim:hardwareInterface>EffortJointInterface</mysim:hardwareInterface>
+  </mysim:joint>
+</mysim:transmission>
+)";
+  EXPECT_EQ(customElemStr, customElem1->ToString(""));
+  EXPECT_EQ(customElemStr, customElem2->ToString(""));
 }
 
 /////////////////////////////////////////////////
@@ -273,8 +311,14 @@ R"(<sdf version='1.7'>
   const sdf::Link *model12link2 = model12->LinkByIndex(0);
   ASSERT_NE(nullptr, model11link1);
   ASSERT_NE(nullptr, model12link2);
-  EXPECT_EQ(model11link1->Element()->ToString(""),
-            model12link2->Element()->ToString(""));
+
+  const std::string linkCustomAttrStr =
+R"(<link name='M1::L1' mysim:custom_attr_str='A' mysim:custom_attr_int='5'>
+  <pose relative_to='M1::__model__'>0 0 0 0 -0 0</pose>
+</link>
+)";
+  EXPECT_EQ(linkCustomAttrStr, model11link1->Element()->ToString(""));
+  EXPECT_EQ(linkCustomAttrStr, model12link2->Element()->ToString(""));
 
   // //model[@name=test]/model[@name=M1::M2]
   const sdf::Model *model21 = model11->ModelByIndex(0);
@@ -291,6 +335,16 @@ R"(<sdf version='1.7'>
   EXPECT_EQ(model21link1->Element()->ToString(""),
             model22link2->Element()->ToString(""));
 
+  // check custom attributes
+  sdf::ParamPtr param1 =
+      model21link1->Element()->GetAttribute("mysim:custom_attr_str");
+  sdf::ParamPtr param2 =
+      model22link2->Element()->GetAttribute("mysim:custom_attr_str");
+  ASSERT_NE(nullptr, param1);
+  ASSERT_NE(nullptr, param2);
+  EXPECT_EQ("B", param1->GetAsString());
+  EXPECT_EQ("B", param2->GetAsString());
+
   // //model[@name=test]/model[@name=M1::M2]/link[@name=M1::L1]
   //  /mysim:transmission
   sdf::ElementPtr customElem1 =
@@ -299,5 +353,15 @@ R"(<sdf version='1.7'>
       model22link2->Element()->FindElement("mysim:transmission");
   ASSERT_NE(nullptr, customElem1);
   ASSERT_NE(nullptr, customElem2);
-  EXPECT_EQ(customElem1->ToString(""), customElem2->ToString(""));
+
+  const std::string customElemStr =
+R"(<mysim:transmission name='simple_trans'>
+  <mysim:type>transmission_interface/SimpleTransmission</mysim:type>
+  <mysim:joint name='M1::J1'>
+    <mysim:hardwareInterface>EffortJointInterface</mysim:hardwareInterface>
+  </mysim:joint>
+</mysim:transmission>
+)";
+  EXPECT_EQ(customElemStr, customElem1->ToString(""));
+  EXPECT_EQ(customElemStr, customElem2->ToString(""));
 }

--- a/test/integration/sdf_custom.cc
+++ b/test/integration/sdf_custom.cc
@@ -82,3 +82,222 @@ TEST(SDFParser, CustomElements)
       tranJointElement->Get<std::string>("mysim:hardwareInterface");
   EXPECT_EQ("EffortJointInterface", tranHwInterface);
 }
+
+/////////////////////////////////////////////////
+TEST(SDFParser, ReloadCustomElements)
+{
+  const std::string sdfTestFile =
+      sdf::testing::TestFile("integration", "custom_elems_attrs.sdf");
+
+  // load file with custom elements
+  sdf::Root root1;
+  sdf::Errors errors = root1.Load(sdfTestFile);
+  EXPECT_TRUE(errors.empty());
+
+  // reload string output of root1
+  sdf::Root root2;
+  errors = root2.LoadSdfString(root1.Element()->ToString(""));
+  EXPECT_TRUE(errors.empty());
+
+  // check that root1 and root2 equal
+  const sdf::World *world1 = root1.WorldByIndex(0);
+  const sdf::World *world2 = root2.WorldByIndex(0);
+  ASSERT_NE(nullptr, world1);
+  ASSERT_NE(nullptr, world2);
+
+  const sdf::Model *model1 = world1->ModelByIndex(0);
+  const sdf::Model *model2 = world2->ModelByIndex(0);
+  ASSERT_NE(nullptr, model1);
+  ASSERT_NE(nullptr, model2);
+  EXPECT_EQ(model1->Element()->ToString(""), model2->Element()->ToString(""));
+
+  const sdf::Link *link1 = model1->LinkByIndex(0);
+  const sdf::Link *link2 = model2->LinkByIndex(0);
+  ASSERT_NE(nullptr, link1);
+  ASSERT_NE(nullptr, link2);
+  EXPECT_EQ(link1->Element()->ToString(""), link2->Element()->ToString(""));
+
+  sdf::ElementPtr customElem1 =
+      model1->Element()->FindElement("mysim:transmission");
+  sdf::ElementPtr customElem2 =
+      model2->Element()->FindElement("mysim:transmission");
+  ASSERT_NE(nullptr, customElem1);
+  ASSERT_NE(nullptr, customElem2);
+  EXPECT_EQ(customElem1->ToString(""), customElem2->ToString(""));
+  sdf::ElementPtr customDesc1 =
+      world1->Element()->FindElement("mysim:description");
+  sdf::ElementPtr customDesc2 =
+      world2->Element()->FindElement("mysim:description");
+  ASSERT_NE(nullptr, customDesc1);
+  ASSERT_NE(nullptr, customDesc2);
+  EXPECT_EQ(customDesc1->ToString(""), customDesc2->ToString(""));
+}
+
+/////////////////////////////////////////////////
+TEST(SDFParser, ReloadIncludedCustomElements)
+{
+  const std::string modelPath = sdf::testing::TestFile("integration", "model");
+
+  sdf::setFindCallback(
+    [&](const std::string &_file)
+    {
+      return sdf::filesystem::append(modelPath, _file);
+    });
+
+  const std::string sdfStr =
+R"(<sdf version='1.7'>
+  <world name='default'>
+    <include>
+      <uri>model_with_custom_elements</uri>
+    </include>
+  </world>
+</sdf>
+)";
+
+  // load included file with custom elements
+  sdf::Root root1;
+  sdf::Errors errors = root1.LoadSdfString(sdfStr);
+  EXPECT_TRUE(errors.empty());
+
+  // reload string output of root1
+  sdf::Root root2;
+  errors = root2.LoadSdfString(root1.Element()->ToString(""));
+  EXPECT_TRUE(errors.empty());
+
+  // check that root1 and root2 equal
+  EXPECT_EQ(root1.Element()->ToString(""), root2.Element()->ToString(""));
+
+  const sdf::World *world1 = root1.WorldByIndex(0);
+  const sdf::World *world2 = root2.WorldByIndex(0);
+  ASSERT_NE(nullptr, world1);
+  ASSERT_NE(nullptr, world2);
+
+  // //model[@name=M1]
+  const sdf::Model *model11 = world1->ModelByIndex(0);
+  const sdf::Model *model12 = world2->ModelByIndex(0);
+  ASSERT_NE(nullptr, model11);
+  ASSERT_NE(nullptr, model12);
+  EXPECT_EQ(model11->Element()->ToString(""), model12->Element()->ToString(""));
+
+  // //model[@name=M1]/link[@name=L1]
+  const sdf::Link *model11link1 = model11->LinkByIndex(0);
+  const sdf::Link *model12link2 = model12->LinkByIndex(0);
+  ASSERT_NE(nullptr, model11link1);
+  ASSERT_NE(nullptr, model12link2);
+  EXPECT_EQ(model11link1->Element()->ToString(""),
+            model12link2->Element()->ToString(""));
+
+  // //model[@name=M1]/model[@name=M2]
+  const sdf::Model *model21 = model11->ModelByIndex(0);
+  const sdf::Model *model22 = model12->ModelByIndex(0);
+  ASSERT_NE(nullptr, model21);
+  ASSERT_NE(nullptr, model22);
+  EXPECT_EQ(model21->Element()->ToString(""), model22->Element()->ToString(""));
+
+  // //model[@name=M1]/model[@name=M2]/link[@name=L1]
+  const sdf::Link *model21link1 = model21->LinkByIndex(0);
+  const sdf::Link *model22link2 = model22->LinkByIndex(0);
+  ASSERT_NE(nullptr, model21link1);
+  ASSERT_NE(nullptr, model22link2);
+  EXPECT_EQ(model21link1->Element()->ToString(""),
+            model22link2->Element()->ToString(""));
+
+  // //model[@name=M1]/model[@name=M2]/link[@name=L1]/mysim:transmission
+  sdf::ElementPtr customElem1 =
+      model21link1->Element()->FindElement("mysim:transmission");
+  sdf::ElementPtr customElem2 =
+      model22link2->Element()->FindElement("mysim:transmission");
+  ASSERT_NE(nullptr, customElem1);
+  ASSERT_NE(nullptr, customElem2);
+  EXPECT_EQ(customElem1->ToString(""), customElem2->ToString(""));
+}
+
+/////////////////////////////////////////////////
+TEST(SDFParser, ReloadNestedIncludedCustomElements)
+{
+  const std::string modelPath = sdf::testing::TestFile("integration", "model");
+
+  sdf::setFindCallback(
+    [&](const std::string &_file)
+    {
+      return sdf::filesystem::append(modelPath, _file);
+    });
+
+  const std::string sdfStr =
+R"(<sdf version='1.7'>
+  <world name='default'>
+    <model name='test'>
+      <include>
+        <uri>model_with_custom_elements</uri>
+      </include>
+    </model>
+  </world>
+</sdf>
+)";
+
+  sdf::Root root1;
+  sdf::Errors errors = root1.LoadSdfString(sdfStr);
+  EXPECT_TRUE(errors.empty());
+
+  for (auto &e : errors)
+    std::cout << e.Message() << std::endl;
+
+  sdf::Root root2;
+  errors = root2.LoadSdfString(root1.Element()->ToString(""));
+  EXPECT_TRUE(errors.empty());
+
+  // check that root1 and root2 equal
+  EXPECT_EQ(root1.Element()->ToString(""), root2.Element()->ToString(""));
+
+  const sdf::World *world1 = root1.WorldByIndex(0);
+  const sdf::World *world2 = root2.WorldByIndex(0);
+  ASSERT_NE(nullptr, world1);
+  ASSERT_NE(nullptr, world2);
+
+  // //model[@name=test]
+  const sdf::Model *model11 = world1->ModelByIndex(0);
+  const sdf::Model *model12 = world2->ModelByIndex(0);
+  ASSERT_NE(nullptr, model11);
+  ASSERT_NE(nullptr, model12);
+  EXPECT_EQ(model11->Element()->ToString(""), model12->Element()->ToString(""));
+
+  // //model[@name=test]/frame[@name=M1::__model__]
+  const sdf::Frame *frame1 = model11->FrameByIndex(0);
+  const sdf::Frame *frame2 = model12->FrameByIndex(0);
+  ASSERT_NE(nullptr, frame1);
+  ASSERT_NE(nullptr, frame2);
+  EXPECT_EQ(frame1->Element()->ToString(""), frame2->Element()->ToString(""));
+
+  // //model[@name=test]/link[@name=M1::L1]
+  const sdf::Link *model11link1 = model11->LinkByIndex(0);
+  const sdf::Link *model12link2 = model12->LinkByIndex(0);
+  ASSERT_NE(nullptr, model11link1);
+  ASSERT_NE(nullptr, model12link2);
+  EXPECT_EQ(model11link1->Element()->ToString(""),
+            model12link2->Element()->ToString(""));
+
+  // //model[@name=test]/model[@name=M1::M2]
+  const sdf::Model *model21 = model11->ModelByIndex(0);
+  const sdf::Model *model22 = model12->ModelByIndex(0);
+  ASSERT_NE(nullptr, model21);
+  ASSERT_NE(nullptr, model22);
+  EXPECT_EQ(model21->Element()->ToString(""), model22->Element()->ToString(""));
+
+  // //model[@name=test]/model[@name=M1::M2]/link[@name=M1::L1]
+  const sdf::Link *model21link1 = model21->LinkByIndex(0);
+  const sdf::Link *model22link2 = model22->LinkByIndex(0);
+  ASSERT_NE(nullptr, model21link1);
+  ASSERT_NE(nullptr, model22link2);
+  EXPECT_EQ(model21link1->Element()->ToString(""),
+            model22link2->Element()->ToString(""));
+
+  // //model[@name=test]/model[@name=M1::M2]/link[@name=M1::L1]
+  //  /mysim:transmission
+  sdf::ElementPtr customElem1 =
+      model21link1->Element()->FindElement("mysim:transmission");
+  sdf::ElementPtr customElem2 =
+      model22link2->Element()->FindElement("mysim:transmission");
+  ASSERT_NE(nullptr, customElem1);
+  ASSERT_NE(nullptr, customElem2);
+  EXPECT_EQ(customElem1->ToString(""), customElem2->ToString(""));
+}


### PR DESCRIPTION
# 🦟 Bug fix

Closes #502

## Summary
When working on tests for #502 , I found a bug with nested includes where the included file contained custom attributes. In the parser's `addNestedModel` call,  after the string replacement for flattening, the `_includeSDF` element was cleared but not it's attributes. This resulted in the custom attribute being added twice and the duplicate attribute would be left with an empty value. This PR fixes the issue by clearing the attributes before calling `readString` and adds tests to ensure custom elements/attributes are preserved when loading a sdformat file and reloading the string output.

**Before PR**
Check out this PR and comment out `_includeSDF->RemoveAllAttributes()` from:
https://github.com/ignitionrobotics/sdformat/blob/1c6c0a55d07cc75057f8cc44c5a25b85f155ee8e/src/parser.cc#L1375-L1377

Then run:
```bash
./path/to/build/test/integration/INTEGRATION_sdf_custom --gtest_filter=SDFParser.ReloadNestedIncludedCustomElements
```

The error is:
```bash
Required attribute[xmlns:mysim] in element[sdf] is not specified in SDF.
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
