### PR TITLE
Apply UsdPhysicsDriveAPI to revolute joints

### DIFF
--- a/src/usd/sdf_usd_parser/joint.cc
+++ b/src/usd/sdf_usd_parser/joint.cc
@@ -30,6 +30,7 @@
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/relationship.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdPhysics/driveAPI.h>
 #include <pxr/usd/usdPhysics/fixedJoint.h>
 #include <pxr/usd/usdPhysics/joint.h>
 #include <pxr/usd/usdPhysics/prismaticJoint.h>
@@ -115,30 +116,47 @@ namespace usd
     auto usdJoint =
       pxr::UsdPhysicsRevoluteJoint::Define(_stage, pxr::SdfPath(_path));
 
-    if (_joint.Axis()->Xyz() == ignition::math::Vector3d::UnitX ||
-        _joint.Axis()->Xyz() == -ignition::math::Vector3d::UnitX)
+    const auto axis = _joint.Axis();
+
+    if (axis->Xyz() == ignition::math::Vector3d::UnitX ||
+        axis->Xyz() == -ignition::math::Vector3d::UnitX)
       usdJoint.CreateAxisAttr().Set(pxr::TfToken("X"));
-    else if (_joint.Axis()->Xyz() == ignition::math::Vector3d::UnitY ||
-        _joint.Axis()->Xyz() == -ignition::math::Vector3d::UnitY)
+    else if (axis->Xyz() == ignition::math::Vector3d::UnitY ||
+        axis->Xyz() == -ignition::math::Vector3d::UnitY)
       usdJoint.CreateAxisAttr().Set(pxr::TfToken("Y"));
-    else if (_joint.Axis()->Xyz() == ignition::math::Vector3d::UnitZ ||
-        _joint.Axis()->Xyz() == -ignition::math::Vector3d::UnitZ)
+    else if (axis->Xyz() == ignition::math::Vector3d::UnitZ ||
+        axis->Xyz() == -ignition::math::Vector3d::UnitZ)
       usdJoint.CreateAxisAttr().Set(pxr::TfToken("Z"));
     else
     {
       std::cerr << "Revolute joint [" << _joint.Name() << "] has an invalid "
-                << "axis: [" << _joint.Axis()->Xyz() << "]\n";
+                << "axis: [" << axis->Xyz() << "]\n";
       return false;
     }
 
     // Revolute joint limits in SDF are in radians, but USD expects degrees
     // of C++ type float
     auto sdfLimitDegrees = static_cast<float>(
-        ignition::math::Angle(_joint.Axis()->Lower()).Degree());
+        ignition::math::Angle(axis->Lower()).Degree());
     usdJoint.CreateLowerLimitAttr().Set(sdfLimitDegrees);
     sdfLimitDegrees = static_cast<float>(
-        ignition::math::Angle(_joint.Axis()->Upper()).Degree());
+        ignition::math::Angle(axis->Upper()).Degree());
     usdJoint.CreateUpperLimitAttr().Set(sdfLimitDegrees);
+
+    pxr::UsdPrim usdJointPrim = _stage->GetPrimAtPath(pxr::SdfPath(_path));
+
+    if (!pxr::UsdPhysicsDriveAPI::Apply(usdJointPrim, pxr::TfToken("angular")))
+    {
+      std::cerr << "Internal error: unable to mark link at path ["
+                << _path << "] as a UsdPhysicsDriveAPI \n";
+      return false;
+    }
+
+    auto drive =
+      pxr::UsdPhysicsDriveAPI(usdJointPrim, pxr::TfToken("angular"));
+    drive.CreateDampingAttr().Set(static_cast<float>(axis->Damping()));
+    drive.CreateStiffnessAttr().Set(static_cast<float>(axis->Stiffness()));
+    drive.CreateMaxForceAttr().Set(static_cast<float>(axis->Effort()));
 
     return true;
   }


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

# 🎉 New feature

## Summary
This was originally in #770, but I have broken it out into a separate PR so that this can be merged into #762 while we continue to work on #770.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.