### PR TITLE
sdf2usd: fix wrong scaling on ellipsoid

### DIFF
--- a/test/sdf/ellipsoid.sdf
+++ b/test/sdf/ellipsoid.sdf
@@ -1,0 +1,62 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <world name="ellipsoid_world">
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>10 10</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>10 10</size>
+            </plane>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+    <model name="ellipsoid">
+      <pose>0 3.0 0.5 0 0 0</pose>
+      <link name="ellipsoid_link">
+        <inertial>
+          <inertia>
+            <ixx>0.068</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.058</iyy>
+            <iyz>0</iyz>
+            <izz>0.026</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="ellipsoid_collision">
+          <geometry>
+            <ellipsoid>
+              <radii>0.2 0.3 0.5</radii>
+            </ellipsoid>
+          </geometry>
+        </collision>
+        <visual name="ellipsoid_visual">
+          <geometry>
+            <ellipsoid>
+              <radii>0.2 0.3 0.5</radii>
+            </ellipsoid>
+          </geometry>
+          <material>
+            <ambient>1 0 1 1</ambient>
+            <diffuse>1 0 1 1</diffuse>
+            <specular>1 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/usd/src/sdf_parser/Geometry.cc
+++ b/usd/src/sdf_parser/Geometry.cc
@@ -550,18 +550,17 @@ namespace usd
       return errors;
     }
 
-    const float maxRadii = sdfEllipsoid->Radii().Max();
-    usdEllipsoid.CreateRadiusAttr().Set(maxRadii);
+    usdEllipsoid.CreateRadiusAttr().Set(1.0);
     pxr::UsdGeomXformCommonAPI xform(usdEllipsoid);
     xform.SetScale(pxr::GfVec3f{
-      static_cast<float>(sdfEllipsoid->Radii().X() / maxRadii),
-      static_cast<float>(sdfEllipsoid->Radii().Y() / maxRadii),
-      static_cast<float>(sdfEllipsoid->Radii().Z() / maxRadii),
+      static_cast<float>(sdfEllipsoid->Radii().X()),
+      static_cast<float>(sdfEllipsoid->Radii().Y()),
+      static_cast<float>(sdfEllipsoid->Radii().Z()),
     });
     // extents is the bounds before any transformation
     pxr::VtArray<pxr::GfVec3f> extentBounds;
-    extentBounds.push_back(pxr::GfVec3f{-maxRadii});
-    extentBounds.push_back(pxr::GfVec3f{maxRadii});
+    extentBounds.push_back(pxr::GfVec3f{-1.0f});
+    extentBounds.push_back(pxr::GfVec3f{1.0f});
     usdEllipsoid.CreateExtentAttr().Set(extentBounds);
 
     return errors;

--- a/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
@@ -82,6 +82,49 @@ class UsdStageFixture : public::testing::Test
 };
 
 /////////////////////////////////////////////////
+TEST_F(UsdStageFixture, Ellipsoid)
+{
+  const auto testFile = sdf::testing::TestFile("sdf", "ellipsoid.sdf");
+
+  sdf::Root root;
+  ASSERT_TRUE(sdf::testing::LoadSdfFile(testFile, root));
+  ASSERT_EQ(1u, root.WorldCount());
+  const auto world = root.WorldByIndex(0u);
+
+  const auto worldPath = std::string("/" + world->Name());
+  const auto usdErrors = sdf::usd::ParseSdfWorld(*world, stage, worldPath);
+  EXPECT_TRUE(usdErrors.empty());
+
+  const auto usdSphere = pxr::UsdGeomSphere::Define(this->stage, pxr::SdfPath("/ellipsoid_world/ellipsoid/ellipsoid_link/ellipsoid_visual/geometry"));
+  ASSERT_TRUE(usdSphere);
+  bool resetXformStack;
+  const auto xformOps = usdSphere.GetOrderedXformOps(&resetXformStack);
+  ASSERT_EQ(xformOps.size(), 1);
+  EXPECT_FALSE(resetXformStack);
+  const auto scaleOp = xformOps[0];
+  EXPECT_EQ(scaleOp.GetOpType(), pxr::UsdGeomXformOp::TypeScale);
+  pxr::GfVec3f scaleValue;
+  scaleOp.Get(&scaleValue);
+  EXPECT_FLOAT_EQ(scaleValue[0], 0.2);
+  EXPECT_FLOAT_EQ(scaleValue[1], 0.3);
+  EXPECT_FLOAT_EQ(scaleValue[2], 0.5);
+
+  double radius;
+  EXPECT_TRUE(usdSphere.GetRadiusAttr().Get(&radius));
+  EXPECT_DOUBLE_EQ(radius, 1);
+
+  pxr::VtArray<pxr::GfVec3f> extent;
+  usdSphere.GetExtentAttr().Get(&extent);
+  ASSERT_EQ(extent.size(), 2);
+  EXPECT_FLOAT_EQ(extent[0][0], -1.0f);
+  EXPECT_FLOAT_EQ(extent[0][1], -1.0f);
+  EXPECT_FLOAT_EQ(extent[0][2], -1.0f);
+  EXPECT_FLOAT_EQ(extent[1][0], 1.0f);
+  EXPECT_FLOAT_EQ(extent[1][1], 1.0f);
+  EXPECT_FLOAT_EQ(extent[1][2], 1.0f);
+}
+
+/////////////////////////////////////////////////
 TEST_F(UsdStageFixture, Geometry)
 {
   sdf::setFindCallback(sdf::usd::testing::findFileCb);


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The ellipsoid conversion results in wrong scale transformations
![image](https://user-images.githubusercontent.com/45189696/157193887-30bad62d-c3c3-45f6-baef-b533b22b285c.png)

After fixing it
![image](https://user-images.githubusercontent.com/45189696/157194037-a1322e72-c794-4e12-ac23-41d2af0f1e39.png)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.