### PR TITLE
Decrease light intensities

### DIFF
--- a/src/usd/sdf_usd_parser/light.cc
+++ b/src/usd/sdf_usd_parser/light.cc
@@ -57,7 +57,8 @@ namespace usd
   bool ParseSdfDirectionalLight(const sdf::Light &_light,
       pxr::UsdStageRefPtr &_stage, const pxr::SdfPath &_path)
   {
-    pxr::UsdLuxDistantLight::Define(_stage, _path);
+    auto directionalLight = pxr::UsdLuxDistantLight::Define(_stage, _path);
+    directionalLight.CreateIntensityAttr().Set(1000.0f);
 
     return true;
   }
@@ -112,7 +113,7 @@ namespace usd
         auto lightPrim = _stage->GetPrimAtPath(sdfLightPath);
         lightPrim.CreateAttribute(pxr::TfToken("intensity"),
             pxr::SdfValueTypeNames->Float, false).Set(
-              static_cast<float>(_light.Intensity()) * 10000.0f);
+              static_cast<float>(_light.Intensity()) * 100.0f);
       }
 
       // TODO(adlarkin) Other things to look at (there may be more):


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
@ahcorde here's a PR that decreases light intensities in USD, since they were too strong before. Feel free to modify the values used in this PR based on the test results you see in isaac sim. Right now, I set the directional light intensity to 1000 (it was 50000 by default), and all other light intensities to be scaled by 100 w.r.t. the SDF value.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.