### PR TITLE
Fix test compilation with USE_INTERNAL_URDF

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ if (BUILD_TESTING)
       target_compile_definitions(using_parser_urdf INTERFACE -D_USE_MATH_DEFINES)
     endif()
   else()
-    target_link_libraries(using_parser_urdf
+    target_link_libraries(using_parser_urdf INTERFACE
       IgnURDFDOM::IgnURDFDOM)
   endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,19 +61,23 @@ if (BUILD_TESTING)
     target_sources(UNIT_FrameSemantics_TEST PRIVATE FrameSemantics.cc)
   endif()
 
-  if (TARGET UNIT_ParamPassing_TEST)
-    if (USE_INTERNAL_URDF)
-      target_include_directories(UNIT_ParamPassing_TEST PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
-      if (WIN32)
-        target_compile_definitions(UNIT_ParamPassing_TEST PRIVATE -D_USE_MATH_DEFINES)
-      endif()
-    else()
-      target_link_libraries(UNIT_ParamPassing_TEST
-        IgnURDFDOM::IgnURDFDOM)
+  # Use interface library to deduplicate cmake logic for URDF linking
+  add_library(using_parser_urdf INTERFACE)
+  if (USE_INTERNAL_URDF)
+    target_include_directories(using_parser_urdf INTERFACE
+      ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
+    if (WIN32)
+      target_compile_definitions(using_parser_urdf INTERFACE -D_USE_MATH_DEFINES)
     endif()
+  else()
+    target_link_libraries(using_parser_urdf
+      IgnURDFDOM::IgnURDFDOM)
+  endif()
+
+  if (TARGET UNIT_ParamPassing_TEST)
     target_link_libraries(UNIT_ParamPassing_TEST
-      TINYXML2::TINYXML2)
+      TINYXML2::TINYXML2
+      using_parser_urdf)
     target_sources(UNIT_ParamPassing_TEST PRIVATE
       Converter.cc
       EmbeddedSdf.cc
@@ -96,18 +100,9 @@ if (BUILD_TESTING)
   endif()
 
   if (TARGET UNIT_parser_urdf_TEST)
-    if (USE_INTERNAL_URDF)
-      target_include_directories(UNIT_parser_urdf_TEST PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
-      if (WIN32)
-        target_compile_definitions(UNIT_parser_urdf_TEST PRIVATE -D_USE_MATH_DEFINES)
-      endif()
-    else()
-      target_link_libraries(UNIT_parser_urdf_TEST
-        IgnURDFDOM::IgnURDFDOM)
-    endif()
     target_link_libraries(UNIT_parser_urdf_TEST
-      TINYXML2::TINYXML2)
+      TINYXML2::TINYXML2
+      using_parser_urdf)
     target_sources(UNIT_parser_urdf_TEST PRIVATE
       SDFExtension.cc
       XmlUtils.cc
@@ -124,7 +119,8 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
     ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
   PRIVATE
-    TINYXML2::TINYXML2)
+    TINYXML2::TINYXML2
+    using_parser_urdf)
 
 if (WIN32)
   target_compile_definitions(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE URDFDOM_STATIC)
@@ -137,18 +133,6 @@ target_include_directories(${PROJECT_LIBRARY_TARGET_NAME}
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
-
-if (USE_INTERNAL_URDF)
-  target_include_directories(${PROJECT_LIBRARY_TARGET_NAME}
-    PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/urdf
-  )
-  if (WIN32)
-    target_compile_definitions(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE -D_USE_MATH_DEFINES)
-  endif()
-else()
-  target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE IgnURDFDOM::IgnURDFDOM)
-endif()
 
 if(NOT WIN32)
   add_subdirectory(cmd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,13 @@ if (BUILD_TESTING)
   endif()
 
   if (TARGET UNIT_ParamPassing_TEST)
-    if (NOT USE_INTERNAL_URDF)
+    if (USE_INTERNAL_URDF)
+      target_include_directories(UNIT_ParamPassing_TEST PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
+      if (WIN32)
+        target_compile_definitions(UNIT_ParamPassing_TEST PRIVATE -D_USE_MATH_DEFINES)
+      endif()
+    else()
       target_link_libraries(UNIT_ParamPassing_TEST
         IgnURDFDOM::IgnURDFDOM)
     endif()
@@ -90,7 +96,15 @@ if (BUILD_TESTING)
   endif()
 
   if (TARGET UNIT_parser_urdf_TEST)
-    if (NOT USE_INTERNAL_URDF)
+    if (USE_INTERNAL_URDF)
+      target_include_directories(UNIT_parser_urdf_TEST PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
+      if (WIN32)
+        target_compile_definitions(UNIT_parser_urdf_TEST PRIVATE -D_USE_MATH_DEFINES)
+      endif()
+    else()
+      target_include_directories(UNIT_parser_urdf_TEST PRIVATE
+          ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
       target_link_libraries(UNIT_parser_urdf_TEST
         IgnURDFDOM::IgnURDFDOM)
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,16 +5,26 @@ ign_get_libsources_and_unittests(sources gtest_sources)
 # Add the source file auto-generated into the build folder from sdf/CMakeLists.txt
 list(APPEND sources EmbeddedSdf.cc)
 
+# Use interface library to deduplicate cmake logic for URDF linking
+add_library(using_parser_urdf INTERFACE)
 if (USE_INTERNAL_URDF)
   set(sources ${sources}
-  urdf/urdf_parser/model.cpp
-  urdf/urdf_parser/link.cpp
-  urdf/urdf_parser/joint.cpp
-  urdf/urdf_parser/pose.cpp
-  urdf/urdf_parser/twist.cpp
-  urdf/urdf_parser/urdf_model_state.cpp
-  urdf/urdf_parser/urdf_sensor.cpp
-  urdf/urdf_parser/world.cpp)
+    urdf/urdf_parser/model.cpp
+    urdf/urdf_parser/link.cpp
+    urdf/urdf_parser/joint.cpp
+    urdf/urdf_parser/pose.cpp
+    urdf/urdf_parser/twist.cpp
+    urdf/urdf_parser/urdf_model_state.cpp
+    urdf/urdf_parser/urdf_sensor.cpp
+    urdf/urdf_parser/world.cpp)
+  target_include_directories(using_parser_urdf INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
+  if (WIN32)
+    target_compile_definitions(using_parser_urdf INTERFACE -D_USE_MATH_DEFINES)
+  endif()
+else()
+  target_link_libraries(using_parser_urdf INTERFACE
+    IgnURDFDOM::IgnURDFDOM)
 endif()
 
 if (BUILD_TESTING)
@@ -59,19 +69,6 @@ if (BUILD_TESTING)
 
   if (TARGET UNIT_FrameSemantics_TEST)
     target_sources(UNIT_FrameSemantics_TEST PRIVATE FrameSemantics.cc)
-  endif()
-
-  # Use interface library to deduplicate cmake logic for URDF linking
-  add_library(using_parser_urdf INTERFACE)
-  if (USE_INTERNAL_URDF)
-    target_include_directories(using_parser_urdf INTERFACE
-      ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
-    if (WIN32)
-      target_compile_definitions(using_parser_urdf INTERFACE -D_USE_MATH_DEFINES)
-    endif()
-  else()
-    target_link_libraries(using_parser_urdf INTERFACE
-      IgnURDFDOM::IgnURDFDOM)
   endif()
 
   if (TARGET UNIT_ParamPassing_TEST)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,8 +103,6 @@ if (BUILD_TESTING)
         target_compile_definitions(UNIT_parser_urdf_TEST PRIVATE -D_USE_MATH_DEFINES)
       endif()
     else()
-      target_include_directories(UNIT_parser_urdf_TEST PRIVATE
-          ${CMAKE_CURRENT_SOURCE_DIR}/urdf)
       target_link_libraries(UNIT_parser_urdf_TEST
         IgnURDFDOM::IgnURDFDOM)
     endif()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation with `USE_INTERNAL_URDF` == True

## Summary

I noticed that the 10.7.0~pre1 debbuilds failed to compile some tests with complaints about finding urdf headers:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat10-debbuilder&build=242)](https://build.osrfoundation.org/job/sdformat10-debbuilder/242/) https://build.osrfoundation.org/job/sdformat10-debbuilder/242

~~~
src/parser_urdf.cc:30:10: fatal error: urdf_model/model.h: No such file or directory
 #include <urdf_model/model.h>
          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
src/CMakeFiles/UNIT_ParamPassing_TEST.dir/build.make:257: recipe for target
 'src/CMakeFiles/UNIT_ParamPassing_TEST.dir/parser_urdf.cc.o' failed
~~~

It turns out the debbuilds are using `USE_INTERNAL_URDF == TRUE` since `pkg-config` is not listed as a `build-depend` in the debian metadata. I will resolve that shortly. In the meantime, this ensures that the `USE_INTERNAL_URDF` logic for include and windows compiler definitions used for libsdformat10 is repeated for tests that add `parser_urdf.cc` via `target_sources`.

Update: I've simplified the cmake logic using an interface library called `using_parser_urdf`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
