### PR TITLE
Fix bug where //include/pose was ignored when using the Interface API 

### DIFF
--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -514,7 +514,8 @@ struct ModelWrapper : public WrapperBase
       : WrapperBase{_ifaceModel.Name(), "Interface Model",
                     _ifaceModel.Static() ? FrameType::STATIC_MODEL
                                          : FrameType::MODEL},
-        rawPose(_ifaceModel.ModelFramePoseInParentFrame()),
+        rawPose(_nestedInclude.IncludeRawPose().value_or(
+            _ifaceModel.ModelFramePoseInParentFrame())),
         rawRelativeTo(_nestedInclude.IncludePoseRelativeTo().value_or("")),
         relativeTo(rawRelativeTo),
         canonicalLinkName(_ifaceModel.CanonicalLinkName()),

--- a/test/integration/interface_api.cc
+++ b/test/integration/interface_api.cc
@@ -85,7 +85,7 @@ class CustomTomlParser
 {
   /// \brief Constructor
   /// \param[in] _supportsMergeInclude Whether the parser supports merge include
-  /// \param[in] _overridePoseInParser Whether the parser should apply pose 
+  /// \param[in] _overridePoseInParser Whether the parser should apply pose
   /// overrides from //include/pose
   public: CustomTomlParser(bool _supportsMergeInclude = true,
                            bool _overridePoseInParser = true)

--- a/test/integration/model/double_pendulum.toml
+++ b/test/integration/model/double_pendulum.toml
@@ -2,7 +2,7 @@
 # very limited toml parser that is not capable of parsing the full toml syntax.
 # Specifically, arrays are not supported.
 name = "double_pendulum"
-pose = "1 0 0 0 0 0"
+pose = "1 2 3 0 0 0"
 canonical_link = "base"
 
 [links.base]


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Pose overrides made using `//include/pose` were not working if the parser did not set the pose of the `sdf::InterfaceModel` it returns equal to whatever is in `//include/pose`. I believe this regression occurred in #764 and I've created #852 to clarify what the parser is expected to do.

1f2d4e902dc37087977bdda0978aeec4459ce249 adds a failing test showing the problem and with the fix in the subsequent commit.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- ~[] Updated documentation (as needed)~
- ~[ ] Updated migration guide (as needed)~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.