### PR TITLE
Make `computeMergedModelProxyFrameName` public

### DIFF
--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -444,6 +444,13 @@ namespace sdf
   /// \return True if the element should be validated
   SDFORMAT_VISIBLE
   bool shouldValidateElement(sdf::ElementPtr _elem);
+
+  /// \brief Function to compute a merged model's proxy frame name
+  ///
+  /// \param [in] _modelName The merged model's name
+  /// \return The computed frame name
+  SDFORMAT_VISIBLE
+  std::string computeMergedModelProxyFrameName(const std::string &_modelName);
   }
 }
 #endif

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -304,11 +304,5 @@ sdf::Errors loadIncludedInterfaceModels(sdf::ElementPtr _sdf,
 
   return allErrors;
 }
-
-/////////////////////////////////////////////////
-std::string computeMergedModelProxyFrameName(const std::string &_modelName)
-{
-  return "_merged__" + _modelName + "__model__";
-}
 }
 }

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -229,11 +229,6 @@ namespace sdf
       return &_opt.value();
     return nullptr;
   }
-
-  /// \brief Function to compute a merged model's proxy frame name
-  /// \param [in] _modelName The merged model's name
-  /// \return The computed frame name
-  std::string computeMergedModelProxyFrameName(const std::string &_modelName);
 }
 }
 #endif

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -2648,5 +2648,11 @@ bool shouldValidateElement(sdf::ElementPtr _elem)
 
   return true;
 }
+
+/////////////////////////////////////////////////
+std::string computeMergedModelProxyFrameName(const std::string &_modelName)
+{
+  return "_merged__" + _modelName + "__model__";
+}
 }
 }


### PR DESCRIPTION

# 🎉 New feature

## Summary
This function may be used by downstream applications (e.g. applications
that utilize the Interface API) to determine the name of the proxy frame
created for a merged model.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
