### PR TITLE
Added OutputConfig

### DIFF
--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -24,6 +24,7 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/utils/ImplPtr.hh>
 #include "sdf/Element.hh"
+#include "sdf/OutputConfig.hh"
 #include "sdf/ParserConfig.hh"
 #include "sdf/Plugin.hh"
 #include "sdf/SemanticPose.hh"
@@ -421,7 +422,7 @@ namespace sdf
     /// model.
     /// Note that parameter passing functionality is not captured with this
     /// function.
-    /// \param[in] _config Parser configuration. When the ToElementUseIncludeTag
+    /// \param[in] _config Output configuration. When the ToElementUseIncludeTag
     /// policy is true, the model's URI is used to create
     /// an SDF `<include>` rather than a `<model>`. The model's URI must be
     /// first set using the `Model::SetUri` function. If the model's URI is
@@ -432,7 +433,7 @@ namespace sdf
     /// automatically expand an `<include>` element to a `<model>` element.
     /// \return SDF element pointer with updated model values.
     public: sdf::ElementPtr ToElement(
-        const ParserConfig &_config = ParserConfig::GlobalConfig()) const;
+        const OutputConfig &_config = OutputConfig::GlobalConfig()) const;
 
     /// \brief Check if a given name exists in the FrameAttachedTo graph at the
     /// scope of the model.

--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -174,28 +174,6 @@ class SDFORMAT_VISIBLE ParserConfig
   /// \brief Get the preserveFixedJoint flag value.
   public: bool URDFPreserveFixedJoint() const;
 
-  /// \brief Several DOM classes have ToElement() methods that return an
-  /// XML Element populated from the contents of the DOM object. When
-  /// populating the details of a model that was included using the
-  /// <include> tag, one may wish to retain the exact include tag and
-  /// URI instead of copying the full details of the included model.
-  /// This method lets you set this behavior.
-  /// \param[in] _useIncludeTag When true, the model's URI is used to create
-  /// an SDF `<include>` rather than a `<model>`. The model's URI must be
-  /// first set using the `Model::SetUri` function. If the model's URI is
-  /// empty, then a `<model>` element will be generated. The default is true
-  /// so that URI values are used when ToElement is called from a
-  /// World object. Make sure to use `Model::SetUri` even when the model
-  /// is loaded from an `<include>` tag since the parser will
-  /// automatically expand an `<include>` element to a `<model>` element.
-  public: void SetToElementUseIncludeTag(bool _useIncludeTag);
-
-  /// \brief Get the policy value about whether <include> tags are
-  /// reconstituted in ToElement() invocations.
-  /// \return True if include tags are reconstituted, or false
-  /// if the fully populated model is returned instead.
-  public: bool ToElementUseIncludeTag() const;
-
   /// \brief Private data pointer.
   IGN_UTILS_IMPL_PTR(dataPtr)
 };

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -20,6 +20,7 @@
 #include <string>
 #include <ignition/utils/ImplPtr.hh>
 
+#include "sdf/OutputConfig.hh"
 #include "sdf/ParserConfig.hh"
 #include "sdf/SDFImpl.hh"
 #include "sdf/Types.hh"
@@ -203,10 +204,10 @@ namespace sdf
     /// root.
     /// Note that parameter passing functionality is not captured with this
     /// function.
-    /// \param[in] _config Custom parser configuration
+    /// \param[in] _config Custom output configuration
     /// \return SDF element pointer with updated root values.
     public: sdf::ElementPtr ToElement(
-        const ParserConfig &_config = ParserConfig::GlobalConfig()) const;
+        const OutputConfig &_config = OutputConfig::GlobalConfig()) const;
 
     /// \brief Private data pointer
     IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -27,6 +27,7 @@
 #include "sdf/Atmosphere.hh"
 #include "sdf/Element.hh"
 #include "sdf/Gui.hh"
+#include "sdf/OutputConfig.hh"
 #include "sdf/ParserConfig.hh"
 #include "sdf/Plugin.hh"
 #include "sdf/Scene.hh"
@@ -435,7 +436,7 @@ namespace sdf
     /// \param[in] _config Custom parser configuration
     /// \return SDF element pointer with updated world values.
     public: sdf::ElementPtr ToElement(
-        const ParserConfig &_config = ParserConfig::GlobalConfig()) const;
+        const OutputConfig &_config = OutputConfig::GlobalConfig()) const;
 
     /// \brief Get the plugins attached to this object.
     /// \return A vector of Plugin, which will be empty if there are no

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -974,7 +974,7 @@ void Model::SetUri(const std::string &_uri)
 }
 
 /////////////////////////////////////////////////
-sdf::ElementPtr Model::ToElement(const ParserConfig &_config) const
+sdf::ElementPtr Model::ToElement(const OutputConfig &_config) const
 {
   if (_config.ToElementUseIncludeTag() && !this->dataPtr->uri.empty())
   {

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -455,7 +455,7 @@ TEST(DOMModel, Uri)
 
   // ToElement NOT using the URI, which should result in a <model>
   {
-    sdf::ParserConfig config = sdf::ParserConfig::GlobalConfig();
+    sdf::OutputConfig config = sdf::OutputConfig::GlobalConfig();
     config.SetToElementUseIncludeTag(false);
     sdf::ElementPtr elem = model.ToElement(config);
     elem->PrintValues("  ");

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -173,15 +173,3 @@ bool ParserConfig::URDFPreserveFixedJoint() const
 {
   return this->dataPtr->preserveFixedJoint;
 }
-
-/////////////////////////////////////////////////
-void ParserConfig::SetToElementUseIncludeTag(bool _useIncludeTag)
-{
-  this->dataPtr->toElementUseIncludeTag = _useIncludeTag;
-}
-
-/////////////////////////////////////////////////
-bool ParserConfig::ToElementUseIncludeTag() const
-{
-  return this->dataPtr->toElementUseIncludeTag;
-}

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -525,7 +525,7 @@ void Root::Implementation::UpdateGraphs(sdf::Model &_model,
 }
 
 /////////////////////////////////////////////////
-sdf::ElementPtr Root::ToElement(const ParserConfig &_config) const
+sdf::ElementPtr Root::ToElement(const OutputConfig &_config) const
 {
   sdf::ElementPtr elem(new sdf::Element);
   sdf::initFile("root.sdf", elem);

--- a/src/World.cc
+++ b/src/World.cc
@@ -856,7 +856,7 @@ Errors World::Implementation::LoadSphericalCoordinates(
 }
 
 /////////////////////////////////////////////////
-sdf::ElementPtr World::ToElement(const ParserConfig &_config) const
+sdf::ElementPtr World::ToElement(const OutputConfig &_config) const
 {
   sdf::ElementPtr elem(new sdf::Element);
   sdf::initFile("world.sdf", elem);

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -698,10 +698,11 @@ TEST(DOMModel, IncludeModelWithPlugin)
   const sdf::Model *model = world->ModelByIndex(0);
   ASSERT_NE(nullptr, model);
 
+  sdf::OutputConfig outConfig;
   // Test ToElement with useInclude == true
   {
-    config.SetToElementUseIncludeTag(true);
-    sdf::ElementPtr elem = model->ToElement(config);
+    outConfig.SetToElementUseIncludeTag(true);
+    sdf::ElementPtr elem = model->ToElement(outConfig);
 
     // There should be a uri
     ASSERT_TRUE(elem->HasElement("uri"));
@@ -724,8 +725,8 @@ TEST(DOMModel, IncludeModelWithPlugin)
   // model SDF which would have two plugins, one from the <include> tag and
   // one from the included model
   {
-    config.SetToElementUseIncludeTag(false);
-    sdf::ElementPtr elem = model->ToElement(config);
+    outConfig.SetToElementUseIncludeTag(false);
+    sdf::ElementPtr elem = model->ToElement(outConfig);
 
     // There should NOT be a uri
     ASSERT_FALSE(elem->HasElement("uri"));


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Adds an `OutputConfig` class to control `ToElement` and other output configurations.

## Test it

The tests have been updated.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.