### PR TITLE
Change how articulate root API is saved

### DIFF
--- a/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
@@ -391,6 +391,13 @@ TEST_F(UsdJointStageFixture, JointParentIsWorld)
     checkedJoints++;
   }
   EXPECT_EQ(checkedJoints, 1);
+
+  // the model prim doesn't have revolute joints, so it shouldn't be marked as a
+  // pxr::UsdPhysicsAtriculationRootAPI
+  const auto modelPrim =
+    this->stage->GetPrimAtPath(pxr::SdfPath(this->modelPath));
+  ASSERT_TRUE(modelPrim);
+  EXPECT_FALSE(modelPrim.HasAPI<pxr::UsdPhysicsArticulationRootAPI>());
 }
 
 /////////////////////////////////////////////////

--- a/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Joint_Sdf2Usd_TEST.cc
@@ -37,6 +37,7 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdPhysics/articulationRootAPI.h>
 #include <pxr/usd/usdPhysics/driveAPI.h>
 #include <pxr/usd/usdPhysics/fixedJoint.h>
 #include <pxr/usd/usdPhysics/joint.h>
@@ -332,6 +333,13 @@ TEST_F(UsdJointStageFixture, RevoluteJoints)
     checkedJoints++;
   }
   EXPECT_EQ(checkedJoints, 2);
+
+  // the model prim that has revolute joints should be marked as a
+  // pxr::UsdPhysicsAtriculationRootAPI
+  const auto modelPrim =
+    this->stage->GetPrimAtPath(pxr::SdfPath(this->modelPath));
+  ASSERT_TRUE(modelPrim);
+  EXPECT_TRUE(modelPrim.HasAPI<pxr::UsdPhysicsArticulationRootAPI>());
 }
 
 /////////////////////////////////////////////////

--- a/usd/src/sdf_parser/World.cc
+++ b/usd/src/sdf_parser/World.cc
@@ -33,7 +33,6 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usdGeom/tokens.h>
-#include <pxr/usd/usdPhysics/articulationRootAPI.h>
 #include <pxr/usd/usdPhysics/scene.h>
 #pragma pop_macro ("__DEPRECATED")
 
@@ -85,28 +84,6 @@ namespace usd
               sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
               "Error parsing model [" + model.Name() + "]"));
         errors.insert(errors.end(), modelErrors.begin(), modelErrors.end());
-      }
-      if (model.JointCount() > 0)
-      {
-        for (uint64_t j = 0; j < model.JointCount(); j++)
-        {
-          const auto joint = *(model.JointByIndex(j));
-          if (joint.Type() == sdf::JointType::REVOLUTE)
-          {
-            auto prim = _stage->GetPrimAtPath(pxr::SdfPath(modelPath));
-            if (prim)
-            {
-              if (!pxr::UsdPhysicsArticulationRootAPI::Apply(prim))
-              {
-                std::cerr << "Internal error: unable to mark Xform at path ["
-                          << modelPath << "] as ArticulationRootAPI "
-                          << "some feature might not work\n";
-                continue;
-              }
-            }
-            break;
-          }
-        }
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
Alternative proposal to #914. The following changes are made here:
* do the articulate root API checking in `usd::ParseSdfModel` instead of `usd::ParseSdfWorld`, since the API is dependent on model properties
* added tests to verify that models with revolute joints are marked as an articulate root API, and that models without revolute joints aren't marked as an articulate root API

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.