### PR TITLE
SDF to USD : support to convert models

### DIFF
--- a/test/sdf/ellipsoid_model.sdf
+++ b/test/sdf/ellipsoid_model.sdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="ellipsoid">
+    <pose>0 3.0 0.5 0 0 0</pose>
+    <link name="ellipsoid_link">
+      <inertial>
+        <inertia>
+          <ixx>0.068</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.058</iyy>
+          <iyz>0</iyz>
+          <izz>0.026</izz>
+        </inertia>
+        <mass>1.0</mass>
+      </inertial>
+      <collision name="ellipsoid_collision">
+        <geometry>
+          <ellipsoid>
+            <radii>0.2 0.3 0.5</radii>
+          </ellipsoid>
+        </geometry>
+      </collision>
+      <visual name="ellipsoid_visual">
+        <geometry>
+          <ellipsoid>
+            <radii>0.2 0.3 0.5</radii>
+          </ellipsoid>
+        </geometry>
+        <material>
+          <ambient>1 0 1 1</ambient>
+          <diffuse>1 0 1 1</diffuse>
+          <specular>1 0 1 1</specular>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/usd/src/cmd/CMakeLists.txt
+++ b/usd/src/cmd/CMakeLists.txt
@@ -1,6 +1,15 @@
 if(TARGET ${usd_target})
   add_executable(sdf2usd
     sdf2usd.cc
+    ../sdf_parser/Model.cc
+    ../sdf_parser/Joint.cc
+    ../sdf_parser/Link.cc
+    ../sdf_parser/Geometry.cc
+    ../sdf_parser/Material.cc
+    ../sdf_parser/Sensor.cc
+    ../sdf_parser/Visual.cc
+    ../sdf_parser/Light.cc
+    ../Conversions.cc
   )
 
   target_link_libraries(sdf2usd

--- a/usd/src/cmd/sdf2usd.cc
+++ b/usd/src/cmd/sdf2usd.cc
@@ -265,7 +265,7 @@ void runCommand(const Options &_opt)
       auto stage = pxr::UsdStage::CreateInMemory();
       std::string modelName = model->Name();
       modelName = ignition::common::replaceAll(modelName, " ", "");
-      if (!modelName.empty() && isdigit(modelName[0]))
+      if (!modelName.empty() && std::isdigit(modelName[0]))
       {
         modelName = "_" + modelName;
       }
@@ -274,7 +274,7 @@ void runCommand(const Options &_opt)
         *model,
         stage,
         modelPath,
-        pxr::SdfPath("/" + modelName));
+        pxr::SdfPath(modelPath));
       if (!usdErrors.empty())
       {
         std::cerr << "The following errors occurred when parsing model ["

--- a/usd/src/cmd/sdf2usd.cc
+++ b/usd/src/cmd/sdf2usd.cc
@@ -15,7 +15,8 @@
  *
  */
 
-#include <string.h>
+#include <cctype>
+#include <string>
 
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Util.hh>
@@ -260,6 +261,10 @@ void runCommand(const Options &_opt)
       auto stage = pxr::UsdStage::CreateInMemory();
       std::string modelName = model->Name();
       modelName = ignition::common::replaceAll(modelName, " ", "");
+      if (isdigit(modelName[0]))
+      {
+        modelName = "_" + modelName;
+      }
       auto modelPath = std::string("/" + modelName);
       auto usdErrors = sdf::usd::ParseSdfModel(
         *model,

--- a/usd/src/cmd/sdf2usd.cc
+++ b/usd/src/cmd/sdf2usd.cc
@@ -225,7 +225,7 @@ void runCommand(const Options &_opt)
     exit(-2);
   }
 
-  // only support SDF files with exactly 1 world for now
+  // only support SDF files with exactly 1 world or 1 model for now
   if (root.WorldCount() != 1u)
   {
     auto model = root.Model();
@@ -240,8 +240,12 @@ void runCommand(const Options &_opt)
       auto systemPaths = ignition::common::systemPaths();
       systemPaths->AddFilePaths(pathInputFile);
 
+      // This loop here will add all the directories inside the sdf file.
+      // For example: If we download a model from fuel, textures might live in
+      // in the same path but in a different folder: materials/textures,
+      // this loop will add these two folders to the systempaths allowing the
+      // cmd to find the resources.
       std::vector<std::string> pathList = {pathInputFile};
-
       while (!pathList.empty())
       {
         std::string pathToAdd = pathList.back();
@@ -261,7 +265,7 @@ void runCommand(const Options &_opt)
       auto stage = pxr::UsdStage::CreateInMemory();
       std::string modelName = model->Name();
       modelName = ignition::common::replaceAll(modelName, " ", "");
-      if (isdigit(modelName[0]))
+      if (!modelName.empty() && isdigit(modelName[0]))
       {
         modelName = "_" + modelName;
       }
@@ -329,7 +333,8 @@ void addFlags(CLI::App &_app)
 
   _app.add_option("input",
     opt->inputFilename,
-    "Input filename. Defaults to input.sdf unless otherwise specified.");
+    "Input filename. Defaults to input.sdf unless otherwise specified."
+    "Input file might be a world or a model");
 
   _app.add_option("output",
     opt->outputFilename,

--- a/usd/src/sdf_parser/World.cc
+++ b/usd/src/sdf_parser/World.cc
@@ -75,7 +75,7 @@ namespace usd
     {
       const auto model = *(_world.ModelByIndex(i));
       std::string modelName = model.Name();
-      if (!modelName.empty() && isdigit(modelName[0]))
+      if (!modelName.empty() && std::isdigit(modelName[0]))
       {
         modelName = "_" + modelName;
       }

--- a/usd/src/sdf_parser/World.cc
+++ b/usd/src/sdf_parser/World.cc
@@ -17,6 +17,7 @@
 
 #include "sdf/usd/sdf_parser/World.hh"
 
+#include <cctype>
 #include <iostream>
 #include <string>
 
@@ -75,6 +76,10 @@ namespace usd
       const auto model = *(_world.ModelByIndex(i));
       auto modelPath = std::string(_path + "/" + model.Name());
       modelPath = ignition::common::replaceAll(modelPath, " ", "");
+      if (isdigit(modelPath[0]))
+      {
+        modelPath = "_" + modelPath;
+      }
       UsdErrors modelErrors =
         ParseSdfModel(model, _stage, modelPath, worldPrimPath);
       if (!modelErrors.empty())

--- a/usd/src/sdf_parser/World.cc
+++ b/usd/src/sdf_parser/World.cc
@@ -74,19 +74,20 @@ namespace usd
     for (uint64_t i = 0; i < _world.ModelCount(); ++i)
     {
       const auto model = *(_world.ModelByIndex(i));
-      auto modelPath = std::string(_path + "/" + model.Name());
-      modelPath = ignition::common::replaceAll(modelPath, " ", "");
-      if (isdigit(modelPath[0]))
+      std::string modelName = model.Name();
+      if (!modelName.empty() && isdigit(modelName[0]))
       {
-        modelPath = "_" + modelPath;
+        modelName = "_" + modelName;
       }
+      auto modelPath = std::string(_path + "/" + modelName);
+      modelPath = ignition::common::replaceAll(modelPath, " ", "");
       UsdErrors modelErrors =
         ParseSdfModel(model, _stage, modelPath, worldPrimPath);
       if (!modelErrors.empty())
       {
         errors.push_back(UsdError(
               sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
-              "Error parsing model [" + model.Name() + "]"));
+              "Error parsing model [" + modelName + "]"));
         errors.insert(errors.end(), modelErrors.begin(), modelErrors.end());
       }
     }

--- a/usd/src/sdf_parser/sdf2usd_TEST.cc
+++ b/usd/src/sdf_parser/sdf2usd_TEST.cc
@@ -114,31 +114,20 @@ TEST(check_cmd_model, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     EXPECT_FALSE(ignition::common::isFile(outputUsdFilePath));
     std::string output =
       custom_exec_str(sdf2usdCommand() + " " + path + " " + outputUsdFilePath);
-    // TODO(adlarkin) make sure 'output' (i.e., the result of running the
-    // sdf2usd executable) is an empty string once the usd2sdf parser is fully
-    // implemented (right now, running the parser outputs an error indicating
-    // that functionality isn't complete)
+    EXPECT_TRUE(output.empty());
 
-    // make sure that a shapes.usd file was generated
+    // make sure that a ellipsoid.usd file was generated
     EXPECT_TRUE(ignition::common::isFile(outputUsdFilePath)) << output;
 
     const auto stage = pxr::UsdStage::Open(outputUsdFilePath);
+    ASSERT_TRUE(stage);
 
-    auto modelUSD = stage->GetPrimAtPath(pxr::SdfPath("/ellipsoid"));
-    ASSERT_TRUE(modelUSD);
-
-    modelUSD = stage->GetPrimAtPath(
-      pxr::SdfPath("/ellipsoid/ellipsoid_link"));
-    ASSERT_TRUE(modelUSD);
-
-    modelUSD = stage->GetPrimAtPath(
-      pxr::SdfPath("/ellipsoid/ellipsoid_link/ellipsoid_visual"));
-    ASSERT_TRUE(modelUSD);
-
-    modelUSD = stage->GetPrimAtPath(
-      pxr::SdfPath("/ellipsoid/ellipsoid_link/ellipsoid_visual/geometry"));
-    ASSERT_TRUE(modelUSD);
-    // TODO(ahcorde): Check the contents of outputUsdFilePath when the parser
-    // is implemented
+    ASSERT_TRUE(stage->GetPrimAtPath(pxr::SdfPath("/ellipsoid")));
+    ASSERT_TRUE(stage->GetPrimAtPath(
+      pxr::SdfPath("/ellipsoid/ellipsoid_link")));
+    ASSERT_TRUE(stage->GetPrimAtPath(
+      pxr::SdfPath("/ellipsoid/ellipsoid_link/ellipsoid_visual")));
+    ASSERT_TRUE(stage->GetPrimAtPath(
+      pxr::SdfPath("/ellipsoid/ellipsoid_link/ellipsoid_visual/geometry")));
   }
 }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🎉 New feature

## Summary

Right now sdf2usd only support SDF world, this PR allows to convert models too.

Most of the models inside fuel will be supported

## Test it

Dowload this [model](https://app.ignitionrobotics.org/chapulina/fuel/models/Extinguisher%20PBR) and run `sdf2usd`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
