### PR TITLE
Revert some instances of `sdf::ParserConfig` propgation

### DIFF
--- a/src/Model.cc
+++ b/src/Model.cc
@@ -979,7 +979,7 @@ sdf::ElementPtr Model::ToElement(const ParserConfig &_config) const
   if (_config.ToElementUseIncludeTag() && !this->dataPtr->uri.empty())
   {
     sdf::ElementPtr worldElem(new sdf::Element);
-    sdf::initFile("world.sdf", _config, worldElem);
+    sdf::initFile("world.sdf", worldElem);
 
     sdf::ElementPtr includeElem = worldElem->AddElement("include");
     includeElem->GetElement("uri")->Set(this->Uri());
@@ -1005,7 +1005,7 @@ sdf::ElementPtr Model::ToElement(const ParserConfig &_config) const
   }
 
   sdf::ElementPtr elem(new sdf::Element);
-  sdf::initFile("model.sdf", _config, elem);
+  sdf::initFile("model.sdf", elem);
   elem->GetAttribute("name")->Set(this->Name());
 
   if (!this->dataPtr->canonicalLink.empty())

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -179,7 +179,7 @@ Errors Root::LoadSdfString(const std::string &_sdf, const ParserConfig &_config)
 {
   Errors errors;
   SDFPtr sdfParsed(new SDF());
-  init(sdfParsed, _config);
+  init(sdfParsed);
 
   // Read an SDF string, and store the result in sdfParsed.
   if (!readString(_sdf, _config, sdfParsed, errors))
@@ -528,7 +528,7 @@ void Root::Implementation::UpdateGraphs(sdf::Model &_model,
 sdf::ElementPtr Root::ToElement(const ParserConfig &_config) const
 {
   sdf::ElementPtr elem(new sdf::Element);
-  sdf::initFile("root.sdf", _config, elem);
+  sdf::initFile("root.sdf", elem);
 
   elem->GetAttribute("version")->Set(this->Version());
 

--- a/src/World.cc
+++ b/src/World.cc
@@ -859,7 +859,7 @@ Errors World::Implementation::LoadSphericalCoordinates(
 sdf::ElementPtr World::ToElement(const ParserConfig &_config) const
 {
   sdf::ElementPtr elem(new sdf::Element);
-  sdf::initFile("world.sdf", _config, elem);
+  sdf::initFile("world.sdf", elem);
 
   elem->GetAttribute("name")->Set(this->Name());
   elem->GetElement("gravity")->Set(this->Gravity());


### PR DESCRIPTION
## Summary

The only use of `sdf::ParserConfig` in `sdf::initFile` and its callees
is when searching for the description (.sdf) file on disk using
`sdf::findFile`. However, all the files used within the `ToElement`
calls are standard `.sdf` files that are kepts in an embedded map. i.e.,
`sdf::findFile` is not needed to find them. Therefore, we can use the
default `sdf::initFile` in these functions.

There is no harm in passing along the `sdf::ParserConfig` object, but it
would be inconsistent with the rest of `*::ToElement` functions which do
not receive a config object.

The same applies to the change in `sdf::Root::Load`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
