### PR TITLE
Changes for replacing PythonInterp with Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (BUILD_SDF)
       # A module's location is usually a directory, but for
       # binary modules
       # it's a .so file.
-      execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+      execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
         RESULT_VARIABLE _${module}_status
         OUTPUT_VARIABLE _${module}_location
         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -58,7 +58,7 @@ set(tests
   world_dom.cc
 )
 
-if (PYTHONINTERP_FOUND AND PY_PSUTIL)
+if (Python3_Interpreter_FOUND AND PY_PSUTIL)
   set(tests ${tests} element_memory_leak.cc)
 endif()
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Changes needed for replacing deprecated `PythonInterp` with `Python3` (`find_package(Python3)`).
Related to https://github.com/ignitionrobotics/ign-cmake/pull/213

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
