### PR TITLE
Fix joint parent/child frame existence checks to include interface elements

### DIFF
--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -346,6 +346,19 @@ namespace sdf
     public: const NestedInclude *InterfaceModelNestedIncludeByIndex(
                 const uint64_t _index) const;
 
+
+    /// \brief Check if a given name exists in the FrameAttachedTo graph at the
+    /// scope of the model.
+    /// \param[in] _name Name of the implicit or explicit frame to check.
+    /// To check for a frame in a nested model, prefix the frame name with
+    /// the sequence of nested models containing this frame, delimited by "::".
+    /// \return True if the frame name is found in the FrameAttachedTo graph.
+    /// False otherwise, or if the frame graph is invalid.
+    /// \note This function assumes the model has a valid FrameAttachedTo graph.
+    /// It will return false if the graph is invalid.
+    public: bool NameExistsInFrameAttachedToGraph(
+                const std::string &_name) const;
+
     /// \brief Give the scoped PoseRelativeToGraph to be used for resolving
     /// poses. This is private and is intended to be called by Root::Load or
     /// World::SetPoseRelativeToGraph if this is a standalone model and

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -790,3 +790,13 @@ const NestedInclude *Model::InterfaceModelNestedIncludeByIndex(
     return &this->dataPtr->interfaceModels[_index].first;
   return nullptr;
 }
+
+/////////////////////////////////////////////////
+bool Model::NameExistsInFrameAttachedToGraph(const std::string &_name) const
+{
+  if (!this->dataPtr->frameAttachedToGraph)
+    return false;
+
+  return this->dataPtr->frameAttachedToGraph.VertexIdByName(sdf::JoinName(
+             this->Name(), _name)) != ignition::math::graph::kNullId;
+}

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2259,9 +2259,7 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
       const std::string parentLocalName = sdf::SplitName(parentName).second;
 
       if (parentName != "world" && parentLocalName != "__model__" &&
-          !_model->LinkNameExists(parentName) &&
-          !_model->JointNameExists(parentName) &&
-          !_model->FrameNameExists(parentName))
+          !_model->NameExistsInFrameAttachedToGraph(parentName))
       {
         errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
           "parent frame with name[" + parentName +
@@ -2278,10 +2276,8 @@ void checkJointParentChildNames(const sdf::Root *_root, Errors &_errors)
           joint->Name() + "] in model with name[" + _model->Name() + "]."});
       }
 
-      if (childLocalName != "__model__" && !_model->LinkNameExists(childName) &&
-          !_model->JointNameExists(childName) &&
-          !_model->FrameNameExists(childName) &&
-          !_model->ModelNameExists(childName))
+      if (childLocalName != "__model__" &&
+          !_model->NameExistsInFrameAttachedToGraph(childName))
       {
         errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
           "child frame with name[" + childName +

--- a/test/integration/interface_api.cc
+++ b/test/integration/interface_api.cc
@@ -858,3 +858,35 @@ TEST_F(InterfaceAPI, NameCollision)
     EXPECT_EQ(sdf::ErrorCode::DUPLICATE_NAME, errors[0].Code());
   }
 }
+
+/////////////////////////////////////////////////
+TEST_F(InterfaceAPI, JointParentOrChildInNestedModel)
+{
+  this->config.RegisterCustomModelParser(customTomlParser);
+
+  const std::string testSdf = R"(
+  <sdf version="1.8">
+    <model name="parent_model">
+      <link name="L1"/>
+
+      <joint name="J1" type="fixed">
+        <parent>L1</parent>
+        <child>double_pendulum::base</child>
+      </joint>
+      <include>
+        <uri>double_pendulum.toml</uri>
+        <name>double_pendulum</name>
+      </include>
+
+      <joint name="J2" type="fixed">
+        <parent>double_pendulum::child_dp::base</parent>
+        <child>L2</child>
+      </joint>
+      <link name="L2"/>
+
+    </model>
+  </sdf>)";
+  sdf::Root root;
+  sdf::Errors errors = root.LoadSdfString(testSdf, this->config);
+  EXPECT_TRUE(errors.empty()) << errors;
+}

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -309,6 +309,23 @@ TEST(DOMRoot, MultiNestedModel)
   EXPECT_EQ(innerModel->FrameByIndex(0),
             outerModel->FrameByName(innerFrameNestedName));
   EXPECT_NE(nullptr, outerModel->FrameByName(innerFrameNestedName));
+
+
+  // Check that each implicit/explicit frame is in the frame attached to graph
+  EXPECT_TRUE(outerModel->NameExistsInFrameAttachedToGraph("outer_link"));
+  EXPECT_TRUE(outerModel->NameExistsInFrameAttachedToGraph("outer_joint"));
+  EXPECT_TRUE(outerModel->NameExistsInFrameAttachedToGraph("outer_frame"));
+  EXPECT_TRUE(outerModel->NameExistsInFrameAttachedToGraph("mid_model"));
+
+  // Check that mid_link does not exist directly under outer_model, but can be
+  // accessed via its scoped name
+  EXPECT_FALSE(outerModel->NameExistsInFrameAttachedToGraph("mid_link"));
+  EXPECT_TRUE(
+      outerModel->NameExistsInFrameAttachedToGraph("mid_model::mid_link"));
+
+  // Check multiple levels of nesting
+  EXPECT_TRUE(outerModel->NameExistsInFrameAttachedToGraph(
+      "mid_model::inner_model::inner_joint"));
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Names in `//joint/parent` or `//joint/child` that reference frames inside a nested model that was included via the Interface API cause errors when loading a model. I believe this is a regression that was introduced when fixing #719 via #727.

9b8a2bdb373c373ca6aa270a7526ed0e543989a8 adds a failing test showing the regression with the following failure message:
```
Value of: errors.empty()
  Actual: false
Expected: true
Error Code 19: Msg: child frame with name[double_pendulum::base] specified by joint with name[J1] not found in model with name[parent_model].
Error Code 20: Msg: parent frame with name[double_pendulum::child_dp::base] specified by joint with name[J2] not found in model with name[parent_model].
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

