### PR TITLE
Use USD component visibility macro

### DIFF
--- a/usd/include/sdf/usd/sdf_parser/Light.hh
+++ b/usd/include/sdf/usd/sdf_parser/Light.hh
@@ -30,8 +30,8 @@
 #pragma pop_macro ("__DEPRECATED")
 
 #include "sdf/config.hh"
+#include "sdf/usd/Export.hh"
 #include "sdf/Light.hh"
-#include "../Export.hh"
 
 namespace sdf
 {

--- a/usd/include/sdf/usd/sdf_parser/Light.hh
+++ b/usd/include/sdf/usd/sdf_parser/Light.hh
@@ -30,8 +30,8 @@
 #pragma pop_macro ("__DEPRECATED")
 
 #include "sdf/config.hh"
-#include "sdf/system_util.hh"
 #include "sdf/Light.hh"
+#include "../Export.hh"
 
 namespace sdf
 {
@@ -48,8 +48,10 @@ namespace sdf
     /// be a valid USD path.
     /// \return Errors, which is a vector of Error objects. Each Error includes
     /// an error code and message. An empty vector indicates no error.
-    sdf::Errors SDFORMAT_VISIBLE ParseSdfLight(const sdf::Light &_light,
-        pxr::UsdStageRefPtr &_stage, const std::string &_path);
+    sdf::Errors IGNITION_SDFORMAT_USD_VISIBLE ParseSdfLight(
+        const sdf::Light &_light,
+        pxr::UsdStageRefPtr &_stage,
+        const std::string &_path);
   }
   }
 }

--- a/usd/include/sdf/usd/sdf_parser/Utils.hh
+++ b/usd/include/sdf/usd/sdf_parser/Utils.hh
@@ -36,7 +36,7 @@
 
 #include "sdf/SemanticPose.hh"
 #include "sdf/system_util.hh"
-#include "../Export.hh"
+#include "sdf/usd/Export.hh"
 
 namespace sdf
 {

--- a/usd/include/sdf/usd/sdf_parser/Utils.hh
+++ b/usd/include/sdf/usd/sdf_parser/Utils.hh
@@ -35,8 +35,8 @@
 #pragma pop_macro ("__DEPRECATED")
 
 #include "sdf/SemanticPose.hh"
-#include "sdf/config.hh"
 #include "sdf/system_util.hh"
+#include "../Export.hh"
 
 namespace sdf
 {
@@ -52,7 +52,8 @@ namespace sdf
     /// \return _obj's pose w.r.t. its parent. If there was an error computing
     /// this pose, the pose's position will be NaNs.
     template <typename T>
-    inline ignition::math::Pose3d SDFORMAT_VISIBLE PoseWrtParent(const T &_obj)
+    inline ignition::math::Pose3d IGNITION_SDFORMAT_USD_VISIBLE
+    PoseWrtParent(const T &_obj)
     {
       ignition::math::Pose3d pose(ignition::math::Vector3d::NaN,
           ignition::math::Quaterniond::Identity);
@@ -70,8 +71,10 @@ namespace sdf
     /// \param[in] _stage The stage that contains the USD prim at path _usdPath.
     /// \param[in] _usdPath The path to the USD prim that should have its
     /// pose modified to match _pose.
-    inline void SDFORMAT_VISIBLE SetPose(const ignition::math::Pose3d &_pose,
-        pxr::UsdStageRefPtr &_stage, const pxr::SdfPath &_usdPath)
+    inline void IGNITION_SDFORMAT_USD_VISIBLE SetPose(
+        const ignition::math::Pose3d &_pose,
+        pxr::UsdStageRefPtr &_stage,
+        const pxr::SdfPath &_usdPath)
     {
       pxr::UsdGeomXformCommonAPI geomXformAPI(_stage->GetPrimAtPath(_usdPath));
 

--- a/usd/include/sdf/usd/sdf_parser/World.hh
+++ b/usd/include/sdf/usd/sdf_parser/World.hh
@@ -30,8 +30,8 @@
 #pragma pop_macro ("__DEPRECATED")
 
 #include "sdf/config.hh"
-#include "sdf/system_util.hh"
 #include "sdf/World.hh"
+#include "../Export.hh"
 
 namespace sdf
 {
@@ -48,8 +48,10 @@ namespace sdf
     /// a valid USD path.
     /// \return Errors, which is a vector of Error objects. Each Error includes
     /// an error code and message. An empty vector indicates no error.
-    sdf::Errors SDFORMAT_VISIBLE ParseSdfWorld(const sdf::World &_world,
-        pxr::UsdStageRefPtr &_stage, const std::string &_path);
+    sdf::Errors IGNITION_SDFORMAT_USD_VISIBLE ParseSdfWorld(
+        const sdf::World &_world,
+        pxr::UsdStageRefPtr &_stage,
+        const std::string &_path);
   }
   }
 }

--- a/usd/include/sdf/usd/sdf_parser/World.hh
+++ b/usd/include/sdf/usd/sdf_parser/World.hh
@@ -30,8 +30,8 @@
 #pragma pop_macro ("__DEPRECATED")
 
 #include "sdf/config.hh"
+#include "sdf/usd/Export.hh"
 #include "sdf/World.hh"
-#include "../Export.hh"
 
 namespace sdf
 {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes visibility macros in USD component. Part of https://github.com/ignitionrobotics/sdformat/issues/845.

## Summary

Each ign-cmake component has its own Export.hh header file and its own visibility macros, so use the proper visibility macros in the header files of the USD component.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
