### PR TITLE
Run cpplint/cppcheck on Focal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         uses: ignition-tooling/action-ignition-ci@focal
         with:
           codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
   jammy-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Jammy CI

--- a/usd/include/sdf/usd/sdf_parser/Light.hh
+++ b/usd/include/sdf/usd/sdf_parser/Light.hh
@@ -20,7 +20,7 @@
 
 #include <string>
 
-// TODO(adlarkin):this is to remove deprecated "warnings" in usd, these warnings
+// TODO(adlarkin) this is to remove deprecated "warnings" in usd, these warnings
 // are reported using #pragma message so normal diagnostic flags cannot remove
 // them. This workaround requires this block to be used whenever usd is
 // included.

--- a/usd/include/sdf/usd/sdf_parser/World.hh
+++ b/usd/include/sdf/usd/sdf_parser/World.hh
@@ -20,7 +20,7 @@
 
 #include <string>
 
-// TODO(ahcorde):this is to remove deprecated "warnings" in usd, these warnings
+// TODO(ahcorde) this is to remove deprecated "warnings" in usd, these warnings
 // are reported using #pragma message so normal diagnostic flags cannot remove
 // them. This workaround requires this block to be used whenever usd is
 // included.

--- a/usd/include/sdf/usd/usd_parser/USDData.hh
+++ b/usd/include/sdf/usd/usd_parser/USDData.hh
@@ -52,18 +52,18 @@ namespace sdf
 
       /// \brief Initialize the data inside the class with the stage
       /// defined in the constructor
-      /// \return Errors, which is a vector of Error objects. Each Error includes
+      /// \return A vector of Error objects. Each Error includes
       /// an error code and message. An empty vector indicates no error.
       public: UsdErrors Init();
 
       /// \brief If a stage contains substages, this will allow to include
       /// them.
-      /// \return Errors, which is a vector of Error objects. Each Error includes
+      /// \return A vector of Error objects. Each Error includes
       /// an error code and message. An empty vector indicates no error.
       public: UsdErrors AddStage(const std::string &_ref);
 
       /// \brief Read materials
-      /// \return Errors, which is a vector of Error objects. Each Error includes
+      /// \return A vector of Error objects. Each Error includes
       /// an error code and message. An empty vector indicates no error.
       public: UsdErrors ParseMaterials();
 

--- a/usd/include/sdf/usd/usd_parser/USDStage.hh
+++ b/usd/include/sdf/usd/usd_parser/USDStage.hh
@@ -47,7 +47,7 @@ namespace sdf
       public: explicit USDStage(const std::string &_refFileName);
 
       /// \brief Initialize the data structure
-      /// \return Errors, which is a vector of Error objects. Each Error includes
+      /// \return A vector of Error objects. Each Error includes
       /// an error code and message. An empty vector indicates no error.
       public: UsdErrors Init();
 

--- a/usd/src/UsdTestUtils.hh
+++ b/usd/src/UsdTestUtils.hh
@@ -227,9 +227,9 @@ void CheckInertial(const pxr::UsdPrim &_usdPrim,
   EXPECT_EQ(_isRigid, _usdPrim.HasAPI<pxr::UsdPhysicsRigidBodyAPI>());
   EXPECT_EQ(_isRigid, _usdPrim.HasAPI<pxr::UsdPhysicsMassAPI>());
 }
-} // namespace testing
-} // namespace usd
+}  // namespace testing
+}  // namespace usd
 }
-} // namespace sdf
+}  // namespace sdf
 
 #endif

--- a/usd/src/sdf_parser/Link_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Link_Sdf2Usd_TEST.cc
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 
-// TODO(ahcorde):this is to remove deprecated "warnings" in usd, these warnings
+// TODO(ahcorde) this is to remove deprecated "warnings" in usd, these warnings
 // are reported using #pragma message so normal diagnostic flags cannot remove
 // them. This workaround requires this block to be used whenever usd is
 // included.
@@ -121,7 +121,8 @@ TEST_F(UsdStageFixture, Link)
         ignition::math::Vector3d(2, 0, 2.5),
         ignition::math::Quaterniond(0, 0, 0)));
   std::string cylinderLinkPath = cylinderPath + "/" + "link";
-  auto cylinderLink = this->stage->GetPrimAtPath(pxr::SdfPath(cylinderLinkPath));
+  auto cylinderLink =
+      this->stage->GetPrimAtPath(pxr::SdfPath(cylinderLinkPath));
   ASSERT_TRUE(cylinderLink);
   sdf::usd::testing::CheckInertial(
     cylinderLink, 1, pxr::GfVec3f(1, 1, 1), pxr::GfQuatf(1, 0, 0, 0),

--- a/usd/src/sdf_parser/Sensors_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Sensors_Sdf2Usd_TEST.cc
@@ -107,9 +107,11 @@ TEST_F(UsdStageFixture, Sensors)
   lidarSensor.GetAttribute(pxr::TfToken("minRange")).Get(&minRange);
   lidarSensor.GetAttribute(pxr::TfToken("maxRange")).Get(&maxRange);
   lidarSensor.GetAttribute(pxr::TfToken("horizontalFov")).Get(&hFOV);
-  lidarSensor.GetAttribute(pxr::TfToken("horizontalResolution")).Get(&hResolution);
+  lidarSensor.GetAttribute(
+      pxr::TfToken("horizontalResolution")).Get(&hResolution);
   lidarSensor.GetAttribute(pxr::TfToken("verticalFov")).Get(&vFOV);
-  lidarSensor.GetAttribute(pxr::TfToken("verticalResolution")).Get(&vResolution);
+  lidarSensor.GetAttribute(
+      pxr::TfToken("verticalResolution")).Get(&vResolution);
   EXPECT_FLOAT_EQ(10.0f, maxRange);
   EXPECT_FLOAT_EQ(0.08f, minRange);
   EXPECT_FLOAT_EQ(159.99995f, hFOV);

--- a/usd/src/sdf_parser/World_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/World_Sdf2Usd_TEST.cc
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 
-// TODO(ahcorde):this is to remove deprecated "warnings" in usd, these warnings
+// TODO(ahcorde) this is to remove deprecated "warnings" in usd, these warnings
 // are reported using #pragma message so normal diagnostic flags cannot remove
 // them. This workaround requires this block to be used whenever usd is
 // included.

--- a/usd/src/usd_parser/USD2SDF.cc
+++ b/usd/src/usd_parser/USD2SDF.cc
@@ -50,7 +50,7 @@ UsdErrors USD2SDF::Read(const std::string &_fileName,
   const auto addWorldErrors = _root.AddWorld(sdfWorld);
   if (!addWorldErrors.empty())
   {
-    for (const auto & error: addWorldErrors)
+    for (const auto & error : addWorldErrors)
     {
       errors.emplace_back(error);
     }

--- a/usd/src/usd_parser/USDData.cc
+++ b/usd/src/usd_parser/USDData.cc
@@ -251,7 +251,7 @@ namespace usd {
         }
       }
     }
-    return std::make_pair<std::string, std::shared_ptr<USDStage>>("", nullptr);
+    return std::make_pair("", nullptr);
   }
 
   /////////////////////////////////////////////////

--- a/usd/src/usd_parser/USDMaterial.cc
+++ b/usd/src/usd_parser/USDMaterial.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <string>
 #include "USDMaterial.hh"
 
 #include <ignition/common/Filesystem.hh>

--- a/usd/src/usd_parser/USDStage.cc
+++ b/usd/src/usd_parser/USDStage.cc
@@ -19,7 +19,7 @@
 #include <set>
 #include <string>
 
-// TODO(ahcorde):this is to remove deprecated "warnings" in usd, these warnings
+// TODO(ahcorde) this is to remove deprecated "warnings" in usd, these warnings
 // are reported using #pragma message so normal diagnostic flags cannot remove
 // them. This workaround requires this block to be used whenever usd is
 // included.

--- a/usd/src/usd_parser/USDWorld.cc
+++ b/usd/src/usd_parser/USDWorld.cc
@@ -16,7 +16,9 @@
 */
 #include "USDWorld.hh"
 
+#include <memory>
 #include <string>
+#include <utility>
 
 #pragma push_macro ("__DEPRECATED")
 #undef __DEPRECATED


### PR DESCRIPTION
# 🎉 New feature

This is a partial backport of #878 to `sdf12`

## Summary

In #878, the GitHub Actions CI was stopped from testing on Ubuntu Bionic on the `main` branch. As part of that change, the `cppcheck` and `cpplint` checks were moved to Ubuntu Focal CI. I noticed that there were some pre-existing errors in the `usd` component, which I believe are not checked on Ubuntu Bionic since the `usd` component is not tested on that workflow. In order to catch these errors, I've backported this portion of #878 and fixed any other listing errors that were reported.

## Test it

Run `make codecheck` on Ubuntu 20.04 or run the GitHub actions workflow on Ubuntu Focal

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
