### PR TITLE
Use the Plugin DOM in other DOM objects

### DIFF
--- a/include/sdf/Actor.hh
+++ b/include/sdf/Actor.hh
@@ -27,6 +27,7 @@
 #include "sdf/Types.hh"
 #include "sdf/Link.hh"
 #include "sdf/Joint.hh"
+#include "sdf/Plugin.hh"
 #include "sdf/sdf_config.h"
 #include "sdf/system_util.hh"
 
@@ -382,6 +383,23 @@ namespace sdf
     /// actor.
     /// \return SDF element pointer with updated actor values.
     public: sdf::ElementPtr ToElement() const;
+
+    /// \brief Get the plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: const sdf::Plugins &Plugins() const;
+
+    /// \brief Get a mutable vector of plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: sdf::Plugins &Plugins();
+
+    /// \brief Remove all plugins
+    public: void ClearPlugins();
+
+    /// \brief Add a plugin to this object.
+    /// \param[in] _plugin Plugin to add.
+    public: void AddPlugin(const Plugin &_plugin);
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Gui.hh
+++ b/include/sdf/Gui.hh
@@ -81,9 +81,19 @@ namespace sdf
     /// \brief Remove all plugins
     public: void ClearPlugins();
 
-    /// \brief Add a plugin to the link.
+    /// \brief Add a plugin to this object.
     /// \param[in] _plugin Plugin to add.
     public: void AddPlugin(const Plugin &_plugin);
+
+    /// \brief Get the plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: const sdf::Plugins &Plugins() const;
+
+    /// \brief Get a mutable vector of plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: sdf::Plugins &Plugins();
 
     /// \brief Private data pointer.
     IGN_UTILS_IMPL_PTR(dataPtr)

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -24,6 +24,7 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/utils/ImplPtr.hh>
 #include "sdf/Element.hh"
+#include "sdf/Plugin.hh"
 #include "sdf/SemanticPose.hh"
 #include "sdf/Types.hh"
 #include "sdf/sdf_config.h"
@@ -471,6 +472,23 @@ namespace sdf
     /// \brief Set the URI associated with this model.
     /// \param[in] _uri The model's URI.
     public: void SetUri(const std::string &_uri);
+
+    /// \brief Get the plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: const sdf::Plugins &Plugins() const;
+
+    /// \brief Get a mutable vector of plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: sdf::Plugins &Plugins();
+
+    /// \brief Remove all plugins
+    public: void ClearPlugins();
+
+    /// \brief Add a plugin to this object.
+    /// \param[in] _plugin Plugin to add.
+    public: void AddPlugin(const Plugin &_plugin);
 
     /// \brief Give the scoped PoseRelativeToGraph to be used for resolving
     /// poses. This is private and is intended to be called by Root::Load or

--- a/include/sdf/Plugin.hh
+++ b/include/sdf/Plugin.hh
@@ -23,6 +23,7 @@
 
 #include <sdf/Element.hh>
 #include <sdf/Error.hh>
+#include <sdf/parser.hh>
 #include <sdf/Types.hh>
 #include "sdf/sdf_config.h"
 #include "sdf/system_util.hh"
@@ -122,9 +123,44 @@ namespace sdf
     /// \return A reference to this plugin
     public: Plugin &operator=(Plugin &&_plugin) noexcept;
 
+    /// \brief Output stream operator for a Plugin.
+    /// \param[in] _out The output stream
+    /// \param[in] _plugin Plugin to output
+    public: friend std::ostream &operator<<(std::ostream& _out,
+                                            const sdf::Plugin &_plugin)
+    {
+      return _out << _plugin.ToElement()->ToString("");
+    }
+
+    /// \brief Input stream operator for a Plugin.
+    /// \param[in] _out The output stream
+    /// \param[in] _plugin Plugin to output
+    public: friend std::istream &operator>>(std::istream &_in,
+                                            sdf::Plugin &_plugin)
+    {
+      std::ostringstream stream;
+      stream << "<sdf version='" << SDF_VERSION << "'>";
+      stream << std::string(std::istreambuf_iterator<char>(_in), {});
+      stream << "</sdf>";
+
+      sdf::SDFPtr sdfParsed(new sdf::SDF());
+      sdf::init(sdfParsed);
+      bool result = sdf::readString(stream.str(), sdfParsed);
+      if (!result)
+        return _in;
+
+      _plugin.ClearContents();
+      _plugin.Load(sdfParsed->Root()->GetFirstElement());
+
+      return _in;
+    }
+
     /// \brief Private data pointer.
     std::unique_ptr<sdf::PluginPrivate> dataPtr;
   };
+
+  /// \brief A vector of Plugin.
+  using Plugins = std::vector<Plugin>;
 }
 }
 

--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -22,6 +22,7 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/utils/ImplPtr.hh>
 #include "sdf/Element.hh"
+#include "sdf/Plugin.hh"
 #include "sdf/SemanticPose.hh"
 #include "sdf/Types.hh"
 #include "sdf/sdf_config.h"
@@ -397,6 +398,23 @@ namespace sdf
     /// \brief Set the lidar sensor.
     /// \param[in] _lidar The lidar sensor.
     public: void SetLidarSensor(const Lidar &_lidar);
+
+    /// \brief Get the plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: const sdf::Plugins &Plugins() const;
+
+    /// \brief Get a mutable vector of plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: sdf::Plugins &Plugins();
+
+    /// \brief Remove all plugins
+    public: void ClearPlugins();
+
+    /// \brief Add a plugin to this object.
+    /// \param[in] _plugin Plugin to add.
+    public: void AddPlugin(const Plugin &_plugin);
 
     /// \brief Give the name of the xml parent of this object, to be used
     /// for resolving poses. This is private and is intended to be called by

--- a/include/sdf/Visual.hh
+++ b/include/sdf/Visual.hh
@@ -26,6 +26,7 @@
 #include "sdf/Element.hh"
 #include "sdf/Material.hh"
 #include "sdf/Plane.hh"
+#include "sdf/Plugin.hh"
 #include "sdf/SemanticPose.hh"
 #include "sdf/Sphere.hh"
 #include "sdf/Types.hh"
@@ -164,6 +165,23 @@ namespace sdf
     /// visual.
     /// \return SDF element pointer with updated visual values.
     public: sdf::ElementPtr ToElement() const;
+
+    /// \brief Get the plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: const sdf::Plugins &Plugins() const;
+
+    /// \brief Get a mutable vector of plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: sdf::Plugins &Plugins();
+
+    /// \brief Remove all plugins
+    public: void ClearPlugins();
+
+    /// \brief Add a plugin to this object.
+    /// \param[in] _plugin Plugin to add.
+    public: void AddPlugin(const Plugin &_plugin);
 
     /// \brief Give the name of the xml parent of this object, to be used
     /// for resolving poses. This is private and is intended to be called by

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -27,6 +27,7 @@
 #include "sdf/Atmosphere.hh"
 #include "sdf/Element.hh"
 #include "sdf/Gui.hh"
+#include "sdf/Plugin.hh"
 #include "sdf/Scene.hh"
 #include "sdf/Types.hh"
 #include "sdf/sdf_config.h"
@@ -430,6 +431,23 @@ namespace sdf
     /// world.
     /// \return SDF element pointer with updated world values.
     public: sdf::ElementPtr ToElement() const;
+
+    /// \brief Get the plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: const sdf::Plugins &Plugins() const;
+
+    /// \brief Get a mutable vector of plugins attached to this object.
+    /// \return A vector of Plugin, which will be empty if there are no
+    /// plugins.
+    public: sdf::Plugins &Plugins();
+
+    /// \brief Remove all plugins
+    public: void ClearPlugins();
+
+    /// \brief Add a plugin to this object.
+    /// \param[in] _plugin Plugin to add.
+    public: void AddPlugin(const Plugin &_plugin);
 
     /// \brief Give the Scoped PoseRelativeToGraph to be passed on to child
     /// entities for resolving poses. This is private and is intended to be

--- a/src/Actor.cc
+++ b/src/Actor.cc
@@ -20,6 +20,7 @@
 #include "sdf/Actor.hh"
 #include "sdf/Error.hh"
 #include "sdf/parser.hh"
+#include "sdf/Plugin.hh"
 #include "Utils.hh"
 
 using namespace sdf;
@@ -113,6 +114,9 @@ class sdf::Actor::Implementation
 
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf;
+
+  /// \brief Actor plugins.
+  public: std::vector<Plugin> plugins;
 };
 
 /////////////////////////////////////////////////
@@ -454,6 +458,11 @@ Errors Actor::Load(ElementPtr _sdf)
   errors.insert(errors.end(), jointLoadErrors.begin(),
                     jointLoadErrors.end());
 
+  // Load the actor plugins
+  Errors pluginErrors = loadRepeated<Plugin>(_sdf, "plugin",
+    this->dataPtr->plugins);
+  errors.insert(errors.end(), pluginErrors.begin(), pluginErrors.end());
+
   return errors;
 }
 
@@ -780,5 +789,33 @@ sdf::ElementPtr Actor::ToElement() const
   for (const sdf::Link &link : this->dataPtr->links)
     elem->InsertElement(link.ToElement(), true);
 
+  // Add in the plugins
+  for (const Plugin &plugin : this->dataPtr->plugins)
+    elem->InsertElement(plugin.ToElement(), true);
+
   return elem;
+}
+
+/////////////////////////////////////////////////
+const sdf::Plugins &Actor::Plugins() const
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+sdf::Plugins &Actor::Plugins()
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+void Actor::ClearPlugins()
+{
+  this->dataPtr->plugins.clear();
+}
+
+/////////////////////////////////////////////////
+void Actor::AddPlugin(const Plugin &_plugin)
+{
+  this->dataPtr->plugins.push_back(_plugin);
 }

--- a/src/Actor_TEST.cc
+++ b/src/Actor_TEST.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <ignition/math/Pose3.hh>
 #include "sdf/Actor.hh"
+#include "sdf/Plugin.hh"
 
 /////////////////////////////////////////////////
 sdf::Animation CreateDummyAnimation()
@@ -561,6 +562,11 @@ TEST(DOMActor, ToElement)
   animation.SetScale(1.2);
   animation.SetInterpolateX(true);
 
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+  actor.AddPlugin(plugin);
+
   sdf::ElementPtr elem = actor.ToElement();
   ASSERT_NE(nullptr, elem);
 
@@ -598,4 +604,32 @@ TEST(DOMActor, ToElement)
   ASSERT_NE(nullptr, waypointB2);
   EXPECT_DOUBLE_EQ(waypointB.Time(), waypointB2->Time());
   EXPECT_EQ(waypointB.Pose(), waypointB2->Pose());
+
+  ASSERT_EQ(1u, actor2.Plugins().size());
+  EXPECT_EQ("name1", actor2.Plugins()[0].Name());
+  EXPECT_EQ("filename1", actor2.Plugins()[0].Filename());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMActor, Plugins)
+{
+  sdf::Actor actor;
+  EXPECT_TRUE(actor.Plugins().empty());
+
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+
+  actor.AddPlugin(plugin);
+  ASSERT_EQ(1u, actor.Plugins().size());
+
+  plugin.SetName("name2");
+  actor.AddPlugin(plugin);
+  ASSERT_EQ(2u, actor.Plugins().size());
+
+  EXPECT_EQ("name1", actor.Plugins()[0].Name());
+  EXPECT_EQ("name2", actor.Plugins()[1].Name());
+
+  actor.ClearPlugins();
+  EXPECT_TRUE(actor.Plugins().empty());
 }

--- a/src/Gui.cc
+++ b/src/Gui.cc
@@ -133,3 +133,17 @@ void Gui::AddPlugin(const Plugin &_plugin)
 {
   this->dataPtr->plugins.push_back(_plugin);
 }
+
+/////////////////////////////////////////////////
+const sdf::Plugins &Gui::Plugins() const
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+sdf::Plugins &Gui::Plugins()
+{
+  return this->dataPtr->plugins;
+}
+
+

--- a/src/Gui_TEST.cc
+++ b/src/Gui_TEST.cc
@@ -144,8 +144,10 @@ TEST(DOMGui, ToElement)
     if (j == 0)
     {
       EXPECT_EQ(6u, gui.PluginCount());
+      EXPECT_EQ(6u, gui.Plugins().size());
       gui.ClearPlugins();
       EXPECT_EQ(0u, gui.PluginCount());
+      EXPECT_TRUE(gui.Plugins().empty());
     }
   }
 

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -106,6 +106,9 @@ class sdf::Model::Implementation
   /// \brief Optional URI string that specifies where this model was or
   /// can be loaded from.
   public: std::string uri = "";
+
+  /// \brief Model plugins.
+  public: std::vector<Plugin> plugins;
 };
 
 /////////////////////////////////////////////////
@@ -379,6 +382,10 @@ Errors Model::Load(sdf::ElementPtr _sdf, const ParserConfig &_config)
     frameNames.insert(frameName);
   }
 
+  // Load the model plugins
+  Errors pluginErrors = loadRepeated<Plugin>(_sdf, "plugin",
+    this->dataPtr->plugins);
+  errors.insert(errors.end(), pluginErrors.begin(), pluginErrors.end());
 
   return errors;
 }
@@ -1000,6 +1007,10 @@ sdf::ElementPtr Model::ToElement(bool _useIncludeTag) const
   for (const sdf::Model &model : this->dataPtr->models)
     elem->InsertElement(model.ToElement(_useIncludeTag), true);
 
+  // Add in the plugins
+  for (const Plugin &plugin : this->dataPtr->plugins)
+    elem->InsertElement(plugin.ToElement(), true);
+
   return elem;
 }
 
@@ -1061,4 +1072,28 @@ bool Model::AddFrame(const Frame &_frame)
 void Model::ClearFrames()
 {
   this->dataPtr->frames.clear();
+}
+
+/////////////////////////////////////////////////
+const sdf::Plugins &Model::Plugins() const
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+sdf::Plugins &Model::Plugins()
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+void Model::ClearPlugins()
+{
+  this->dataPtr->plugins.clear();
+}
+
+/////////////////////////////////////////////////
+void Model::AddPlugin(const Plugin &_plugin)
+{
+  this->dataPtr->plugins.push_back(_plugin);
 }

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -373,6 +373,11 @@ TEST(DOMModel, ToElement)
       model.ClearModels();
   }
 
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+  model.AddPlugin(plugin);
+
   sdf::ElementPtr elem = model.ToElement();
   ASSERT_NE(nullptr, elem);
 
@@ -399,6 +404,10 @@ TEST(DOMModel, ToElement)
   EXPECT_EQ(model.ModelCount(), model2.ModelCount());
   for (uint64_t i = 0; i < model2.ModelCount(); ++i)
     EXPECT_NE(nullptr, model2.ModelByIndex(i));
+
+  ASSERT_EQ(1u, model2.Plugins().size());
+  EXPECT_EQ("name1", model2.Plugins()[0].Name());
+  EXPECT_EQ("filename1", model2.Plugins()[0].Filename());
 }
 
 /////////////////////////////////////////////////
@@ -609,4 +618,28 @@ TEST(DOMModel, MutableByName)
   f->SetName("frame2");
   EXPECT_FALSE(model.FrameNameExists("frame1"));
   EXPECT_TRUE(model.FrameNameExists("frame2"));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMModel, Plugins)
+{
+  sdf::Model model;
+  EXPECT_TRUE(model.Plugins().empty());
+
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+
+  model.AddPlugin(plugin);
+  ASSERT_EQ(1u, model.Plugins().size());
+
+  plugin.SetName("name2");
+  model.AddPlugin(plugin);
+  ASSERT_EQ(2u, model.Plugins().size());
+
+  EXPECT_EQ("name1", model.Plugins()[0].Name());
+  EXPECT_EQ("name2", model.Plugins()[1].Name());
+
+  model.ClearPlugins();
+  EXPECT_TRUE(model.Plugins().empty());
 }

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -466,8 +466,7 @@ void handleIndividualChildActions(const ParserConfig &_config,
 
     if (actionStr == "add")
     {
-      _elem->InsertElement(elemChild);
-      elemChild->SetParent(_elem);
+      _elem->InsertElement(elemChild->Clone(), true);
     }
     else if (actionStr == "replace")
     {
@@ -511,8 +510,7 @@ void add(const ParserConfig &_config, const std::string &_source,
 
   if (xmlToSdf(_config, _source, _childXml, newElem, _errors))
   {
-    _elem->InsertElement(newElem);
-    newElem->SetParent(_elem);
+    _elem->InsertElement(newElem, true);
   }
   else
   {

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -262,3 +262,59 @@ TEST(DOMPlugin, ToElement)
   EXPECT_EQ(1u, plugin2.Contents().size());
   EXPECT_EQ("an-element", plugin2.Contents()[0]->GetName());
 }
+
+/////////////////////////////////////////////////
+TEST(DOMPlugin, OutputStreamOperator)
+{
+  sdf::Plugin plugin;
+  plugin.SetName("my-plugin");
+  EXPECT_EQ("my-plugin", plugin.Name());
+
+  plugin.SetFilename("filename.so");
+  EXPECT_EQ("filename.so", plugin.Filename());
+
+  sdf::ElementPtr content(new sdf::Element);
+  content->SetName("an-element");
+  plugin.InsertContent(content);
+  EXPECT_EQ(1u, plugin.Contents().size());
+
+  sdf::ElementPtr elem = plugin.ToElement();
+  ASSERT_NE(nullptr, elem);
+  std::string elemString = elem->ToString("");
+
+  std::ostringstream stream;
+  stream << plugin;
+
+  EXPECT_EQ(elemString, stream.str());
+
+  // The expected plugin output string.
+  std::string expected = R"foo(<plugin name='my-plugin' filename='filename.so'>
+  <an-element/>
+</plugin>
+)foo";
+
+  EXPECT_EQ(expected, stream.str());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMPlugin, InputStreamOperator)
+{
+  // The provided plugin input string.
+  std::string input = R"foo(<plugin name='my-plugin' filename='filename.so'>
+  <an-element/>
+</plugin>
+)foo";
+  std::istringstream stream(input);
+
+  sdf::Plugin plugin;
+  stream >> plugin;
+
+  EXPECT_EQ("my-plugin", plugin.Name());
+  EXPECT_EQ("filename.so", plugin.Filename());
+  EXPECT_EQ(1u, plugin.Contents().size());
+
+  sdf::ElementPtr elem = plugin.ToElement();
+  ASSERT_NE(nullptr, elem);
+  std::string elemString = elem->ToString("");
+  EXPECT_EQ(input, elemString);
+}

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -129,6 +129,9 @@ class sdf::Sensor::Implementation
   /// \brief The frequency at which the sensor data is generated.
   /// If left unspecified (0.0), the sensor will generate data every cycle.
   public: double updateRate = 0.0;
+
+  /// \brief Sensor plugins.
+  public: std::vector<Plugin> plugins;
 };
 
 /////////////////////////////////////////////////
@@ -397,6 +400,11 @@ Errors Sensor::Load(ElementPtr _sdf)
 
   // Load the pose. Ignore the return value since the sensor pose is optional.
   loadPose(_sdf, this->dataPtr->pose, this->dataPtr->poseRelativeTo);
+
+  // Load the sensor plugins
+  Errors pluginErrors = loadRepeated<Plugin>(_sdf, "plugin",
+    this->dataPtr->plugins);
+  errors.insert(errors.end(), pluginErrors.begin(), pluginErrors.end());
 
   return errors;
 }
@@ -755,5 +763,34 @@ sdf::ElementPtr Sensor::ToElement() const
     std::cout << "Conversion of sensor type: [" << this->TypeStr() << "] from "
       << "SDF DOM to Element is not supported yet." << std::endl;
   }
+
+  // Add in the plugins
+  for (const Plugin &plugin : this->dataPtr->plugins)
+    elem->InsertElement(plugin.ToElement(), true);
+
   return elem;
+}
+
+/////////////////////////////////////////////////
+const sdf::Plugins &Sensor::Plugins() const
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+sdf::Plugins &Sensor::Plugins()
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+void Sensor::ClearPlugins()
+{
+  this->dataPtr->plugins.clear();
+}
+
+/////////////////////////////////////////////////
+void Sensor::AddPlugin(const Plugin &_plugin)
+{
+  this->dataPtr->plugins.push_back(_plugin);
 }

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -520,6 +520,11 @@ TEST(DOMSensor, ToElement)
   mag.SetXNoise(noise);
   sensor.SetMagnetometerSensor(mag);
 
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+  sensor.AddPlugin(plugin);
+
   sdf::ElementPtr sensorElem = sensor.ToElement();
   EXPECT_NE(nullptr, sensorElem);
   EXPECT_EQ(nullptr, sensor.Element());
@@ -537,6 +542,10 @@ TEST(DOMSensor, ToElement)
                    sensor2.MagnetometerSensor()->XNoise().Mean());
   EXPECT_DOUBLE_EQ(0.123, sensor2.UpdateRate());
 
+  ASSERT_EQ(1u, sensor2.Plugins().size());
+  EXPECT_EQ("name1", sensor2.Plugins()[0].Name());
+  EXPECT_EQ("filename1", sensor2.Plugins()[0].Filename());
+
   // make changes to DOM and verify ToElement produces updated values
   sensor2.SetUpdateRate(1.23);
   sdf::ElementPtr sensor2Elem = sensor2.ToElement();
@@ -544,4 +553,28 @@ TEST(DOMSensor, ToElement)
   sdf::Sensor sensor3;
   sensor3.Load(sensor2Elem);
   EXPECT_DOUBLE_EQ(1.23, sensor3.UpdateRate());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMSensor, Plugins)
+{
+  sdf::Sensor sensor;
+  EXPECT_TRUE(sensor.Plugins().empty());
+
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+
+  sensor.AddPlugin(plugin);
+  ASSERT_EQ(1u, sensor.Plugins().size());
+
+  plugin.SetName("name2");
+  sensor.AddPlugin(plugin);
+  ASSERT_EQ(2u, sensor.Plugins().size());
+
+  EXPECT_EQ("name1", sensor.Plugins()[0].Name());
+  EXPECT_EQ("name2", sensor.Plugins()[1].Name());
+
+  sensor.ClearPlugins();
+  EXPECT_TRUE(sensor.Plugins().empty());
 }

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -68,6 +68,9 @@ class sdf::Visual::Implementation
 
   /// \brief Lidar reflective intensity
   public: double laserRetro = 0;
+
+  /// \brief Visual plugins.
+  public: std::vector<Plugin> plugins;
 };
 
 /////////////////////////////////////////////////
@@ -148,6 +151,11 @@ Errors Visual::Load(ElementPtr _sdf)
   {
     this->SetLaserRetro(_sdf->Get<double>("laser_retro"));
   }
+
+  // Load the visual plugins
+  Errors pluginErrors = loadRepeated<Plugin>(_sdf, "plugin",
+    this->dataPtr->plugins);
+  errors.insert(errors.end(), pluginErrors.begin(), pluginErrors.end());
 
   return errors;
 }
@@ -332,5 +340,33 @@ sdf::ElementPtr Visual::ToElement() const
     elem->InsertElement(this->dataPtr->material->ToElement(), true);
   }
 
+  // Add in the plugins
+  for (const Plugin &plugin : this->dataPtr->plugins)
+    elem->InsertElement(plugin.ToElement(), true);
+
   return elem;
+}
+
+/////////////////////////////////////////////////
+const sdf::Plugins &Visual::Plugins() const
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+sdf::Plugins &Visual::Plugins()
+{
+  return this->dataPtr->plugins;
+}
+
+/////////////////////////////////////////////////
+void Visual::ClearPlugins()
+{
+  this->dataPtr->plugins.clear();
+}
+
+/////////////////////////////////////////////////
+void Visual::AddPlugin(const Plugin &_plugin)
+{
+  this->dataPtr->plugins.push_back(_plugin);
 }

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -304,6 +304,11 @@ TEST(DOMVisual, ToElement)
   sdf::Material mat;
   visual.SetMaterial(mat);
 
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+  visual.AddPlugin(plugin);
+
   sdf::ElementPtr elem = visual.ToElement();
   ASSERT_NE(nullptr, elem);
 
@@ -319,4 +324,32 @@ TEST(DOMVisual, ToElement)
   EXPECT_DOUBLE_EQ(visual.LaserRetro(), visual2.LaserRetro());
   EXPECT_NE(nullptr, visual2.Geom());
   EXPECT_NE(nullptr, visual2.Material());
+
+  ASSERT_EQ(1u, visual2.Plugins().size());
+  EXPECT_EQ("name1", visual2.Plugins()[0].Name());
+  EXPECT_EQ("filename1", visual2.Plugins()[0].Filename());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMVisual, Plugins)
+{
+  sdf::Visual visual;
+  EXPECT_TRUE(visual.Plugins().empty());
+
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+
+  visual.AddPlugin(plugin);
+  ASSERT_EQ(1u, visual.Plugins().size());
+
+  plugin.SetName("name2");
+  visual.AddPlugin(plugin);
+  ASSERT_EQ(2u, visual.Plugins().size());
+
+  EXPECT_EQ("name1", visual.Plugins()[0].Name());
+  EXPECT_EQ("name2", visual.Plugins()[1].Name());
+
+  visual.ClearPlugins();
+  EXPECT_TRUE(visual.Plugins().empty());
 }

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -529,6 +529,11 @@ TEST(DOMWorld, ToElement)
       world.ClearPhysics();
   }
 
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+  world.AddPlugin(plugin);
+
   sdf::ElementPtr elem = world.ToElement();
   ASSERT_NE(nullptr, elem);
 
@@ -566,6 +571,10 @@ TEST(DOMWorld, ToElement)
   EXPECT_EQ(world.PhysicsCount(), world2.PhysicsCount());
   for (uint64_t i = 0; i < world2.PhysicsCount(); ++i)
     EXPECT_NE(nullptr, world2.PhysicsByIndex(i));
+
+  ASSERT_EQ(1u, world2.Plugins().size());
+  EXPECT_EQ("name1", world2.Plugins()[0].Name());
+  EXPECT_EQ("filename1", world2.Plugins()[0].Filename());
 }
 
 /////////////////////////////////////////////////
@@ -657,4 +666,28 @@ TEST(DOMWorld, MutableByName)
   f->SetName("frame2");
   EXPECT_FALSE(world.FrameByName("frame1"));
   EXPECT_TRUE(world.FrameByName("frame2"));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMWorld, Plugins)
+{
+  sdf::World world;
+  EXPECT_TRUE(world.Plugins().empty());
+
+  sdf::Plugin plugin;
+  plugin.SetName("name1");
+  plugin.SetFilename("filename1");
+
+  world.AddPlugin(plugin);
+  ASSERT_EQ(1u, world.Plugins().size());
+
+  plugin.SetName("name2");
+  world.AddPlugin(plugin);
+  ASSERT_EQ(2u, world.Plugins().size());
+
+  EXPECT_EQ("name1", world.Plugins()[0].Name());
+  EXPECT_EQ("name2", world.Plugins()[1].Name());
+
+  world.ClearPlugins();
+  EXPECT_TRUE(world.Plugins().empty());
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -15,6 +15,7 @@ set(tests
   force_torque_sensor.cc
   frame.cc
   geometry_dom.cc
+  gui_dom.cc
   include.cc
   includes.cc
   interface_api.cc
@@ -47,6 +48,7 @@ set(tests
   sdf_basic.cc
   sdf_custom.cc
   sdf_dom_conversion.cc
+  sensor_dom.cc
   surface_dom.cc
   unknown.cc
   urdf_gazebo_extensions.cc

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -159,3 +159,28 @@ TEST(DOMActor, CopySdfLoadedProperties)
   EXPECT_EQ(actor1.LinkCount(), actor2->LinkCount());
   EXPECT_EQ(actor1.JointCount(), actor2->JointCount());
 }
+
+//////////////////////////////////////////////////
+TEST(DOMActor, ActorPlugins)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(testFile, root.Element()->FilePath());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  const sdf::Actor *actor = world->ActorByIndex(0);
+  ASSERT_NE(nullptr, actor);
+
+  ASSERT_EQ(2u, actor->Plugins().size());
+  EXPECT_EQ("actor_plugin1", actor->Plugins()[0].Name());
+  EXPECT_EQ("test/file/actor1", actor->Plugins()[0].Filename());
+  EXPECT_EQ("actor_plugin2", actor->Plugins()[1].Name());
+  EXPECT_EQ("test/file/actor2", actor->Plugins()[1].Filename());
+}

--- a/test/integration/gui_dom.cc
+++ b/test/integration/gui_dom.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <string>
+#include <gtest/gtest.h>
+
+#include "sdf/Gui.hh"
+#include "sdf/World.hh"
+#include "test_config.h"
+#include "test_utils.hh"
+
+//////////////////////////////////////////////////
+TEST(DOMGui, GuiPlugins)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(testFile, root.Element()->FilePath());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  const sdf::Gui *gui = world->Gui();
+  ASSERT_NE(nullptr, gui);
+
+  ASSERT_EQ(2u, gui->Plugins().size());
+  EXPECT_EQ("gui_plugin1", gui->Plugins()[0].Name());
+  EXPECT_EQ("test/file/gui1", gui->Plugins()[0].Filename());
+  EXPECT_EQ("gui_plugin2", gui->Plugins()[1].Name());
+  EXPECT_EQ("test/file/gui2", gui->Plugins()[1].Filename());
+}

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -645,3 +645,28 @@ TEST(DOMModel, LoadModelWithDuplicateChildNames)
     EXPECT_TRUE(buffer.str().empty()) << buffer.str();
   }
 }
+
+//////////////////////////////////////////////////
+TEST(DOMModel, ModelPlugins)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(testFile, root.Element()->FilePath());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+
+  ASSERT_EQ(2u, model->Plugins().size());
+  EXPECT_EQ("model_plugin1", model->Plugins()[0].Name());
+  EXPECT_EQ("test/file/model1", model->Plugins()[0].Filename());
+  EXPECT_EQ("model_plugin2", model->Plugins()[1].Name());
+  EXPECT_EQ("test/file/model2", model->Plugins()[1].Filename());
+}

--- a/test/integration/param_passing.cc
+++ b/test/integration/param_passing.cc
@@ -17,7 +17,11 @@
 #include <string>
 #include <gtest/gtest.h>
 #include "sdf/Filesystem.hh"
+#include "sdf/Link.hh"
+#include "sdf/Model.hh"
 #include "sdf/Root.hh"
+#include "sdf/Visual.hh"
+#include "sdf/World.hh"
 #include "test_config.h"
 
 void PrintErrors(sdf::Errors &_errors)
@@ -162,4 +166,37 @@ TEST(ParamPassingTest, NestedInclude)
   EXPECT_EQ(root.Element()->ToString(""), expectedRoot.Element()->ToString(""))
         << "ACTUAL:\n" << root.Element()->ToString("\t")
         << "\nEXPECTED:\n" << expectedRoot.Element()->ToString("\t");
+}
+
+/////////////////////////////////////////////////
+TEST(ParamPassingTest, CheckPluginClone)
+{
+  const std::string modelRootPath =
+    sdf::testing::TestFile("integration", "model");
+  sdf::setFindCallback(
+      [&](const std::string &_file)
+      {
+        return sdf::filesystem::append(modelRootPath, _file);
+      });
+
+  // checks <include> containing <experimental:params> w/ correctly specified
+  // elements
+  sdf::Root root;
+  std::string testFile = sdf::testing::TestFile("integration",
+      "include_custom_model.sdf");
+  sdf::Errors errors = root.Load(testFile);
+  PrintErrors(errors);
+  EXPECT_TRUE(errors.empty());
+
+  sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  sdf::Model *model = world->ModelByName("robot");
+  ASSERT_NE(nullptr, model);
+  sdf::Model *nestedModel = model->ModelByName("vehicle");
+  ASSERT_NE(nullptr, nestedModel);
+  sdf::Link *link = nestedModel->LinkByName("top");
+  ASSERT_NE(nullptr, link);
+  sdf::Visual *visual = link->VisualByName("camera_visual");
+  ASSERT_NE(nullptr, visual);
+  EXPECT_EQ(4u, visual->Plugins().size());
 }

--- a/test/integration/sensor_dom.cc
+++ b/test/integration/sensor_dom.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <string>
+#include <gtest/gtest.h>
+
+#include "sdf/Link.hh"
+#include "sdf/Model.hh"
+#include "sdf/Sensor.hh"
+#include "sdf/World.hh"
+#include "test_config.h"
+#include "test_utils.hh"
+
+//////////////////////////////////////////////////
+TEST(DOMSensor, SensorPlugins)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(testFile, root.Element()->FilePath());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+
+  const sdf::Link *link = model->LinkByIndex(0);
+  ASSERT_NE(nullptr, link);
+
+  const sdf::Sensor *sensor = link->SensorByIndex(0);
+  ASSERT_NE(nullptr, sensor);
+
+  ASSERT_EQ(2u, sensor->Plugins().size());
+  EXPECT_EQ("sensor_plugin1", sensor->Plugins()[0].Name());
+  EXPECT_EQ("test/file/sensor1", sensor->Plugins()[0].Filename());
+  EXPECT_EQ("sensor_plugin2", sensor->Plugins()[1].Name());
+  EXPECT_EQ("test/file/sensor2", sensor->Plugins()[1].Filename());
+}

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -28,6 +28,7 @@
 #include "sdf/Root.hh"
 #include "sdf/Types.hh"
 #include "sdf/Visual.hh"
+#include "sdf/World.hh"
 #include "test_config.h"
 
 //////////////////////////////////////////////////
@@ -435,4 +436,35 @@ TEST(DOMVisual, VisibilityFlags)
   ASSERT_NE(nullptr, vis1);
 
   EXPECT_EQ(0x00000001u, vis1->VisibilityFlags());
+}
+
+//////////////////////////////////////////////////
+TEST(DOMVisual, VisualPlugins)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(testFile, root.Element()->FilePath());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+
+  const sdf::Link *link = model->LinkByIndex(0);
+  ASSERT_NE(nullptr, link);
+
+  const sdf::Visual *visual = link->VisualByIndex(0);
+  ASSERT_NE(nullptr, visual);
+
+  ASSERT_EQ(2u, visual->Plugins().size());
+  EXPECT_EQ("visual_plugin1", visual->Plugins()[0].Name());
+  EXPECT_EQ("test/file/visual1", visual->Plugins()[0].Filename());
+  EXPECT_EQ("visual_plugin2", visual->Plugins()[1].Name());
+  EXPECT_EQ("test/file/visual2", visual->Plugins()[1].Filename());
 }

--- a/test/integration/world_dom.cc
+++ b/test/integration/world_dom.cc
@@ -358,3 +358,25 @@ TEST(DOMWorld, LoadWorldWithDuplicateChildNames)
     EXPECT_TRUE(buffer.str().empty()) << buffer.str();
   }
 }
+
+//////////////////////////////////////////////////
+TEST(DOMWorld, WorldPlugins)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(testFile, root.Element()->FilePath());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  ASSERT_EQ(2u, world->Plugins().size());
+  EXPECT_EQ("world_plugin1", world->Plugins()[0].Name());
+  EXPECT_EQ("test/file/world1", world->Plugins()[0].Filename());
+  EXPECT_EQ("world_plugin2", world->Plugins()[1].Name());
+  EXPECT_EQ("test/file/world2", world->Plugins()[1].Filename());
+}

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -27,6 +27,8 @@
       <heading_deg>90</heading_deg>
     </spherical_coordinates>
     <gui fullscreen="true">
+      <plugin name="gui_plugin1" filename="test/file/gui1"/>
+      <plugin name="gui_plugin2" filename="test/file/gui2"/>
     </gui>
     <scene>
       <ambient>0.3 0.4 0.5</ambient>
@@ -111,7 +113,35 @@
             <falloff>2.2</falloff>
           </spot>
         </light>
+        <visual name="link_visual">
+          <geometry>
+            <box><size>1 1 1</size></box>
+          </geometry>
+          <plugin name="visual_plugin1" filename="test/file/visual1"/>
+          <plugin name="visual_plugin2" filename="test/file/visual2"/>
+        </visual>
+
+        <sensor name="altimeter_sensor" type="altimeter">
+          <altimeter>
+            <vertical_position>
+              <noise type="gaussian">
+                <mean>0.1</mean>
+                <stddev>0.2</stddev>
+              </noise>
+            </vertical_position>
+            <vertical_velocity>
+              <noise type="gaussian">
+                <mean>2.3</mean>
+                <stddev>4.5</stddev>
+              </noise>
+            </vertical_velocity>
+          </altimeter>
+          <plugin name="sensor_plugin1" filename="test/file/sensor1"/>
+          <plugin name="sensor_plugin2" filename="test/file/sensor2"/>
+        </sensor>
       </link>
+      <plugin name="model_plugin1" filename="test/file/model1"/>
+      <plugin name="model_plugin2" filename="test/file/model2"/>
     </model>
 
     <actor name="actor_1">
@@ -148,6 +178,8 @@
           </waypoint>
         </trajectory>
       </script>
+      <plugin name="actor_plugin1" filename="test/file/actor1"/>
+      <plugin name="actor_plugin2" filename="test/file/actor2"/>
     </actor>
 
     <actor name="actor_2">
@@ -224,6 +256,9 @@
         <parent>link2</parent>
       </joint>
     </actor>
+
+    <plugin name="world_plugin1" filename="test/file/world1"/>
+    <plugin name="world_plugin2" filename="test/file/world2"/>
 
   </world>
 </sdf>


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

A lot of file have changed, but most of the changes all follow an identical pattern.

There is a `Plugin` DOM object, but only the `GUI` DOM object was using it. This is particularly problematic when attempting to build and use a programmatically created DOM. For example, Ignition Gazebo is currently relying on the `Element()` function(s) to access plugin information. This will not work for programmatically create DOM objects.

I've also added input and output stream operators to the `Plugin` class. This is here to facilitate the use of [VectorSerialization](https://github.com/ignitionrobotics/ign-gazebo/blob/91a79da407b913b1e6bc6b96739a80f6e7254f18/include/ignition/gazebo/components/Serialization.hh#L231). This is also the reason why I choose to access a `std::vector` of `Plugins` rather than use the `ByIndex` and `ByName` pattern.

Example usage in https://github.com/ignitionrobotics/ign-gazebo/pull/1352.

## Test it
Run the tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.