### PR TITLE
SDF to USD: set UsdPhysicsArticulationRootAPI

### DIFF
--- a/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
@@ -37,6 +37,7 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdPhysics/articulationRootAPI.h>
 #include <pxr/usd/usdPhysics/driveAPI.h>
 #include <pxr/usd/usdPhysics/fixedJoint.h>
 #include <pxr/usd/usdPhysics/joint.h>
@@ -332,6 +333,13 @@ TEST_F(UsdJointStageFixture, RevoluteJoints)
     checkedJoints++;
   }
   EXPECT_EQ(checkedJoints, 2);
+
+  // the model prim that has revolute joints should be marked as a
+  // pxr::UsdPhysicsAtriculationRootAPI
+  const auto modelPrim =
+    this->stage->GetPrimAtPath(pxr::SdfPath(this->modelPath));
+  ASSERT_TRUE(modelPrim);
+  EXPECT_TRUE(modelPrim.HasAPI<pxr::UsdPhysicsArticulationRootAPI>());
 }
 
 /////////////////////////////////////////////////
@@ -383,6 +391,13 @@ TEST_F(UsdJointStageFixture, JointParentIsWorld)
     checkedJoints++;
   }
   EXPECT_EQ(checkedJoints, 1);
+
+  // the model prim doesn't have revolute joints, so it shouldn't be marked as a
+  // pxr::UsdPhysicsAtriculationRootAPI
+  const auto modelPrim =
+    this->stage->GetPrimAtPath(pxr::SdfPath(this->modelPath));
+  ASSERT_TRUE(modelPrim);
+  EXPECT_FALSE(modelPrim.HasAPI<pxr::UsdPhysicsArticulationRootAPI>());
 }
 
 /////////////////////////////////////////////////

--- a/usd/src/sdf_parser/Link.cc
+++ b/usd/src/sdf_parser/Link.cc
@@ -85,7 +85,7 @@ namespace usd
         return errors;
       }
 
-      if (!pxr::UsdPhysicsRigidBodyAPI::Apply(linkPrim.GetParent()))
+      if (!pxr::UsdPhysicsRigidBodyAPI::Apply(linkPrim))
       {
         errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
               "Internal error: unable to mark model at path [" +

--- a/usd/src/sdf_parser/Link.cc
+++ b/usd/src/sdf_parser/Link.cc
@@ -89,7 +89,7 @@ namespace usd
       {
         errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
               "Internal error: unable to mark model at path [" +
-              linkPrim.GetParent().GetPath().GetString() + "] as a rigid body, "
+              linkPrim.GetPath().GetString() + "] as a rigid body, "
               "so mass properties won't be attached"));
         return errors;
       }

--- a/usd/src/sdf_parser/Model.cc
+++ b/usd/src/sdf_parser/Model.cc
@@ -181,8 +181,7 @@ namespace usd
       {
         errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
               "Internal error: unable to mark model at path [" +
-              modelPrim.GetPath().GetString() + "] as a rigid body, "
-              "so mass properties won't be attached"));
+              modelPrim.GetPath().GetString() + "] as a rigid body."));
         return errors;
       }
     }

--- a/usd/src/sdf_parser/Model.cc
+++ b/usd/src/sdf_parser/Model.cc
@@ -33,6 +33,7 @@
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdPhysics/articulationRootAPI.h>
+#include <pxr/usd/usdPhysics/rigidBodyAPI.h>
 #pragma pop_macro ("__DEPRECATED")
 
 #include "sdf/Model.hh"
@@ -171,6 +172,18 @@ namespace usd
         {
           markedArticulationRoot = true;
         }
+      }
+    }
+
+    if (!markedArticulationRoot && !_model.Static())
+    {
+      if (!pxr::UsdPhysicsRigidBodyAPI::Apply(modelPrim))
+      {
+        errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
+              "Internal error: unable to mark model at path [" +
+              modelPrim.GetPath().GetString() + "] as a rigid body, "
+              "so mass properties won't be attached"));
+        return errors;
       }
     }
 

--- a/usd/src/sdf_parser/World.cc
+++ b/usd/src/sdf_parser/World.cc
@@ -36,7 +36,6 @@
 #include <pxr/usd/usdPhysics/scene.h>
 #pragma pop_macro ("__DEPRECATED")
 
-#include "sdf/Joint.hh"
 #include "sdf/World.hh"
 #include "Light.hh"
 #include "Model.hh"

--- a/usd/src/sdf_parser/World.cc
+++ b/usd/src/sdf_parser/World.cc
@@ -33,7 +33,6 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usdGeom/tokens.h>
-#include <pxr/usd/usdPhysics/articulationRootAPI.h>
 #include <pxr/usd/usdPhysics/scene.h>
 #pragma pop_macro ("__DEPRECATED")
 
@@ -85,28 +84,6 @@ namespace usd
               sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
               "Error parsing model [" + model.Name() + "]"));
         errors.insert(errors.end(), modelErrors.begin(), modelErrors.end());
-      }
-      if (model.JointCount() > 0)
-      {
-        for (uint64_t j = 0; j < model.JointCount(); j++)
-        {
-          const auto joint = *(model.JointByIndex(j));
-          if (joint.Type() == sdf::JointType::REVOLUTE)
-          {
-            auto prim = _stage->GetPrimAtPath(pxr::SdfPath(modelPath));
-            if (prim)
-            {
-              if (!pxr::UsdPhysicsArticulationRootAPI::Apply(prim))
-              {
-                std::cerr << "Internal error: unable to mark Xform at path ["
-                          << modelPath << "] as ArticulationRootAPI "
-                          << "some feature might not work\n";
-                continue;
-              }
-            }
-            break;
-          }
-        }
       }
     }
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

We should set the `UsdPhysicsArticulationRootAPI` to allow articulation arms to move in IsaacSim

## Summary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

