### PR TITLE
require the cli component of ign-utils for usd component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if (BUILD_SDF)
   ########################################
   # Find ignition utils
   ign_find_package(ignition-utils1 VERSION REQUIRED)
+  ign_find_package(ignition-utils1 COMPONENTS cli REQUIRED_BY usd)
   set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
 
   ########################################

--- a/usd/src/cmd/CMakeLists.txt
+++ b/usd/src/cmd/CMakeLists.txt
@@ -6,6 +6,7 @@ if(TARGET ${usd_target})
   target_link_libraries(sdf2usd
     PUBLIC
       ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
+      ignition-utils${IGN_UTILS_VER}::cli
       ${usd_target}
   )
 
@@ -16,6 +17,7 @@ if(TARGET ${usd_target})
   target_link_libraries(usd2sdf
     PUBLIC
       ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
+      ignition-utils${IGN_UTILS_VER}::cli
       ${usd_target}
   )
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
When doing some testing of the USD component in a clean docker container, I found that I was able to invoke cmake and attempt to build the USD component without installing the `cli` component of `ign-utils`. This resulted in a build error because the following headers couldn't be found:
* https://github.com/ignitionrobotics/sdformat/blob/90a990867d9e79fe5ec23d0383c358e75d9bc8db/usd/src/cmd/sdf2usd.cc#L23
* https://github.com/ignitionrobotics/sdformat/blob/90a990867d9e79fe5ec23d0383c358e75d9bc8db/usd/src/cmd/usd2sdf.cc#L21

I've updated the cmake code to make sure that the `cli` component of `ign-utils` is installed before the user tries to build the usd component.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.