### PR TITLE
Added to light if the light is on or off

### DIFF
--- a/include/sdf/Light.hh
+++ b/include/sdf/Light.hh
@@ -126,6 +126,14 @@ namespace sdf
     /// \param[in] _cast True to indicate that the light casts shadows.
     public: void SetCastShadows(const bool _cast);
 
+    /// \brief Get if the light is on
+    /// \return True if the light is on.
+    public: bool LightOn() const;
+
+    /// \brief Set if the light is ON/OFF
+    /// \param[in] _cast True to indicate that the light is on, False otherwise.
+    public: void SetLightOn(const bool _isLightOn);
+
     /// \brief Get the light intensity
     /// \return The light intensity
     public: double Intensity() const;

--- a/sdf/1.8/light.sdf
+++ b/sdf/1.8/light.sdf
@@ -14,6 +14,10 @@
     <description>When true, the light will cast shadows.</description>
   </element>
 
+  <element name="light_on" type="bool" default="true" required="0">
+    <description>When true, the light is on.</description>
+  </element>
+
   <element name="intensity" type="double" default="1" required="0">
     <description>Scale factor to set the relative power of a light.</description>
   </element>

--- a/src/Light.cc
+++ b/src/Light.cc
@@ -83,6 +83,9 @@ class sdf::Light::Implementation
 
   /// \brief Spot light falloff.
   public: double spotFalloff = 0.0;
+
+  /// \brief Is light on ?
+  public: bool isLightOn = true;
 };
 
 /////////////////////////////////////////////////
@@ -140,6 +143,9 @@ Errors Light::Load(ElementPtr _sdf)
 
   // Load the pose. Ignore the return value since the light pose is optional.
   loadPose(_sdf, this->dataPtr->pose, this->dataPtr->poseRelativeTo);
+
+  this->dataPtr->isLightOn = _sdf->Get<bool>("light_on",
+      this->dataPtr->isLightOn).first;
 
   this->dataPtr->castShadows = _sdf->Get<bool>("cast_shadows",
       this->dataPtr->castShadows).first;
@@ -314,6 +320,18 @@ bool Light::CastShadows() const
 void Light::SetCastShadows(const bool _cast)
 {
   this->dataPtr->castShadows = _cast;
+}
+
+/////////////////////////////////////////////////
+bool Light::LightOn() const
+{
+  return this->dataPtr->isLightOn;
+}
+
+/////////////////////////////////////////////////
+void Light::SetLightOn(const bool _isLightOn)
+{
+  this->dataPtr->isLightOn = _isLightOn;
 }
 
 /////////////////////////////////////////////////

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -55,6 +55,10 @@ TEST(DOMLight, DefaultConstruction)
     EXPECT_FALSE(semanticPose.Resolve(pose).empty());
   }
 
+  EXPECT_TRUE(light.LightOn());
+  light.SetLightOn(false);
+  EXPECT_FALSE(light.LightOn());
+
   EXPECT_FALSE(light.CastShadows());
   light.SetCastShadows(true);
   EXPECT_TRUE(light.CastShadows());
@@ -113,6 +117,7 @@ TEST(DOMLight, CopyConstructor)
   light.SetRawPose({3, 2, 1, 0, IGN_PI, 0});
   light.SetPoseRelativeTo("ground_plane");
   light.SetCastShadows(true);
+  light.SetLightOn(false);
   light.SetDiffuse(ignition::math::Color(0.4f, 0.5f, 0.6f, 1.0));
   light.SetSpecular(ignition::math::Color(0.8f, 0.9f, 0.1f, 1.0));
   light.SetAttenuationRange(3.2);
@@ -131,6 +136,7 @@ TEST(DOMLight, CopyConstructor)
   EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), light2.RawPose());
   EXPECT_EQ("ground_plane", light2.PoseRelativeTo());
   EXPECT_TRUE(light2.CastShadows());
+  EXPECT_FALSE(light2.LightOn());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 1), light2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.8f, 0.9f, 0.1f, 1), light2.Specular());
   EXPECT_DOUBLE_EQ(3.2, light2.AttenuationRange());
@@ -153,6 +159,7 @@ TEST(DOMLight, CopyAssignmentOperator)
   light.SetRawPose({3, 2, 1, 0, IGN_PI, 0});
   light.SetPoseRelativeTo("ground_plane");
   light.SetCastShadows(true);
+  light.SetLightOn(false);
   light.SetDiffuse(ignition::math::Color(0.4f, 0.5f, 0.6f, 1.0));
   light.SetSpecular(ignition::math::Color(0.8f, 0.9f, 0.1f, 1.0));
   light.SetAttenuationRange(3.2);
@@ -172,6 +179,7 @@ TEST(DOMLight, CopyAssignmentOperator)
   EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), light2.RawPose());
   EXPECT_EQ("ground_plane", light2.PoseRelativeTo());
   EXPECT_TRUE(light2.CastShadows());
+  EXPECT_FALSE(light2.LightOn());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 1), light2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.8f, 0.9f, 0.1f, 1), light2.Specular());
   EXPECT_DOUBLE_EQ(3.2, light2.AttenuationRange());
@@ -194,6 +202,7 @@ TEST(DOMLight, MoveConstructor)
   light.SetRawPose({3, 2, 1, 0, IGN_PI, 0});
   light.SetPoseRelativeTo("ground_plane");
   light.SetCastShadows(true);
+  light.SetLightOn(false);
   light.SetDiffuse(ignition::math::Color(0.4f, 0.5f, 0.6f, 1.0));
   light.SetSpecular(ignition::math::Color(0.8f, 0.9f, 0.1f, 1.0));
   light.SetAttenuationRange(3.2);
@@ -212,6 +221,7 @@ TEST(DOMLight, MoveConstructor)
   EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), light2.RawPose());
   EXPECT_EQ("ground_plane", light2.PoseRelativeTo());
   EXPECT_TRUE(light2.CastShadows());
+  EXPECT_FALSE(light2.LightOn());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 1), light2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.8f, 0.9f, 0.1f, 1), light2.Specular());
   EXPECT_DOUBLE_EQ(3.2, light2.AttenuationRange());
@@ -234,6 +244,7 @@ TEST(DOMLight, MoveAssignment)
   light.SetRawPose({3, 2, 1, 0, IGN_PI, 0});
   light.SetPoseRelativeTo("ground_plane");
   light.SetCastShadows(true);
+  light.SetLightOn(false);
   light.SetDiffuse(ignition::math::Color(0.4f, 0.5f, 0.6f, 1.0));
   light.SetSpecular(ignition::math::Color(0.8f, 0.9f, 0.1f, 1.0));
   light.SetAttenuationRange(3.2);
@@ -253,6 +264,7 @@ TEST(DOMLight, MoveAssignment)
   EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), light2.RawPose());
   EXPECT_EQ("ground_plane", light2.PoseRelativeTo());
   EXPECT_TRUE(light2.CastShadows());
+  EXPECT_FALSE(light2.LightOn());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 1), light2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.8f, 0.9f, 0.1f, 1), light2.Specular());
   EXPECT_DOUBLE_EQ(3.2, light2.AttenuationRange());


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🎉 New feature

## Summary

Related with:
 - Issues: Related with this issue https://github.com/ignitionrobotics/ign-gazebo/issues/638
 - PR https://github.com/ignitionrobotics/ign-gazebo/pull/1343

This will allow to define if a light is on or off.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
