### PR TITLE
Use ParserConfig more in parser.cc

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -181,7 +181,9 @@ static inline bool _initFile(const std::string &_filename, TPtr _sdf)
 /// \param[out] _errors Captures errors encountered during parsing.
 static void insertIncludedElement(sdf::SDFPtr _includeSDF,
                                   const SourceLocation &_sourceLoc, bool _merge,
-                                  sdf::ElementPtr _parent, sdf::Errors &_errors)
+                                  sdf::ElementPtr _parent,
+                                  const ParserConfig &_config,
+                                  sdf::Errors &_errors)
 {
   Error invalidFileError(ErrorCode::FILE_READ,
                          "Included model is invalid. Skipping model.");
@@ -230,7 +232,7 @@ static void insertIncludedElement(sdf::SDFPtr _includeSDF,
   // We create a throwaway sdf::Root object in order to validate the
   // included entity.
   sdf::Root includedRoot;
-  sdf::Errors includeDOMerrors = includedRoot.Load(_includeSDF);
+  sdf::Errors includeDOMerrors = includedRoot.Load(_includeSDF, _config);
   _errors.insert(_errors.end(), includeDOMerrors.begin(),
                  includeDOMerrors.end());
 
@@ -1510,7 +1512,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     ElementPtr refSDF;
     refSDF.reset(new Element);
     std::string refFilename = refSDFStr + ".sdf";
-    initFile(refFilename, refSDF);
+    initFile(refFilename, _config, refSDF);
     _sdf->RemoveFromParent();
     _sdf->Copy(refSDF);
 
@@ -1803,7 +1805,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           SourceLocation sourceLoc{includeXmlPath, _source,
                                    elemXml->GetLineNum()};
 
-          insertIncludedElement(includeSDF, sourceLoc, toMerge, _sdf, _errors);
+          insertIncludedElement(includeSDF, sourceLoc, toMerge, _sdf, _config,
+                                _errors);
           continue;
         }
       }

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -46,16 +46,24 @@ namespace sdf
   /// This actually forwards to initXml after converting the inputs
   /// \param[in] _xmlDoc TinyXML2 document containing the SDFormat description
   /// file that corresponds with the input SDFPtr
+  /// \param[in] _config Custom parser configuration
   /// \param[out] _sdf SDF interface to be initialized
-  bool initDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf);
+  /// \return True on success, false on error.
+  bool initDoc(tinyxml2::XMLDocument *_xmlDoc,
+               const ParserConfig &_config,
+               SDFPtr _sdf);
 
   /// \brief Initialize the SDF Element using a TinyXML2 document
   ///
   /// This actually forwards to initXml after converting the inputs
   /// \param[in] _xmlDoc TinyXML2 document containing the SDFormat description
   /// file that corresponds with the input ElementPtr
+  /// \param[in] _config Custom parser configuration
   /// \param[out] _sdf SDF Element to be initialized
-  bool initDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf);
+  /// \return True on success, false on error.
+  bool initDoc(tinyxml2::XMLDocument *_xmlDoc,
+               const ParserConfig &_config,
+               ElementPtr _sdf);
 
   /// \brief Initialize the SDF Element by parsing the SDFormat description in
   /// the input TinyXML2 element. This is where SDFormat spec/description files
@@ -63,8 +71,12 @@ namespace sdf
   /// \remark For internal use only. Do not use this function.
   /// \param[in] _xml TinyXML2 element containing the SDFormat description
   /// file that corresponds with the input ElementPtr
+  /// \param[in] _config Custom parser configuration
   /// \param[out] _sdf SDF ElementPtr to be initialized
-  bool initXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf);
+  /// \return True on success, false on error.
+  bool initXml(tinyxml2::XMLElement *_xml,
+               const ParserConfig &_config,
+               ElementPtr _sdf);
 
   /// \brief Populate the SDF values from a TinyXML document
   bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
@@ -83,6 +95,7 @@ namespace sdf
   /// \param[in] _xmlRoot Pointer to the root level TinyXML element.
   /// \param[in] _source Source of the XML document.
   /// \param[in] _errors Captures errors found during the checks.
+  /// \return True on success, false on error.
   bool checkXmlFromRoot(tinyxml2::XMLElement *_xmlRoot,
       const std::string &_source, Errors &_errors);
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/sdformat/issues/881

## Summary

As noted in #881, `ParserConfig` objects are not always propagated even when they are available. A recent partial fix for this was recently merged in #824, and a patch by @jwnimmer-tri was suggested in https://github.com/RobotLocomotion/drake/pull/16791, which has been applied to this branch in https://github.com/ignitionrobotics/sdformat/commit/58198fa75b1531fb03827d92d11c92e5c1b2c3db. Additionally, several private helper functions in parser.cc are updated in https://github.com/ignitionrobotics/sdformat/commit/e92d2451a932dabfa8a02e3eb55580fc558237e6 to require `ParserConfig` objects.

There is more to do to fully resolve #881, but this is a start.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.