### PR TITLE
DOC 1.9: clarify behavior of //model/model/static

### DIFF
--- a/sdf/1.9/model.sdf
+++ b/sdf/1.9/model.sdf
@@ -14,9 +14,11 @@
   <attribute name="canonical_link" type="string" default="" required="0">
     <description>
       The name of the model's canonical link, to which the model's implicit
-      coordinate frame is attached. If unset or set to an empty string,
-      the first link element listed as a child of this model is chosen
-      as the canonical link.
+      coordinate frame is attached. If unset or set to an empty string, the
+      first `/link` listed as a direct child of this model is chosen as the
+      canonical link. If the model has no direct `/link` children, it will
+      instead be attached to the first nested (or included) model's implicit
+      frame.
     </description>
   </attribute>
   <attribute name="placement_frame" type="string" default="" required="0">
@@ -24,7 +26,13 @@
   </attribute>
 
   <element name="static" type="bool" default="false" required="0">
-    <description>If set to true, the model is immovable. Otherwise the model is simulated in the dynamics engine.</description>
+    <description>
+      If set to true, the model is immovable; i.e., a dynamics engine will not
+      update its position. This will also overwrite this model's `@canonical_link`
+      and instead attach the model's implicit frame to the world's implicit frame.
+      This holds even if this model is nested (or included) by another model
+      instead of being a direct child of `//world`.
+    </description>
   </element>
 
   <element name="self_collide" type="bool" default="false" required="0">


### PR DESCRIPTION
# 🦟 Bug fix

Fixes an incomplete forward port of #713.

## Summary

These changes were applied to SDFormat 1.8 in #713 but were not propagated to 1.9 after being merged forward. This completes the merge.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
