### PR TITLE
Allow model frames (__model__) to be used as joint parent or child

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2256,7 +2256,10 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
       auto joint = _model->JointByIndex(j);
 
       const std::string &parentName = joint->ParentLinkName();
-      if (parentName != "world" && !_model->LinkNameExists(parentName) &&
+      const std::string parentLocalName = sdf::SplitName(parentName).second;
+
+      if (parentName != "world" && parentLocalName != "__model__" &&
+          !_model->LinkNameExists(parentName) &&
           !_model->JointNameExists(parentName) &&
           !_model->FrameNameExists(parentName))
       {
@@ -2267,6 +2270,7 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
       }
 
       const std::string &childName = joint->ChildLinkName();
+      const std::string childLocalName = sdf::SplitName(childName).second;
       if (childName == "world")
       {
         errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
@@ -2274,7 +2278,7 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
           joint->Name() + "] in model with name[" + _model->Name() + "]."});
       }
 
-      if (!_model->LinkNameExists(childName) &&
+      if (childLocalName != "__model__" && !_model->LinkNameExists(childName) &&
           !_model->JointNameExists(childName) &&
           !_model->FrameNameExists(childName) &&
           !_model->ModelNameExists(childName))

--- a/test/sdf/joint_child_model_frame.sdf
+++ b/test/sdf/joint_child_model_frame.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_child_model_frame">
+    <link name="base_link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+
+    <link name="parent_link">
+      <pose>1 0 0 0 0 0</pose>
+    </link>
+
+    <joint name="joint" type="fixed">
+      <parent>parent_link</parent>
+      <child>__model__</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_nested_parent_child.sdf
+++ b/test/sdf/joint_nested_parent_child.sdf
@@ -57,5 +57,19 @@
       <parent>L1</parent>
       <child>M1::M2</child>
     </joint>
+
+    <!-- Joint with a nested model frame as a parent  -->
+    <joint name="J6" type="fixed">
+      <pose>0 0 1 0 0 0</pose>
+      <parent>M1::__model__</parent>
+      <child>L1</child>
+    </joint>
+
+    <!-- Joint with a nested model frame as a child  -->
+    <joint name="J7" type="fixed">
+      <pose>0 0 1 0 0 0</pose>
+      <parent>L1</parent>
+      <child>M1::__model__</child>
+    </joint>
   </model>
 </sdf>

--- a/test/sdf/joint_parent_model_frame.sdf
+++ b/test/sdf/joint_parent_model_frame.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_parent_model_frame">
+    <link name="base_link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+
+    <link name="child_link">
+      <pose>1 0 0 0 0 0</pose>
+    </link>
+
+    <joint name="joint" type="fixed">
+      <parent>__model__</parent>
+      <child>child_link</child>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The spec (http://sdformat.org/tutorials?tut=composition_proposal&cat=pose_semantics_docs&#1-3-3-model-frame-references) says "For a model named `{name}`, model frames can be referenced by their name. `{name}::__model__` is also valid, but {name} is preferred instead." libsdformat has supported using a model's `{name}` in `//joint/parent` and `//joint/child` for a while, but it currently does not support `{name}::__model__`. This PR rectifies that and also adds support for using just `__model__` since that is a valid frame inside a model.

Came up in PR review for #768: [comment](https://github.com/ignitionrobotics/sdformat/pull/768#discussion_r792866634)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- ~[ ] Updated documentation (as needed)~
- ~[ ] Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
