### PR TITLE
USD -> SDF: Added cmd line tool

### DIFF
--- a/usd/src/CMakeLists.txt
+++ b/usd/src/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(${usd_target}
 
 set(gtest_sources
   sdf_parser/sdf2usd_TEST.cc
+  usd_parser/usd2sdf_TEST.cc
   sdf_parser/Geometry_Sdf2Usd_TEST.cc
   sdf_parser/Joint_Sdf2Usd_TEST.cc
   sdf_parser/Light_Sdf2Usd_TEST.cc

--- a/usd/src/cmd/CMakeLists.txt
+++ b/usd/src/cmd/CMakeLists.txt
@@ -9,9 +9,20 @@ if(TARGET ${usd_target})
       ${usd_target}
   )
 
+  add_executable(usd2sdf
+    usd2sdf.cc
+  )
+
+  target_link_libraries(usd2sdf
+    PUBLIC
+      ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
+      ${usd_target}
+  )
+
   install(
     TARGETS
     	sdf2usd
+    	usd2sdf
     DESTINATION
     	${BIN_INSTALL_DIR}
   )

--- a/usd/src/cmd/usd2sdf.cc
+++ b/usd/src/cmd/usd2sdf.cc
@@ -15,11 +15,12 @@
  *
  */
 
-#include <string.h>
+#include <iostream>
+#include <string>
 
 #include <ignition/utils/cli/CLI.hpp>
 
-#include "sdf/sdf.hh"
+#include "sdf/config.hh"
 
 //////////////////////////////////////////////////
 /// \brief Enumeration of available commands
@@ -44,7 +45,8 @@ struct Options
 
 void runCommand(const Options &/*_opt*/)
 {
-  // TODO(ahcorde): Call here the USD to SDF conversor code
+  // TODO(ahcorde): Call here the USD to SDF converter code
+  std::cerr << "USD to SDF conversion is not implemented yet.\n";
 }
 
 void addFlags(CLI::App &_app)

--- a/usd/src/cmd/usd2sdf.cc
+++ b/usd/src/cmd/usd2sdf.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <string.h>
+
+#include <ignition/utils/cli/CLI.hpp>
+
+#include "sdf/sdf.hh"
+
+//////////////////////////////////////////////////
+/// \brief Enumeration of available commands
+enum class Command
+{
+  kNone,
+};
+
+//////////////////////////////////////////////////
+/// \brief Structure to hold all filenames
+struct Options
+{
+  /// \brief Command to execute
+  Command command{Command::kNone};
+
+  /// \brief input filename
+  std::string inputFilename{"input.usd"};
+
+  /// \brief output filename
+  std::string outputFilename{"output.sdf"};
+};
+
+void runCommand(const Options &/*_opt*/)
+{
+  // TODO(ahcorde): Call here the USD to SDF conversor code
+}
+
+void addFlags(CLI::App &_app)
+{
+  auto opt = std::make_shared<Options>();
+
+  _app.add_option("input",
+    opt->inputFilename,
+    "Input filename. Defaults to input.usd unless otherwise specified.");
+
+  _app.add_option("output",
+    opt->outputFilename,
+    "Output filename. Defaults to output.sdf unless otherwise specified.");
+
+  _app.callback([&_app, opt](){
+    runCommand(*opt);
+  });
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char** argv)
+{
+  CLI::App app{"USD to SDF converter"};
+
+  app.set_help_all_flag("--help-all", "Show all help");
+
+  app.add_flag_callback("--version", [](){
+    std::cout << SDF_VERSION_FULL << std::endl;
+    throw CLI::Success();
+  });
+
+  addFlags(app);
+  CLI11_PARSE(app, argc, argv);
+
+  return 0;
+}

--- a/usd/src/usd_parser/usd2sdf_TEST.cc
+++ b/usd/src/usd_parser/usd2sdf_TEST.cc
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/Filesystem.hh>
-#include <ignition/common/TempDirectory.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "test_config.h"

--- a/usd/src/usd_parser/usd2sdf_TEST.cc
+++ b/usd/src/usd_parser/usd2sdf_TEST.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/TempDirectory.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
+
+#include "test_config.h"
+#include "test_utils.hh"
+
+#ifdef _WIN32
+  #define popen  _popen
+  #define pclose _pclose
+#endif
+
+static std::string usd2sdfCommand()
+{
+  return ignition::common::joinPaths(std::string(PROJECT_BINARY_DIR), "bin",
+      "usd2sdf");
+}
+
+/////////////////////////////////////////////////
+std::string custom_exec_str(std::string _cmd)
+{
+  _cmd += " 2>&1";
+  FILE *pipe = popen(_cmd.c_str(), "r");
+
+  if (!pipe)
+    return "ERROR";
+
+  char buffer[128];
+  std::string result = "";
+
+  while (!feof(pipe))
+  {
+    if (fgets(buffer, 128, pipe) != NULL)
+      result += buffer;
+  }
+
+  pclose(pipe);
+  return result;
+}
+
+/////////////////////////////////////////////////
+TEST(version_cmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+{
+  // Check a good SDF file
+  {
+    std::string output =
+      custom_exec_str(usd2sdfCommand() + " --version");
+
+    EXPECT_EQ(output, std::string(SDF_VERSION_FULL) + "\n");
+
+    // TODO(ahcorde): Check the contents of outputUsdFilePath when the parser
+    // is implemented
+  }
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR builds on top of this other PR https://github.com/ignitionrobotics/sdformat/pull/827. It adds the cmd line tool `usd2sdf`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.