### PR TITLE
Added non-const accessors for Link child objects

### DIFF
--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -76,6 +76,13 @@ namespace sdf
     /// \sa uint64_t VisualCount() const
     public: const Visual *VisualByIndex(const uint64_t _index) const;
 
+    /// \brief Get a mutable visual based on an index.
+    /// \param[in] _index Index of the visual. The index should be in the
+    /// range [0..VisualCount()).
+    /// \return Pointer to the visual. Nullptr if the index does not exist.
+    /// \sa uint64_t VisualCount() const
+    public: Visual *VisualByIndex(uint64_t _index);
+
     /// \brief Get whether a visual name exists.
     /// \param[in] _name Name of the visual to check.
     /// \return True if there exists a visual with the given name.
@@ -85,6 +92,11 @@ namespace sdf
     /// \param[in] _name Name of the visual.
     /// \return Pointer to the visual. Nullptr if the name does not exist.
     public: const Visual *VisualByName(const std::string &_name) const;
+
+    /// \brief Get a mutable visual based on a name.
+    /// \param[in] _name Name of the visual.
+    /// \return Pointer to the visual. Nullptr if the name does not exist.
+    public: Visual *VisualByName(const std::string &_name);
 
     /// \brief Get the number of collisions.
     /// \return Number of collisions contained in this Link object.
@@ -97,6 +109,13 @@ namespace sdf
     /// \sa uint64_t CollisionCount() const
     public: const Collision *CollisionByIndex(const uint64_t _index) const;
 
+    /// \brief Get a mutable collision based on an index.
+    /// \param[in] _index Index of the collision. The index should be in the
+    /// range [0..CollisionCount()).
+    /// \return Pointer to the collision. Nullptr if the index does not exist.
+    /// \sa uint64_t CollisionCount() const
+    public: Collision *CollisionByIndex(uint64_t _index);
+
     /// \brief Get whether a collision name exists.
     /// \param[in] _name Name of the collision to check.
     /// \return True if there exists a collision with the given name.
@@ -106,6 +125,11 @@ namespace sdf
     /// \param[in] _name Name of the collision.
     /// \return Pointer to the collision. Nullptr if the name does not exist.
     public: const Collision *CollisionByName(const std::string &_name) const;
+
+    /// \brief Get a mutable collision based on a name.
+    /// \param[in] _name Name of the collision.
+    /// \return Pointer to the collision. Nullptr if the name does not exist.
+    public: Collision *CollisionByName(const std::string &_name);
 
     /// \brief Get the number of lights.
     /// \return Number of lights contained in this Link object.
@@ -118,6 +142,13 @@ namespace sdf
     /// \sa uint64_t LightCount() const
     public: const Light *LightByIndex(const uint64_t _index) const;
 
+    /// \brief Get a mutable light based on an index.
+    /// \param[in] _index Index of the light. The index should be in the
+    /// range [0..LightCount()).
+    /// \return Pointer to the light. Nullptr if the index does not exist.
+    /// \sa uint64_t LightCount() const
+    public: Light *LightByIndex(uint64_t _index);
+
     /// \brief Get whether a light name exists.
     /// \param[in] _name Name of the light to check.
     /// \return True if there exists a light with the given name.
@@ -127,6 +158,11 @@ namespace sdf
     /// \param[in] _name Name of the light.
     /// \return Pointer to the light. Nullptr if the name does not exist.
     public: const Light *LightByName(const std::string &_name) const;
+
+    /// \brief Get a mutable light based on a name.
+    /// \param[in] _name Name of the light.
+    /// \return Pointer to the light. Nullptr if the name does not exist.
+    public: Light *LightByName(const std::string &_name);
 
     /// \brief Get the number of sensors.
     /// \return Number of sensors contained in this Link object.
@@ -139,6 +175,13 @@ namespace sdf
     /// \sa uint64_t SensorCount() const
     public: const Sensor *SensorByIndex(const uint64_t _index) const;
 
+    /// \brief Get a mutable sensor based on an index.
+    /// \param[in] _index Index of the sensor. The index should be in the
+    /// range [0..SensorCount()).
+    /// \return Pointer to the sensor. Nullptr if the index does not exist.
+    /// \sa uint64_t SensorCount() const
+    public: Sensor *SensorByIndex(uint64_t _index);
+
     /// \brief Get whether a sensor name exists.
     /// \param[in] _name Name of the sensor to check.
     /// \return True if there exists a sensor with the given name.
@@ -150,6 +193,13 @@ namespace sdf
     ///  does not exist.
     /// \sa bool SensorNameExists(const std::string &_name) const
     public: const Sensor *SensorByName(const std::string &_name) const;
+
+    /// \brief Get a mutable sensor based on a name.
+    /// \param[in] _name Name of the sensor.
+    /// \return Pointer to the sensor. Nullptr if a sensor with the given name
+    ///  does not exist.
+    /// \sa bool SensorNameExists(const std::string &_name) const
+    public: Sensor *SensorByName(const std::string &_name);
 
     /// \brief Get the number of particle emitters.
     /// \return Number of particle emitters contained in this Link object.
@@ -164,6 +214,14 @@ namespace sdf
     public: const ParticleEmitter *ParticleEmitterByIndex(
                 const uint64_t _index) const;
 
+    /// \brief Get a mutable particle emitter based on an index.
+    /// \param[in] _index Index of the particle emitter.
+    /// The index should be in the range [0..ParticleEmitterCount()).
+    /// \return Pointer to the particle emitter. Nullptr if the index does
+    /// not exist.
+    /// \sa uint64_t ParticleEmitterCount() const
+    public: ParticleEmitter *ParticleEmitterByIndex(uint64_t _index);
+
     /// \brief Get whether a particle emitter name exists.
     /// \param[in] _name Name of the particle emitter to check.
     /// \return True if there exists a particle emitter with the given name.
@@ -176,6 +234,13 @@ namespace sdf
     /// \sa bool ParticleEmitterNameExists(const std::string &_name) const
     public: const ParticleEmitter *ParticleEmitterByName(
                 const std::string &_name) const;
+
+    /// \brief Get a mutable particle emitter based on a name.
+    /// \param[in] _name Name of the particle emitter.
+    /// \return Pointer to the particle emitter. Nullptr if a particle emitter
+    /// with the given name does not exist.
+    /// \sa bool ParticleEmitterNameExists(const std::string &_name) const
+    public: ParticleEmitter *ParticleEmitterByName(const std::string &_name);
 
     /// \brief Get the inertial value for this link. The inertial object
     /// consists of the link's mass, a 3x3 rotational inertia matrix, and

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -39,57 +39,6 @@ using namespace sdf;
 
 class sdf::Link::Implementation
 {
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _index Index value.
-  /// \return Object pointer or nullptr
-  public: const Sensor *SensorByIndex(uint64_t _index) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _name Element name.
-  /// \return Object pointer or nullptr
-  public: const Sensor *SensorByName(const std::string &_name) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _index Index value.
-  /// \return Object pointer or nullptr
-  public: const ParticleEmitter *ParticleEmitterByIndex(uint64_t _index) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _name Element name.
-  /// \return Object pointer or nullptr
-  public: const ParticleEmitter *ParticleEmitterByName(
-              const std::string &_name) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _index Index value.
-  /// \return Object pointer or nullptr
-  public: const Collision *CollisionByIndex(uint64_t _index) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _name Element name.
-  /// \return Object pointer or nullptr
-  public: const Collision *CollisionByName(const std::string &_name) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _index Index value.
-  /// \return Object pointer or nullptr
-  public: const Visual *VisualByIndex(uint64_t _index) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _name Element name.
-  /// \return Object pointer or nullptr
-  public: const Visual *VisualByName(const std::string &_name) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _index Index value.
-  /// \return Object pointer or nullptr
-  public: const Light *LightByIndex(uint64_t _index) const;
-
-  /// \brief Helper function for the public facing functions by the same name.
-  /// \param[in] _name Element name.
-  /// \return Object pointer or nullptr
-  public: const Light *LightByName(const std::string &_name) const;
-
   /// \brief Name of the link.
   public: std::string name = "";
 
@@ -264,21 +213,16 @@ uint64_t Link::VisualCount() const
 /////////////////////////////////////////////////
 const Visual *Link::VisualByIndex(const uint64_t _index) const
 {
-  return this->dataPtr->VisualByIndex(_index);
+  if (_index < this->dataPtr->visuals.size())
+    return &this->dataPtr->visuals[_index];
+  return nullptr;
 }
 
 /////////////////////////////////////////////////
 Visual *Link::VisualByIndex(uint64_t _index)
 {
-  return const_cast<Visual*>(this->dataPtr->VisualByIndex(_index));
-}
-
-/////////////////////////////////////////////////
-const Visual *Link::Implementation::VisualByIndex(uint64_t _index) const
-{
-  if (_index < this->visuals.size())
-    return &this->visuals[_index];
-  return nullptr;
+  return const_cast<Visual*>(
+      static_cast<const Link*>(this)->VisualByIndex(_index));
 }
 
 /////////////////////////////////////////////////
@@ -303,21 +247,16 @@ uint64_t Link::CollisionCount() const
 /////////////////////////////////////////////////
 const Collision *Link::CollisionByIndex(const uint64_t _index) const
 {
-  return this->dataPtr->CollisionByIndex(_index);
+  if (_index < this->dataPtr->collisions.size())
+    return &this->dataPtr->collisions[_index];
+  return nullptr;
 }
 
 /////////////////////////////////////////////////
 Collision *Link::CollisionByIndex(uint64_t _index)
 {
-  return const_cast<Collision*>(this->dataPtr->CollisionByIndex(_index));
-}
-
-/////////////////////////////////////////////////
-const Collision *Link::Implementation::CollisionByIndex(uint64_t _index) const
-{
-  if (_index < this->collisions.size())
-    return &this->collisions[_index];
-  return nullptr;
+  return const_cast<Collision*>(
+      static_cast<const Link*>(this)->CollisionByIndex(_index));
 }
 
 /////////////////////////////////////////////////
@@ -342,21 +281,16 @@ uint64_t Link::LightCount() const
 /////////////////////////////////////////////////
 const Light *Link::LightByIndex(const uint64_t _index) const
 {
-  return this->dataPtr->LightByIndex(_index);
+  if (_index < this->dataPtr->lights.size())
+    return &this->dataPtr->lights[_index];
+  return nullptr;
 }
 
 /////////////////////////////////////////////////
 Light *Link::LightByIndex(uint64_t _index)
 {
-  return const_cast<Light*>(this->dataPtr->LightByIndex(_index));
-}
-
-/////////////////////////////////////////////////
-const Light *Link::Implementation::LightByIndex(uint64_t _index) const
-{
-  if (_index < this->lights.size())
-    return &this->lights[_index];
-  return nullptr;
+  return const_cast<Light*>(
+      static_cast<const Link*>(this)->LightByIndex(_index));
 }
 
 /////////////////////////////////////////////////
@@ -374,21 +308,16 @@ uint64_t Link::SensorCount() const
 /////////////////////////////////////////////////
 const Sensor *Link::SensorByIndex(const uint64_t _index) const
 {
-  return this->dataPtr->SensorByIndex(_index);
+  if (_index < this->dataPtr->sensors.size())
+    return &this->dataPtr->sensors[_index];
+  return nullptr;
 }
 
 /////////////////////////////////////////////////
 Sensor *Link::SensorByIndex(uint64_t _index)
 {
-  return const_cast<Sensor*>(this->dataPtr->SensorByIndex(_index));
-}
-
-/////////////////////////////////////////////////
-const Sensor *Link::Implementation::SensorByIndex(uint64_t _index) const
-{
-  if (_index < this->sensors.size())
-    return &this->sensors[_index];
-  return nullptr;
+  return const_cast<Sensor*>(
+      static_cast<const Link*>(this)->SensorByIndex(_index));
 }
 
 /////////////////////////////////////////////////
@@ -407,19 +336,7 @@ bool Link::SensorNameExists(const std::string &_name) const
 /////////////////////////////////////////////////
 const Sensor *Link::SensorByName(const std::string &_name) const
 {
-  return this->dataPtr->SensorByName(_name);
-}
-
-/////////////////////////////////////////////////
-Sensor *Link::SensorByName(const std::string &_name)
-{
-  return const_cast<Sensor*>(this->dataPtr->SensorByName(_name));
-}
-
-/////////////////////////////////////////////////
-const Sensor *Link::Implementation::SensorByName(const std::string &_name) const
-{
-  for (auto const &s : this->sensors)
+  for (auto const &s : this->dataPtr->sensors)
   {
     if (s.Name() == _name)
     {
@@ -427,6 +344,13 @@ const Sensor *Link::Implementation::SensorByName(const std::string &_name) const
     }
   }
   return nullptr;
+}
+
+/////////////////////////////////////////////////
+Sensor *Link::SensorByName(const std::string &_name)
+{
+  return const_cast<Sensor*>(
+      static_cast<const Link*>(this)->SensorByName(_name));
 }
 
 /////////////////////////////////////////////////
@@ -438,23 +362,16 @@ uint64_t Link::ParticleEmitterCount() const
 /////////////////////////////////////////////////
 const ParticleEmitter *Link::ParticleEmitterByIndex(const uint64_t _index) const
 {
-  return this->dataPtr->ParticleEmitterByIndex(_index);
+  if (_index < this->dataPtr->emitters.size())
+    return &this->dataPtr->emitters[_index];
+  return nullptr;
 }
 
 /////////////////////////////////////////////////
 ParticleEmitter *Link::ParticleEmitterByIndex(uint64_t _index)
 {
   return const_cast<ParticleEmitter*>(
-      this->dataPtr->ParticleEmitterByIndex(_index));
-}
-
-/////////////////////////////////////////////////
-const ParticleEmitter *Link::Implementation::ParticleEmitterByIndex(
-    uint64_t _index) const
-{
-  if (_index < this->emitters.size())
-    return &this->emitters[_index];
-  return nullptr;
+      static_cast<const Link*>(this)->ParticleEmitterByIndex(_index));
 }
 
 /////////////////////////////////////////////////
@@ -474,21 +391,7 @@ bool Link::ParticleEmitterNameExists(const std::string &_name) const
 const ParticleEmitter *Link::ParticleEmitterByName(
     const std::string &_name) const
 {
-  return this->dataPtr->ParticleEmitterByName(_name);
-}
-
-/////////////////////////////////////////////////
-ParticleEmitter *Link::ParticleEmitterByName(const std::string &_name)
-{
-  return const_cast<ParticleEmitter*>(
-      this->dataPtr->ParticleEmitterByName(_name));
-}
-
-/////////////////////////////////////////////////
-const ParticleEmitter *Link::Implementation::ParticleEmitterByName(
-    const std::string &_name) const
-{
-  for (auto const &e : this->emitters)
+  for (auto const &e : this->dataPtr->emitters)
   {
     if (e.Name() == _name)
     {
@@ -496,6 +399,13 @@ const ParticleEmitter *Link::Implementation::ParticleEmitterByName(
     }
   }
   return nullptr;
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter *Link::ParticleEmitterByName(const std::string &_name)
+{
+  return const_cast<ParticleEmitter *>(
+      static_cast<const Link*>(this)->ParticleEmitterByName(_name));
 }
 
 /////////////////////////////////////////////////
@@ -583,19 +493,7 @@ sdf::SemanticPose Link::SemanticPose() const
 /////////////////////////////////////////////////
 const Visual *Link::VisualByName(const std::string &_name) const
 {
-  return this->dataPtr->VisualByName(_name);
-}
-
-/////////////////////////////////////////////////
-Visual *Link::VisualByName(const std::string &_name)
-{
-  return const_cast<Visual*>(this->dataPtr->VisualByName(_name));
-}
-
-/////////////////////////////////////////////////
-const Visual *Link::Implementation::VisualByName(const std::string &_name) const
-{
-  for (auto const &v : this->visuals)
+  for (auto const &v : this->dataPtr->visuals)
   {
     if (v.Name() == _name)
     {
@@ -606,47 +504,36 @@ const Visual *Link::Implementation::VisualByName(const std::string &_name) const
 }
 
 /////////////////////////////////////////////////
+Visual *Link::VisualByName(const std::string &_name)
+{
+  return const_cast<Visual *>(
+      static_cast<const Link*>(this)->VisualByName(_name));
+}
+
+/////////////////////////////////////////////////
 const Collision *Link::CollisionByName(const std::string &_name) const
 {
-  return this->dataPtr->CollisionByName(_name);
+  for (auto &c : this->dataPtr->collisions)
+  {
+    if (c.Name() == _name)
+    {
+      return &c;
+    }
+  }
+  return nullptr;
 }
 
 /////////////////////////////////////////////////
 Collision *Link::CollisionByName(const std::string &_name)
 {
-  return const_cast<Collision*>(this->dataPtr->CollisionByName(_name));
-}
-
-/////////////////////////////////////////////////
-const Collision *Link::Implementation::CollisionByName(
-    const std::string &_name) const
-{
-  for (auto &c : this->collisions)
-  {
-    if (c.Name() == _name)
-    {
-      return &c;
-    }
-  }
-  return nullptr;
+  return const_cast<Collision *>(
+      static_cast<const Link*>(this)->CollisionByName(_name));
 }
 
 /////////////////////////////////////////////////
 const Light *Link::LightByName(const std::string &_name) const
 {
-  return this->dataPtr->LightByName(_name);
-}
-
-/////////////////////////////////////////////////
-Light *Link::LightByName(const std::string &_name)
-{
-  return const_cast<Light*>(this->dataPtr->LightByName(_name));
-}
-
-/////////////////////////////////////////////////
-const Light *Link::Implementation::LightByName(const std::string &_name) const
-{
-  for (auto const &c : this->lights)
+  for (auto const &c : this->dataPtr->lights)
   {
     if (c.Name() == _name)
     {
@@ -654,6 +541,14 @@ const Light *Link::Implementation::LightByName(const std::string &_name) const
     }
   }
   return nullptr;
+}
+
+/////////////////////////////////////////////////
+Light *Link::LightByName(const std::string &_name)
+{
+  return const_cast<Light *>(
+      static_cast<const Link*>(this)->LightByName(_name));
+
 }
 
 /////////////////////////////////////////////////

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -39,6 +39,57 @@ using namespace sdf;
 
 class sdf::Link::Implementation
 {
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _index Index value.
+  /// \return Object pointer or nullptr
+  public: const Sensor *SensorByIndex(uint64_t _index) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _name Element name.
+  /// \return Object pointer or nullptr
+  public: const Sensor *SensorByName(const std::string &_name) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _index Index value.
+  /// \return Object pointer or nullptr
+  public: const ParticleEmitter *ParticleEmitterByIndex(uint64_t _index) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _name Element name.
+  /// \return Object pointer or nullptr
+  public: const ParticleEmitter *ParticleEmitterByName(
+              const std::string &_name) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _index Index value.
+  /// \return Object pointer or nullptr
+  public: const Collision *CollisionByIndex(uint64_t _index) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _name Element name.
+  /// \return Object pointer or nullptr
+  public: const Collision *CollisionByName(const std::string &_name) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _index Index value.
+  /// \return Object pointer or nullptr
+  public: const Visual *VisualByIndex(uint64_t _index) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _name Element name.
+  /// \return Object pointer or nullptr
+  public: const Visual *VisualByName(const std::string &_name) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _index Index value.
+  /// \return Object pointer or nullptr
+  public: const Light *LightByIndex(uint64_t _index) const;
+
+  /// \brief Helper function for the public facing functions by the same name.
+  /// \param[in] _name Element name.
+  /// \return Object pointer or nullptr
+  public: const Light *LightByName(const std::string &_name) const;
+
   /// \brief Name of the link.
   public: std::string name = "";
 
@@ -213,8 +264,20 @@ uint64_t Link::VisualCount() const
 /////////////////////////////////////////////////
 const Visual *Link::VisualByIndex(const uint64_t _index) const
 {
-  if (_index < this->dataPtr->visuals.size())
-    return &this->dataPtr->visuals[_index];
+  return this->dataPtr->VisualByIndex(_index);
+}
+
+/////////////////////////////////////////////////
+Visual *Link::VisualByIndex(uint64_t _index)
+{
+  return const_cast<Visual*>(this->dataPtr->VisualByIndex(_index));
+}
+
+/////////////////////////////////////////////////
+const Visual *Link::Implementation::VisualByIndex(uint64_t _index) const
+{
+  if (_index < this->visuals.size())
+    return &this->visuals[_index];
   return nullptr;
 }
 
@@ -240,8 +303,20 @@ uint64_t Link::CollisionCount() const
 /////////////////////////////////////////////////
 const Collision *Link::CollisionByIndex(const uint64_t _index) const
 {
-  if (_index < this->dataPtr->collisions.size())
-    return &this->dataPtr->collisions[_index];
+  return this->dataPtr->CollisionByIndex(_index);
+}
+
+/////////////////////////////////////////////////
+Collision *Link::CollisionByIndex(uint64_t _index)
+{
+  return const_cast<Collision*>(this->dataPtr->CollisionByIndex(_index));
+}
+
+/////////////////////////////////////////////////
+const Collision *Link::Implementation::CollisionByIndex(uint64_t _index) const
+{
+  if (_index < this->collisions.size())
+    return &this->collisions[_index];
   return nullptr;
 }
 
@@ -267,8 +342,20 @@ uint64_t Link::LightCount() const
 /////////////////////////////////////////////////
 const Light *Link::LightByIndex(const uint64_t _index) const
 {
-  if (_index < this->dataPtr->lights.size())
-    return &this->dataPtr->lights[_index];
+  return this->dataPtr->LightByIndex(_index);
+}
+
+/////////////////////////////////////////////////
+Light *Link::LightByIndex(uint64_t _index)
+{
+  return const_cast<Light*>(this->dataPtr->LightByIndex(_index));
+}
+
+/////////////////////////////////////////////////
+const Light *Link::Implementation::LightByIndex(uint64_t _index) const
+{
+  if (_index < this->lights.size())
+    return &this->lights[_index];
   return nullptr;
 }
 
@@ -287,8 +374,20 @@ uint64_t Link::SensorCount() const
 /////////////////////////////////////////////////
 const Sensor *Link::SensorByIndex(const uint64_t _index) const
 {
-  if (_index < this->dataPtr->sensors.size())
-    return &this->dataPtr->sensors[_index];
+  return this->dataPtr->SensorByIndex(_index);
+}
+
+/////////////////////////////////////////////////
+Sensor *Link::SensorByIndex(uint64_t _index)
+{
+  return const_cast<Sensor*>(this->dataPtr->SensorByIndex(_index));
+}
+
+/////////////////////////////////////////////////
+const Sensor *Link::Implementation::SensorByIndex(uint64_t _index) const
+{
+  if (_index < this->sensors.size())
+    return &this->sensors[_index];
   return nullptr;
 }
 
@@ -308,7 +407,19 @@ bool Link::SensorNameExists(const std::string &_name) const
 /////////////////////////////////////////////////
 const Sensor *Link::SensorByName(const std::string &_name) const
 {
-  for (auto const &s : this->dataPtr->sensors)
+  return this->dataPtr->SensorByName(_name);
+}
+
+/////////////////////////////////////////////////
+Sensor *Link::SensorByName(const std::string &_name)
+{
+  return const_cast<Sensor*>(this->dataPtr->SensorByName(_name));
+}
+
+/////////////////////////////////////////////////
+const Sensor *Link::Implementation::SensorByName(const std::string &_name) const
+{
+  for (auto const &s : this->sensors)
   {
     if (s.Name() == _name)
     {
@@ -327,8 +438,22 @@ uint64_t Link::ParticleEmitterCount() const
 /////////////////////////////////////////////////
 const ParticleEmitter *Link::ParticleEmitterByIndex(const uint64_t _index) const
 {
-  if (_index < this->dataPtr->emitters.size())
-    return &this->dataPtr->emitters[_index];
+  return this->dataPtr->ParticleEmitterByIndex(_index);
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter *Link::ParticleEmitterByIndex(uint64_t _index)
+{
+  return const_cast<ParticleEmitter*>(
+      this->dataPtr->ParticleEmitterByIndex(_index));
+}
+
+/////////////////////////////////////////////////
+const ParticleEmitter *Link::Implementation::ParticleEmitterByIndex(
+    uint64_t _index) const
+{
+  if (_index < this->emitters.size())
+    return &this->emitters[_index];
   return nullptr;
 }
 
@@ -349,7 +474,21 @@ bool Link::ParticleEmitterNameExists(const std::string &_name) const
 const ParticleEmitter *Link::ParticleEmitterByName(
     const std::string &_name) const
 {
-  for (auto const &e : this->dataPtr->emitters)
+  return this->dataPtr->ParticleEmitterByName(_name);
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter *Link::ParticleEmitterByName(const std::string &_name)
+{
+  return const_cast<ParticleEmitter*>(
+      this->dataPtr->ParticleEmitterByName(_name));
+}
+
+/////////////////////////////////////////////////
+const ParticleEmitter *Link::Implementation::ParticleEmitterByName(
+    const std::string &_name) const
+{
+  for (auto const &e : this->emitters)
   {
     if (e.Name() == _name)
     {
@@ -358,7 +497,6 @@ const ParticleEmitter *Link::ParticleEmitterByName(
   }
   return nullptr;
 }
-
 
 /////////////////////////////////////////////////
 const ignition::math::Inertiald &Link::Inertial() const
@@ -445,7 +583,19 @@ sdf::SemanticPose Link::SemanticPose() const
 /////////////////////////////////////////////////
 const Visual *Link::VisualByName(const std::string &_name) const
 {
-  for (auto const &v : this->dataPtr->visuals)
+  return this->dataPtr->VisualByName(_name);
+}
+
+/////////////////////////////////////////////////
+Visual *Link::VisualByName(const std::string &_name)
+{
+  return const_cast<Visual*>(this->dataPtr->VisualByName(_name));
+}
+
+/////////////////////////////////////////////////
+const Visual *Link::Implementation::VisualByName(const std::string &_name) const
+{
+  for (auto const &v : this->visuals)
   {
     if (v.Name() == _name)
     {
@@ -458,7 +608,20 @@ const Visual *Link::VisualByName(const std::string &_name) const
 /////////////////////////////////////////////////
 const Collision *Link::CollisionByName(const std::string &_name) const
 {
-  for (auto const &c : this->dataPtr->collisions)
+  return this->dataPtr->CollisionByName(_name);
+}
+
+/////////////////////////////////////////////////
+Collision *Link::CollisionByName(const std::string &_name)
+{
+  return const_cast<Collision*>(this->dataPtr->CollisionByName(_name));
+}
+
+/////////////////////////////////////////////////
+const Collision *Link::Implementation::CollisionByName(
+    const std::string &_name) const
+{
+  for (auto &c : this->collisions)
   {
     if (c.Name() == _name)
     {
@@ -471,7 +634,19 @@ const Collision *Link::CollisionByName(const std::string &_name) const
 /////////////////////////////////////////////////
 const Light *Link::LightByName(const std::string &_name) const
 {
-  for (auto const &c : this->dataPtr->lights)
+  return this->dataPtr->LightByName(_name);
+}
+
+/////////////////////////////////////////////////
+Light *Link::LightByName(const std::string &_name)
+{
+  return const_cast<Light*>(this->dataPtr->LightByName(_name));
+}
+
+/////////////////////////////////////////////////
+const Light *Link::Implementation::LightByName(const std::string &_name) const
+{
+  for (auto const &c : this->lights)
   {
     if (c.Name() == _name)
     {

--- a/src/Link_TEST.cc
+++ b/src/Link_TEST.cc
@@ -414,3 +414,132 @@ TEST(DOMLink, ToElement)
   for (uint64_t i = 0; i < link2.ParticleEmitterCount(); ++i)
     EXPECT_NE(nullptr, link2.ParticleEmitterByIndex(i));
 }
+
+/////////////////////////////////////////////////
+TEST(DOMLink, MutableByIndex)
+{
+  sdf::Link link;
+  link.SetName("my-name");
+
+  sdf::Visual visual;
+  visual.SetName("visual1");
+  EXPECT_TRUE(link.AddVisual(visual));
+
+  sdf::Collision collision;
+  collision.SetName("collision1");
+  EXPECT_TRUE(link.AddCollision(collision));
+
+  sdf::Light light;
+  light.SetName("light1");
+  EXPECT_TRUE(link.AddLight(light));
+
+  sdf::Sensor sensor;
+  sensor.SetName("sensor1");
+  EXPECT_TRUE(link.AddSensor(sensor));
+
+  sdf::ParticleEmitter pe;
+  pe.SetName("pe1");
+  EXPECT_TRUE(link.AddParticleEmitter(pe));
+
+  // Modify the visual
+  sdf::Visual *v = link.VisualByIndex(0);
+  ASSERT_NE(nullptr, v);
+  EXPECT_EQ("visual1", v->Name());
+  v->SetName("visual2");
+  EXPECT_EQ("visual2", link.VisualByIndex(0)->Name());
+
+  // Modify the collision
+  sdf::Collision *c = link.CollisionByIndex(0);
+  ASSERT_NE(nullptr, c);
+  EXPECT_EQ("collision1", c->Name());
+  c->SetName("collision2");
+  EXPECT_EQ("collision2", link.CollisionByIndex(0)->Name());
+
+  // Modify the light
+  sdf::Light *l = link.LightByIndex(0);
+  ASSERT_NE(nullptr, l);
+  EXPECT_EQ("light1", l->Name());
+  l->SetName("light2");
+  EXPECT_EQ("light2", link.LightByIndex(0)->Name());
+
+  // Modify the sensor
+  sdf::Sensor *s = link.SensorByIndex(0);
+  ASSERT_NE(nullptr, s);
+  EXPECT_EQ("sensor1", s->Name());
+  s->SetName("sensor2");
+  EXPECT_EQ("sensor2", link.SensorByIndex(0)->Name());
+
+  // Modify the particle emitter
+  sdf::ParticleEmitter *p = link.ParticleEmitterByIndex(0);
+  ASSERT_NE(nullptr, p);
+  EXPECT_EQ("pe1", p->Name());
+  p->SetName("pe2");
+  EXPECT_EQ("pe2", link.ParticleEmitterByIndex(0)->Name());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMLink, MutableByName)
+{
+  sdf::Link link;
+  link.SetName("my-name");
+
+  sdf::Visual visual;
+  visual.SetName("visual1");
+  EXPECT_TRUE(link.AddVisual(visual));
+
+  sdf::Collision collision;
+  collision.SetName("collision1");
+  EXPECT_TRUE(link.AddCollision(collision));
+
+  sdf::Light light;
+  light.SetName("light1");
+  EXPECT_TRUE(link.AddLight(light));
+
+  sdf::Sensor sensor;
+  sensor.SetName("sensor1");
+  EXPECT_TRUE(link.AddSensor(sensor));
+
+  sdf::ParticleEmitter pe;
+  pe.SetName("pe1");
+  EXPECT_TRUE(link.AddParticleEmitter(pe));
+
+  // Modify the visual
+  sdf::Visual *v = link.VisualByName("visual1");
+  ASSERT_NE(nullptr, v);
+  EXPECT_EQ("visual1", v->Name());
+  v->SetName("visual2");
+  EXPECT_FALSE(link.VisualNameExists("visual1"));
+  EXPECT_TRUE(link.VisualNameExists("visual2"));
+
+  // Modify the collision
+  sdf::Collision *c = link.CollisionByName("collision1");
+  ASSERT_NE(nullptr, c);
+  EXPECT_EQ("collision1", c->Name());
+  c->SetName("collision2");
+  EXPECT_FALSE(link.CollisionNameExists("collision1"));
+  EXPECT_TRUE(link.CollisionNameExists("collision2"));
+
+  // Modify the light
+  sdf::Light *l = link.LightByName("light1");
+  ASSERT_NE(nullptr, l);
+  EXPECT_EQ("light1", l->Name());
+  l->SetName("light2");
+  EXPECT_FALSE(link.LightNameExists("light1"));
+  EXPECT_TRUE(link.LightNameExists("light2"));
+
+  // Modify the sensor
+  sdf::Sensor *s = link.SensorByName("sensor1");
+  ASSERT_NE(nullptr, s);
+  EXPECT_EQ("sensor1", s->Name());
+  s->SetName("sensor2");
+  EXPECT_FALSE(link.SensorNameExists("sensor1"));
+  EXPECT_TRUE(link.SensorNameExists("sensor2"));
+
+  // Modify the particle emitter
+  sdf::ParticleEmitter *p = link.ParticleEmitterByName("pe1");
+  ASSERT_NE(nullptr, p);
+  EXPECT_EQ("pe1", p->Name());
+  p->SetName("pe2");
+  EXPECT_FALSE(link.ParticleEmitterNameExists("pe1"));
+  EXPECT_TRUE(link.ParticleEmitterNameExists("pe2"));
+}


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

I need the ability to access mutable versions of child objects. This is part of my effort to support building and editing the SDF DOM programmatically. I've added private helper functions in order to reduce code duplication.

## Test it
Run the tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.