### PR TITLE
SDF to USD: Fixed material defined in textureImage not in PBR

### DIFF
--- a/usd/src/CMakeLists.txt
+++ b/usd/src/CMakeLists.txt
@@ -92,4 +92,9 @@ if (TARGET UNIT_Light_Sdf2Usd_TEST)
     ${sdf2usd_test_sources})
 endif()
 
+if (TARGET UNIT_Material_Sdf2Usd_TEST)
+  target_sources(UNIT_Material_Sdf2Usd_TEST PRIVATE
+    ${sdf2usd_test_sources})
+endif()
+
 add_subdirectory(cmd)

--- a/usd/src/Conversions.cc
+++ b/usd/src/Conversions.cc
@@ -43,7 +43,14 @@ namespace sdf
       out.SetNormalMap(pbr->NormalMap());
       sdf::Pbr pbrOut;
       sdf::PbrWorkflow pbrWorkflow;
-      pbrWorkflow.SetAlbedoMap(pbr->AlbedoMap());
+      if (!pbr->AlbedoMap().empty())
+      {
+        pbrWorkflow.SetAlbedoMap(pbr->AlbedoMap());
+      }
+      else
+      {
+        pbrWorkflow.SetAlbedoMap(_in->TextureImage());
+      }
       pbrWorkflow.SetMetalnessMap(pbr->MetalnessMap());
       pbrWorkflow.SetEmissiveMap(pbr->EmissiveMap());
       pbrWorkflow.SetRoughnessMap(pbr->RoughnessMap());
@@ -66,13 +73,15 @@ namespace sdf
           pbr->NormalMap(), sdf::NormalMapSpace::OBJECT);
       }
 
-      if (pbr->Type() == ignition::common::PbrType::METAL)
+      if (pbr->Type() == ignition::common::PbrType::SPECULAR)
       {
-        pbrOut.SetWorkflow(sdf::PbrWorkflowType::METAL, pbrWorkflow);
-      }
-      else if (pbr->Type() == ignition::common::PbrType::SPECULAR)
-      {
+        pbrWorkflow.SetType(sdf::PbrWorkflowType::SPECULAR);
         pbrOut.SetWorkflow(sdf::PbrWorkflowType::SPECULAR, pbrWorkflow);
+      }
+      else
+      {
+        pbrWorkflow.SetType(sdf::PbrWorkflowType::METAL);
+        pbrOut.SetWorkflow(sdf::PbrWorkflowType::METAL, pbrWorkflow);
       }
       out.SetPbrMaterial(pbrOut);
     }

--- a/usd/src/sdf_parser/Material.cc
+++ b/usd/src/sdf_parser/Material.cc
@@ -192,6 +192,7 @@ namespace usd
         sdf::usd::UsdErrorCode::INVALID_PRIM_PATH,
         "Not able to cast the UsdShadeShader at path [" + shaderPath.GetString()
         + "] to a Prim"));
+      return errors;
     }
 
     auto shaderOut = pxr::UsdShadeConnectableAPI(shaderPrim).CreateOutput(

--- a/usd/src/sdf_parser/Material_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Material_Sdf2Usd_TEST.cc
@@ -216,7 +216,7 @@ TEST_F(UsdStageFixture, MaterialTextureName)
   EXPECT_TRUE(errors.empty());
 
   {
-    ASSERT_TRUE(this->stage->GetPrimAtPath(pxr::SdfPath(materialPathStr)));
+    ASSERT_TRUE(this->stage->GetPrimAtPath(materialPath));
 
     const std::string materialshaderPath = materialPathStr + "/Shader";
     const auto materialShaderPrim = this->stage->GetPrimAtPath(
@@ -228,7 +228,8 @@ TEST_F(UsdStageFixture, MaterialTextureName)
 
     std::vector<pxr::UsdShadeInput> inputs = variantshader.GetInputs();
 
-    for (auto &input : inputs)
+    bool checkedTextureInput = false;
+    for (const auto &input : inputs)
     {
       if (input.GetBaseName() == "diffuse_texture")
       {
@@ -238,8 +239,11 @@ TEST_F(UsdStageFixture, MaterialTextureName)
         diffuseTextureShaderInput.Get(&materialPathUSD);
         EXPECT_EQ("materials/textures/albedo_map.png",
           materialPathUSD.GetAssetPath());
+        checkedTextureInput = true;
+        break;
       }
     }
+    EXPECT_TRUE(checkedTextureInput);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Meshes defining the Texture in the `TextureImage()` method was not taking in account, this PR should fix this issue

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
