### PR TITLE
Remove USD visibility macro from internal APIs

### DIFF
--- a/usd/src/UsdUtils.hh
+++ b/usd/src/UsdUtils.hh
@@ -42,7 +42,6 @@
 #include "sdf/SemanticPose.hh"
 #include "sdf/Visual.hh"
 #include "sdf/system_util.hh"
-#include "sdf/usd/Export.hh"
 #include "sdf/usd/UsdError.hh"
 
 namespace sdf
@@ -60,8 +59,7 @@ namespace sdf
     /// \return UsdErrors, which is a vector of UsdError objects. Each UsdError
     /// includes an error code and message. An empty vector indicates no error.
     template <typename T>
-    inline UsdErrors IGNITION_SDFORMAT_USD_VISIBLE
-    PoseWrtParent(const T &_obj, ignition::math::Pose3d &_pose)
+    inline UsdErrors PoseWrtParent(const T &_obj, ignition::math::Pose3d &_pose)
     {
       UsdErrors errors;
       const auto poseResolutionErrors = _obj.SemanticPose().Resolve(_pose, "");
@@ -85,8 +83,7 @@ namespace sdf
     /// pose modified to match _pose.
     /// \return UsdErrors, which is a vector of UsdError objects. Each UsdError
     /// includes an error code and message. An empty vector indicates no error.
-    inline UsdErrors IGNITION_SDFORMAT_USD_VISIBLE SetPose(
-        const ignition::math::Pose3d &_pose,
+    inline UsdErrors SetPose(const ignition::math::Pose3d &_pose,
         pxr::UsdStageRefPtr &_stage,
         const pxr::SdfPath &_usdPath)
     {
@@ -132,7 +129,7 @@ namespace sdf
     /// and one collision that have a plane geometry. False otherwise
     /// \note This method will no longer be needed when a pxr::USDGeomPlane
     /// class is created
-    inline bool SDFORMAT_VISIBLE IsPlane(const sdf::Model &_model)
+    inline bool IsPlane(const sdf::Model &_model)
     {
       if (!_model.Static() || _model.LinkCount() != 1u)
         return false;


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

# 🦟 Bug fix

## Summary
As discussed in https://github.com/ignitionrobotics/sdformat/pull/828#discussion_r809811749, internal APIs of the USD component (in this case, `usd/src/UsdUtils.hh`) do not need to have visibility macros applied to them since they aren't meant to be exposed to downstream users.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.