### PR TITLE
Anti-aliasing element for <camera><image>

### DIFF
--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -59,13 +59,6 @@ namespace sdf
     BAYER_GRBG8,
   };
 
-  enum class AntiAliasingType
-  {
-    UNKNOWN_ANTI_ALIASING = 0,
-    MSAA,
-    SSAA,
-  };
-
   /// \brief Information about a monocular camera sensor.
   class SDFORMAT_VISIBLE Camera
   {
@@ -166,23 +159,6 @@ namespace sdf
     /// \brief Set the pixel format from a string.
     /// \param[in] _fmt The pixel format string.
     public: void SetPixelFormatStr(const std::string &_fmt);
-
-    /// \brief Get the anti-aliasing type. This value is set from the
-    /// <anti_aliasing> element that is the child of <image>.
-    /// \return The anti-aliasing type.
-    public: AntiAliasingType AntiAliasing() const;
-
-    /// \brief Set the anti-aliasing type.
-    /// \param[in] _antiAliasing The anti-aliasing type.
-    public: void SetAntiAliasing(AntiAliasingType _antiAliasing);
-
-    /// \brief Get the anti-aliasing type as a string.
-    /// \return The anti-aliasing type string.
-    public: std::string AntiAliasingStr() const;
-
-    /// \brief Set the anti-aliasing type from a string.
-    /// \param[in] _antiAliasing The anti-aliasing type string.
-    public: void SetAntiAliasingStr(const std::string &_antiAliasing);
 
     /// \brief Get the anti-aliasing value.
     /// \return The anti-aliasing value.
@@ -512,17 +488,6 @@ namespace sdf
     /// \param[in] _type Pixel format type to convert.
     /// \return String equivalent of _type.
     public: static std::string ConvertPixelFormat(PixelFormatType _type);
-
-    /// \brief Convert a string to a AntiAliasingType.
-    /// \param[in] _format String equivalent of a anti-aliasing type to convert.
-    /// \return The matching AntiAliasingType.
-    public: static AntiAliasingType ConvertAntiAliasing(
-                const std::string &_antiAliasing);
-
-    /// \brief Convert a AntiAliasingType to a string.
-    /// \param[in] _type Anti-aliasing type to convert.
-    /// \return String equivalent of _type.
-    public: static std::string ConvertAntiAliasing(AntiAliasingType _type);
 
     /// \brief Get the visibility mask of a camera
     /// \return visibility mask

--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -59,6 +59,13 @@ namespace sdf
     BAYER_GRBG8,
   };
 
+  enum class AntiAliasingType
+  {
+    UNKNOWN_ANTI_ALIASING = 0,
+    MSAA,
+    SSAA,
+  };
+
   /// \brief Information about a monocular camera sensor.
   class SDFORMAT_VISIBLE Camera
   {
@@ -159,6 +166,31 @@ namespace sdf
     /// \brief Set the pixel format from a string.
     /// \param[in] _fmt The pixel format string.
     public: void SetPixelFormatStr(const std::string &_fmt);
+
+    /// \brief Get the anti-aliasing type. This value is set from the
+    /// <anti_aliasing> element that is the child of <image>.
+    /// \return The anti-aliasing type.
+    public: AntiAliasingType AntiAliasing() const;
+
+    /// \brief Set the anti-aliasing type.
+    /// \param[in] _antiAliasing The anti-aliasing type.
+    public: void SetAntiAliasing(AntiAliasingType _antiAliasing);
+
+    /// \brief Get the anti-aliasing type as a string.
+    /// \return The anti-aliasing type string.
+    public: std::string AntiAliasingStr() const;
+
+    /// \brief Set the anti-aliasing type from a string.
+    /// \param[in] _antiAliasing The anti-aliasing type string.
+    public: void SetAntiAliasingStr(const std::string &_antiAliasing);
+
+    /// \brief Get the anti-aliasing value.
+    /// \return The anti-aliasing value.
+    public: uint32_t AntiAliasingValue() const;
+
+    /// \brief Set the anti-aliasing value.
+    /// \param[in] _antiAliasingValue The anti-aliasing value.
+    public: void SetAntiAliasingValue(uint32_t _antiAliasingValue);
 
     /// \brief Get the near clip distance for the depth camera.
     /// \return The near clip depth distance.
@@ -480,6 +512,17 @@ namespace sdf
     /// \param[in] _type Pixel format type to convert.
     /// \return String equivalent of _type.
     public: static std::string ConvertPixelFormat(PixelFormatType _type);
+
+    /// \brief Convert a string to a AntiAliasingType.
+    /// \param[in] _format String equivalent of a anti-aliasing type to convert.
+    /// \return The matching AntiAliasingType.
+    public: static AntiAliasingType ConvertAntiAliasing(
+                const std::string &_antiAliasing);
+
+    /// \brief Convert a AntiAliasingType to a string.
+    /// \param[in] _type Anti-aliasing type to convert.
+    /// \return String equivalent of _type.
+    public: static std::string ConvertAntiAliasing(AntiAliasingType _type);
 
     /// \brief Get the visibility mask of a camera
     /// \return visibility mask

--- a/sdf/1.7/camera.sdf
+++ b/sdf/1.7/camera.sdf
@@ -20,11 +20,8 @@
     <element name="format" type="string" default="R8G8B8" required="0">
       <description>(L8|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
     </element>
-    <element name="anti_aliasing" type="string" default="MSAA" required="0">
-      <description>(MSAA)</description>
-    </element>
-    <element name="anti_aliasing_value" type="int" default="4" required="0">
-      <description>Anti-aliasing filter size</description>
+    <element name="anti_aliasing" type="int" default="4" required="0">
+      <description>Value used for anti-aliasing</description>
     </element>
   </element> <!-- End Image -->
 

--- a/sdf/1.7/camera.sdf
+++ b/sdf/1.7/camera.sdf
@@ -20,6 +20,12 @@
     <element name="format" type="string" default="R8G8B8" required="0">
       <description>(L8|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
     </element>
+    <element name="anti_aliasing" type="string" default="MSAA" required="0">
+      <description>(MSAA)</description>
+    </element>
+    <element name="anti_aliasing_value" type="int" default="4" required="0">
+      <description>Anti-aliasing filter size</description>
+    </element>
   </element> <!-- End Image -->
 
   <element name="clip" required="1">

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -45,13 +45,6 @@ static std::array<std::string, 19> kPixelFormatNames =
   "BAYER_GRBG8"
 };
 
-static std::array<std::string, 3> kAntiAliasingTypeNames =
-{
-  "UNKNOWN_ANTI_ALIASING",
-  "MSAA",
-  "SSAA",
-};
-
 // Private data class
 class sdf::CameraPrivate
 {
@@ -72,9 +65,6 @@ class sdf::CameraPrivate
 
   /// \brief Image format.
   public: PixelFormatType pixelFormat{PixelFormatType::RGB_INT8};
-
-  /// \brief Anti-aliasing.
-  public: AntiAliasingType antiAliasing{AntiAliasingType::MSAA};
 
   /// \brief Anti-aliasing value.
   public: uint32_t antiAliasingValue{4};
@@ -284,16 +274,6 @@ Errors Camera::Load(ElementPtr _sdf)
         "Camera sensor <image><format> has invalid value of " + format});
     }
 
-    std::string antiAliasingType =
-        elem->Get<std::string>("anti_aliasing", "MSAA").first;
-    this->dataPtr->antiAliasing = ConvertAntiAliasing(antiAliasingType);
-    if (this->dataPtr->antiAliasing == AntiAliasingType::UNKNOWN_ANTI_ALIASING)
-    {
-      errors.push_back({ErrorCode::ELEMENT_INVALID,
-          "Camera sensor <image><anti_aliasing> has invalid value of " +
-          antiAliasingType});
-    }
-
     this->dataPtr->antiAliasingValue =
         elem->Get<uint32_t>("anti_aliasing_value",
             this->dataPtr->antiAliasingValue).first;
@@ -492,30 +472,6 @@ std::string Camera::PixelFormatStr() const
 void Camera::SetPixelFormatStr(const std::string &_fmt)
 {
   this->dataPtr->pixelFormat = ConvertPixelFormat(_fmt);
-}
-
-//////////////////////////////////////////////////
-AntiAliasingType Camera::AntiAliasing() const
-{
-  return this->dataPtr->antiAliasing;
-}
-
-//////////////////////////////////////////////////
-void Camera::SetAntiAliasing(AntiAliasingType _antiAliasing)
-{
-  this->dataPtr->antiAliasing = _antiAliasing;
-}
-
-//////////////////////////////////////////////////
-std::string Camera::AntiAliasingStr() const
-{
-  return ConvertAntiAliasing(this->dataPtr->antiAliasing);
-}
-
-//////////////////////////////////////////////////
-void Camera::SetAntiAliasingStr(const std::string &_antiAliasing)
-{
-  this->dataPtr->antiAliasing = ConvertAntiAliasing(_antiAliasing);
 }
 
 //////////////////////////////////////////////////
@@ -1001,30 +957,6 @@ PixelFormatType Camera::ConvertPixelFormat(const std::string &_format)
     return PixelFormatType::BAYER_GRBG8;
 
   return PixelFormatType::UNKNOWN_PIXEL_FORMAT;
-}
-
-/////////////////////////////////////////////////
-std::string Camera::ConvertAntiAliasing(AntiAliasingType _type)
-{
-  unsigned int index = static_cast<int>(_type);
-  if (index < kAntiAliasingTypeNames.size())
-    return kAntiAliasingTypeNames[static_cast<int>(_type)];
-
-  return kAntiAliasingTypeNames[0];
-}
-
-/////////////////////////////////////////////////
-AntiAliasingType Camera::ConvertAntiAliasing(const std::string &_antiAliasing)
-{
-  for (unsigned int i = 0; i < kAntiAliasingTypeNames.size(); ++i)
-  {
-    if (kAntiAliasingTypeNames[i] == _antiAliasing)
-    {
-      return static_cast<AntiAliasingType>(i);
-    }
-  }
-
-  return AntiAliasingType::UNKNOWN_ANTI_ALIASING;
 }
 
 /////////////////////////////////////////////////

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -275,7 +275,7 @@ Errors Camera::Load(ElementPtr _sdf)
     }
 
     this->dataPtr->antiAliasingValue =
-        elem->Get<uint32_t>("anti_aliasing_value",
+        elem->Get<uint32_t>("anti_aliasing",
             this->dataPtr->antiAliasingValue).first;
   }
   else

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -45,6 +45,13 @@ static std::array<std::string, 19> kPixelFormatNames =
   "BAYER_GRBG8"
 };
 
+static std::array<std::string, 3> kAntiAliasingTypeNames =
+{
+  "UNKNOWN_ANTI_ALIASING",
+  "MSAA",
+  "SSAA",
+};
+
 // Private data class
 class sdf::CameraPrivate
 {
@@ -65,6 +72,12 @@ class sdf::CameraPrivate
 
   /// \brief Image format.
   public: PixelFormatType pixelFormat{PixelFormatType::RGB_INT8};
+
+  /// \brief Anti-aliasing.
+  public: AntiAliasingType antiAliasing{AntiAliasingType::MSAA};
+
+  /// \brief Anti-aliasing value.
+  public: uint32_t antiAliasingValue{4};
 
   /// \brief Near clip distance.
   public: double nearClip{0.1};
@@ -270,6 +283,20 @@ Errors Camera::Load(ElementPtr _sdf)
       errors.push_back({ErrorCode::ELEMENT_INVALID,
         "Camera sensor <image><format> has invalid value of " + format});
     }
+
+    std::string antiAliasingType =
+        elem->Get<std::string>("anti_aliasing", "MSAA").first;
+    this->dataPtr->antiAliasing = ConvertAntiAliasing(antiAliasingType);
+    if (this->dataPtr->antiAliasing == AntiAliasingType::UNKNOWN_ANTI_ALIASING)
+    {
+      errors.push_back({ErrorCode::ELEMENT_INVALID,
+          "Camera sensor <image><anti_aliasing> has invalid value of " +
+          antiAliasingType});
+    }
+
+    this->dataPtr->antiAliasingValue =
+        elem->Get<uint32_t>("anti_aliasing_value",
+            this->dataPtr->antiAliasingValue).first;
   }
   else
   {
@@ -465,6 +492,42 @@ std::string Camera::PixelFormatStr() const
 void Camera::SetPixelFormatStr(const std::string &_fmt)
 {
   this->dataPtr->pixelFormat = ConvertPixelFormat(_fmt);
+}
+
+//////////////////////////////////////////////////
+AntiAliasingType Camera::AntiAliasing() const
+{
+  return this->dataPtr->antiAliasing;
+}
+
+//////////////////////////////////////////////////
+void Camera::SetAntiAliasing(AntiAliasingType _antiAliasing)
+{
+  this->dataPtr->antiAliasing = _antiAliasing;
+}
+
+//////////////////////////////////////////////////
+std::string Camera::AntiAliasingStr() const
+{
+  return ConvertAntiAliasing(this->dataPtr->antiAliasing);
+}
+
+//////////////////////////////////////////////////
+void Camera::SetAntiAliasingStr(const std::string &_antiAliasing)
+{
+  this->dataPtr->antiAliasing = ConvertAntiAliasing(_antiAliasing);
+}
+
+//////////////////////////////////////////////////
+uint32_t Camera::AntiAliasingValue() const
+{
+  return this->dataPtr->antiAliasingValue;
+}
+
+//////////////////////////////////////////////////
+void Camera::SetAntiAliasingValue(uint32_t _antiAliasingValue)
+{
+  this->dataPtr->antiAliasingValue = _antiAliasingValue;
 }
 
 //////////////////////////////////////////////////
@@ -938,6 +1001,30 @@ PixelFormatType Camera::ConvertPixelFormat(const std::string &_format)
     return PixelFormatType::BAYER_GRBG8;
 
   return PixelFormatType::UNKNOWN_PIXEL_FORMAT;
+}
+
+/////////////////////////////////////////////////
+std::string Camera::ConvertAntiAliasing(AntiAliasingType _type)
+{
+  unsigned int index = static_cast<int>(_type);
+  if (index < kAntiAliasingTypeNames.size())
+    return kAntiAliasingTypeNames[static_cast<int>(_type)];
+
+  return kAntiAliasingTypeNames[0];
+}
+
+/////////////////////////////////////////////////
+AntiAliasingType Camera::ConvertAntiAliasing(const std::string &_antiAliasing)
+{
+  for (unsigned int i = 0; i < kAntiAliasingTypeNames.size(); ++i)
+  {
+    if (kAntiAliasingTypeNames[i] == _antiAliasing)
+    {
+      return static_cast<AntiAliasingType>(i);
+    }
+  }
+
+  return AntiAliasingType::UNKNOWN_ANTI_ALIASING;
 }
 
 /////////////////////////////////////////////////

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -42,10 +42,6 @@ TEST(DOMCamera, Construction)
   cam.SetPixelFormat(sdf::PixelFormatType::L_INT8);
   EXPECT_EQ(sdf::PixelFormatType::L_INT8 , cam.PixelFormat());
 
-  EXPECT_EQ(sdf::AntiAliasingType::MSAA, cam.AntiAliasing());
-  cam.SetAntiAliasing(sdf::AntiAliasingType::SSAA);
-  EXPECT_EQ(sdf::AntiAliasingType::SSAA, cam.AntiAliasing());
-
   EXPECT_EQ(4u, cam.AntiAliasingValue());
   cam.SetAntiAliasingValue(8);
   EXPECT_EQ(8u, cam.AntiAliasingValue());

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -42,6 +42,14 @@ TEST(DOMCamera, Construction)
   cam.SetPixelFormat(sdf::PixelFormatType::L_INT8);
   EXPECT_EQ(sdf::PixelFormatType::L_INT8 , cam.PixelFormat());
 
+  EXPECT_EQ(sdf::AntiAliasingType::MSAA, cam.AntiAliasing());
+  cam.SetAntiAliasing(sdf::AntiAliasingType::SSAA);
+  EXPECT_EQ(sdf::AntiAliasingType::SSAA, cam.AntiAliasing());
+
+  EXPECT_EQ(4u, cam.AntiAliasingValue());
+  cam.SetAntiAliasingValue(8);
+  EXPECT_EQ(8u, cam.AntiAliasingValue());
+
   EXPECT_DOUBLE_EQ(0.1, cam.DepthNearClip());
   EXPECT_FALSE(cam.HasDepthNearClip());
   cam.SetDepthNearClip(0.2);


### PR DESCRIPTION
# 🎉 Anti-aliasing element for <camera><image>

## Summary
Adds the <anti_aliasing> element to <camera><image>.

Anti-aliasing is always associated with a value (usually for the filter size).
<anti_aliasing> is the value that will be used by the anti-aliasing type.

When engines continue to support different anti-aliasing types (currently OGRE1 and OGRE2 only use MSAA), an attribute (type="MSAA") can be added to the element.

```
<camera name="camera">
  <image>
    <width>640</width>
    <height>480</height>
    <format>R8G8B8</format>
    <anti_aliasing>4</anti_aliasing>
  </image>
...
</camera>
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.