### PR TITLE
USD -> SDF transform fixes

### DIFF
--- a/test/usd/nested_transforms.usda
+++ b/test/usd/nested_transforms.usda
@@ -19,4 +19,18 @@ def "transforms"
             uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ"]
         }
     }
+
+    def Xform "nested_transforms_ZYX"
+    {
+        float3 xformOp:rotateZYX = (90, 0, 0)
+        double3 xformOp:translate = (1, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX"]
+
+        def Xform "child_transform"
+        {
+            float3 xformOp:rotateZYX = (0, 0, 0)
+            double3 xformOp:translate = (1, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX"]
+        }
+    }
 }

--- a/usd/include/sdf/usd/usd_parser/USDTransforms.hh
+++ b/usd/include/sdf/usd/usd_parser/USDTransforms.hh
@@ -53,8 +53,6 @@ namespace sdf
     /// This might contain scale, translate or rotation operations
     /// The booleans are used to check if there is a transform defined
     /// in the schema
-    /// Rotation is splitted in a vector because this might be defined
-    /// as a rotation of 3 angles (ZYX, XYZ, etc).
     class IGNITION_SDFORMAT_USD_VISIBLE UDSTransforms
     {
       /// \brief Default constructor
@@ -68,13 +66,10 @@ namespace sdf
       /// \return A 3D vector with the scale
       public: const ignition::math::Vector3d Scale() const;
 
-      /// \brief Rotation
-      /// \return Return a vector with all the rotations
-      /// If RotationXYZ or RotationZYY is true, this method will return a
-      /// vector of 3 quaternions, Rotation<axis1><axis2><axis3> with the first
-      /// quaternion being rotation <axis1>, the second being rotation about
-      /// <axis2>, and the third being rotation about <axis3>
-      public: const std::vector<ignition::math::Quaterniond> Rotations() const;
+      /// \brief Get the Rotation
+      /// \return Return The rotation, if one exists. If no rotation exists,
+      /// std::nullopt is returned
+      public: const std::optional<ignition::math::Quaterniond> Rotation() const;
 
       /// \brief Set translate
       /// \param[in] _translate Translate to set
@@ -84,33 +79,9 @@ namespace sdf
       /// \param[in] _scale Scale to set
       public: void SetScale(const ignition::math::Vector3d &_scale);
 
-      /// \brief Add rotation
-      /// \param[in] _q Quaternion to add to the list of rotations
-      public: void AddRotation(const ignition::math::Quaterniond &_q);
-
-      /// \brief True if there is a rotation ZYX defined or false otherwise
-      public: bool RotationZYX() const;
-
-      /// \brief True if there is a rotation XYZ defined or false otherwise
-      public: bool RotationXYZ() const;
-
-      /// \brief True if there is a rotation (as a quaternion) defined
-      /// or false otherwise
-      public: bool Rotation() const;
-
-      /// \brief Set if there is any rotation ZYX defined
-      /// RotationZYX is used to determine the order of stored rotations
-      /// If RotationZYX is true, then Rotation should be True too
-      /// If Rotation is false, then RotationZYX cannot be true
-      /// \param[in] _rotationZYX If the rotation is ZYX (true) or not (false)
-      public: void SetRotationZYX(bool _rotationZYX);
-
-      /// \brief Set if there is any rotation XYZ defined
-      /// RotationXYZ is used to determine the order of stored rotations
-      /// If RotationXYZ is true, then Rotation should be True too
-      /// If Rotation is false, then RotationXYZ cannot be true
-      /// \param[in] _rotationXYZ If the rotation is XYZ (true) or not (false)
-      public: void SetRotationXYZ(bool _rotationXYZ);
+      /// \brief Set rotation
+      /// \param[in] _q Quaternion that defines the rotation
+      public: void SetRotation(const ignition::math::Quaterniond &_q);
 
       /// \brief Private data pointer.
       IGN_UTILS_IMPL_PTR(dataPtr)

--- a/usd/src/usd_parser/USDTransforms.cc
+++ b/usd/src/usd_parser/USDTransforms.cc
@@ -17,6 +17,8 @@
 
 #include "sdf/usd/usd_parser/USDTransforms.hh"
 
+#include <utility>
+
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
 
@@ -212,18 +214,9 @@ void GetAllTransforms(
         t.Translation() * metersPerUnit,
         ignition::math::Quaterniond(1, 0, 0, 0));
 
-      if (t.RotationZYX())
-      {
-        _tfs.push_back(poseZ);
-        _tfs.push_back(poseY);
-        _tfs.push_back(poseX);
-      }
-      else if (t.RotationXYZ())
-      {
-        _tfs.push_back(poseX);
-        _tfs.push_back(poseY);
-        _tfs.push_back(poseZ);
-      }
+      _tfs.push_back(poseX);
+      _tfs.push_back(poseY);
+      _tfs.push_back(poseZ);
       _tfs.push_back(poseT);
     }
     parent = parent.GetParent();
@@ -320,6 +313,10 @@ UDSTransforms ParseUSDTransform(const pxr::UsdPrim &_prim)
       ignition::math::Angle angleX(IGN_DTOR(rotationEuler[0]));
       ignition::math::Angle angleY(IGN_DTOR(rotationEuler[1]));
       ignition::math::Angle angleZ(IGN_DTOR(rotationEuler[2]));
+      if (t.RotationZYX())
+      {
+        std::swap(angleX, angleZ);
+      }
       qX = ignition::math::Quaterniond(angleX.Normalized().Radian(), 0, 0);
       qY = ignition::math::Quaterniond(0, angleY.Normalized().Radian(), 0);
       qZ = ignition::math::Quaterniond(0, 0, angleZ.Normalized().Radian());

--- a/usd/src/usd_parser/USDTransforms.cc
+++ b/usd/src/usd_parser/USDTransforms.cc
@@ -17,6 +17,7 @@
 
 #include "sdf/usd/usd_parser/USDTransforms.hh"
 
+#include <optional>
 #include <utility>
 
 #include <ignition/math/Pose3.hh>
@@ -51,16 +52,10 @@ class UDSTransforms::Implementation
   public: ignition::math::Vector3d scale{1, 1, 1};
 
   /// \brief Rotation of the schema
-  public: std::vector<ignition::math::Quaterniond> q;
+  public: std::optional<ignition::math::Quaterniond> q = std::nullopt;
 
   /// \brief Translation of the schema
   public: ignition::math::Vector3d translate{0, 0, 0};
-
-  /// \brief True if there is a rotation ZYX defined or false otherwise
-  public: bool isRotationZYX = false;
-
-  /// \brief True if there is a rotation XYZ defined or false otherwise
-  public: bool isRotationXYZ = false;
 };
 
 /////////////////////////////////////////////////
@@ -82,8 +77,7 @@ const ignition::math::Vector3d UDSTransforms::Scale() const
 }
 
 //////////////////////////////////////////////////
-const std::vector<ignition::math::Quaterniond>
-  UDSTransforms::Rotations() const
+const std::optional<ignition::math::Quaterniond> UDSTransforms::Rotation() const
 {
   return this->dataPtr->q;
 }
@@ -103,44 +97,10 @@ void UDSTransforms::SetScale(
 }
 
 //////////////////////////////////////////////////
-void UDSTransforms::AddRotation(
+void UDSTransforms::SetRotation(
   const ignition::math::Quaterniond &_q)
 {
-  this->dataPtr->q.push_back(_q);
-}
-
-//////////////////////////////////////////////////
-bool UDSTransforms::RotationZYX() const
-{
-  return this->dataPtr->isRotationZYX;
-}
-
-//////////////////////////////////////////////////
-bool UDSTransforms::RotationXYZ() const
-{
-  return this->dataPtr->isRotationXYZ;
-}
-
-//////////////////////////////////////////////////
-bool UDSTransforms::Rotation() const
-{
-  return !this->dataPtr->q.empty();
-}
-
-//////////////////////////////////////////////////
-void UDSTransforms::SetRotationZYX(bool _rotationZYX)
-{
-  this->dataPtr->isRotationZYX = _rotationZYX;
-  if (_rotationZYX)
-    this->dataPtr->isRotationXYZ = false;
-}
-
-//////////////////////////////////////////////////
-void UDSTransforms::SetRotationXYZ(bool _rotationXYZ)
-{
-  this->dataPtr->isRotationXYZ = _rotationXYZ;
-  if (_rotationXYZ)
-    this->dataPtr->isRotationZYX = false;
+  this->dataPtr->q = _q;
 }
 
 //////////////////////////////////////////////////
@@ -193,32 +153,11 @@ void GetAllTransforms(
         child.Pos().Z() * t.Scale()[2]);
     }
 
-    if (!t.RotationZYX() && !t.RotationXYZ())
+    if (t.Rotation())
     {
-      if (t.Rotation())
-      {
-        pose.Rot() = t.Rotations()[0];
-      }
-      _tfs.push_back(pose);
+      pose.Rot() = t.Rotation().value();
     }
-    else
-    {
-      ignition::math::Pose3d poseZ = ignition::math::Pose3d(
-        ignition::math::Vector3d(0, 0, 0), t.Rotations()[2]);
-      ignition::math::Pose3d poseY = ignition::math::Pose3d(
-        ignition::math::Vector3d(0, 0, 0), t.Rotations()[1]);
-      ignition::math::Pose3d poseX = ignition::math::Pose3d(
-        ignition::math::Vector3d(0, 0, 0), t.Rotations()[0]);
-
-      ignition::math::Pose3d poseT = ignition::math::Pose3d(
-        t.Translation() * metersPerUnit,
-        ignition::math::Quaterniond(1, 0, 0, 0));
-
-      _tfs.push_back(poseX);
-      _tfs.push_back(poseY);
-      _tfs.push_back(poseZ);
-      _tfs.push_back(poseT);
-    }
+    _tfs.push_back(pose);
     parent = parent.GetParent();
   }
 
@@ -290,12 +229,10 @@ UDSTransforms ParseUSDTransform(const pxr::UsdPrim &_prim)
       if (op == kXFormOpRotateZYX)
       {
         attribute = _prim.GetAttribute(pxr::TfToken(kXFormOpRotateZYX));
-        t.SetRotationZYX(true);
       }
       else
       {
         attribute = _prim.GetAttribute(pxr::TfToken(kXFormOpRotateXYZ));
-        t.SetRotationXYZ(true);
       }
       if (attribute.GetTypeName().GetCPPTypeName() == kGfVec3fString)
       {
@@ -313,17 +250,14 @@ UDSTransforms ParseUSDTransform(const pxr::UsdPrim &_prim)
       ignition::math::Angle angleX(IGN_DTOR(rotationEuler[0]));
       ignition::math::Angle angleY(IGN_DTOR(rotationEuler[1]));
       ignition::math::Angle angleZ(IGN_DTOR(rotationEuler[2]));
-      if (t.RotationZYX())
+      if (op == kXFormOpRotateZYX)
       {
         std::swap(angleX, angleZ);
       }
-      qX = ignition::math::Quaterniond(angleX.Normalized().Radian(), 0, 0);
-      qY = ignition::math::Quaterniond(0, angleY.Normalized().Radian(), 0);
-      qZ = ignition::math::Quaterniond(0, 0, angleZ.Normalized().Radian());
-
-      t.AddRotation(qX);
-      t.AddRotation(qY);
-      t.AddRotation(qZ);
+      t.SetRotation(ignition::math::Quaterniond(
+            angleX.Normalized().Radian(),
+            angleY.Normalized().Radian(),
+            angleZ.Normalized().Radian()));
     }
     else if (op == kXFormOpTranslate)
     {
@@ -367,7 +301,7 @@ UDSTransforms ParseUSDTransform(const pxr::UsdPrim &_prim)
         rotationQuad.GetImaginary()[0],
         rotationQuad.GetImaginary()[1],
         rotationQuad.GetImaginary()[2]);
-      t.AddRotation(q);
+      t.SetRotation(q);
     }
 
     if (op == kXFormOpTransform)
@@ -394,7 +328,7 @@ UDSTransforms ParseUSDTransform(const pxr::UsdPrim &_prim)
         rotQuat.GetImaginary()[1],
         rotQuat.GetImaginary()[2]
       );
-      t.AddRotation(q);
+      t.SetRotation(q);
     }
   }
   return t;

--- a/usd/src/usd_parser/USDTransforms_TEST.cc
+++ b/usd/src/usd_parser/USDTransforms_TEST.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <functional>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -119,9 +120,9 @@ TEST(USDTransformsTest, ParseUSDTransform)
     stage,
     ignition::math::Vector3d(0, 1.5, 0.5),
     {
-      ignition::math::Quaterniond(IGN_DTOR(-69), 0, 0),
+      ignition::math::Quaterniond(IGN_DTOR(-62), 0, 0),
       ignition::math::Quaterniond(0, IGN_DTOR(31), 0),
-      ignition::math::Quaterniond(0, 0, IGN_DTOR(-62))
+      ignition::math::Quaterniond(0, 0, IGN_DTOR(-69))
     },
     ignition::math::Vector3d(1, 1, 1),
     false,
@@ -133,9 +134,9 @@ TEST(USDTransformsTest, ParseUSDTransform)
     stage,
     ignition::math::Vector3d(0, -3.0, 0.5),
     {
-      ignition::math::Quaterniond(IGN_DTOR(15), 0, 0),
+      ignition::math::Quaterniond(IGN_DTOR(-55), 0, 0),
       ignition::math::Quaterniond(0, IGN_DTOR(80), 0),
-      ignition::math::Quaterniond(0, 0, IGN_DTOR(-55))
+      ignition::math::Quaterniond(0, 0, IGN_DTOR(15))
     },
     ignition::math::Vector3d(1, 1, 1),
     false,
@@ -147,9 +148,9 @@ TEST(USDTransformsTest, ParseUSDTransform)
     stage,
     ignition::math::Vector3d(0, 0, 0),
     {
+      ignition::math::Quaterniond(M_PI_2, 0, 0),
       ignition::math::Quaterniond(1, 0, 0, 0),
-      ignition::math::Quaterniond(1, 0, 0, 0),
-      ignition::math::Quaterniond(0, 0, M_PI_2)
+      ignition::math::Quaterniond(1, 0, 0, 0)
     },
     ignition::math::Vector3d(1, 1, 1),
     false,
@@ -233,20 +234,26 @@ TEST(USDTransformsTest, GetAllTransform)
     sdf::usd::USDData usdData(filename);
     usdData.Init();
 
-    const pxr::UsdPrim prim = stage->GetPrimAtPath(
-        pxr::SdfPath("/transforms/nested_transforms_XYZ/child_transform"));
-    ASSERT_TRUE(prim);
+    std::function<void(const std::string &)> verifyNestedTf =
+      [&](const std::string &_path)
+      {
+        pxr::UsdPrim prim = stage->GetPrimAtPath(pxr::SdfPath(_path));
+        ASSERT_TRUE(prim);
 
-    ignition::math::Pose3d pose;
-    ignition::math::Vector3d scale{1, 1, 1};
+        ignition::math::Pose3d pose;
+        ignition::math::Vector3d scale{1, 1, 1};
 
-    sdf::usd::GetTransform(prim, usdData, pose, scale, "/transforms");
+        sdf::usd::GetTransform(prim, usdData, pose, scale, "/transforms");
 
-    EXPECT_EQ(ignition::math::Vector3d(1, 1, 1), scale);
-    EXPECT_EQ(
-      ignition::math::Pose3d(
-        ignition::math::Vector3d(.01, .01, 0),
-        ignition::math::Quaterniond(0, 0, IGN_DTOR(90))),
-      pose);
+        EXPECT_EQ(ignition::math::Vector3d(1, 1, 1), scale);
+        EXPECT_EQ(
+          ignition::math::Pose3d(
+            ignition::math::Vector3d(.01, .01, 0),
+            ignition::math::Quaterniond(0, 0, IGN_DTOR(90))),
+          pose);
+      };
+
+    verifyNestedTf("/transforms/nested_transforms_XYZ/child_transform");
+    verifyNestedTf("/transforms/nested_transforms_ZYX/child_transform");
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Here are some proposals I have after reviewing #871:
1. Make sure to swap the `X` and `Z` rotation angles if the rotation is defined as `RotationZYX` instead of `RotationXYZ`
2. Store all of the rotations in a single quaternion instead of a list of quaternions, since the angles of rotation are all along a unique axis (x, y, or z).

The following changes simplify the API for the `UsdTransforms` class. Now, we no longer need methods for determining whether a rotation exists and if its XYZ/ZYX.

I have also added a test case that uses the new `nested_transforms_ZYX` prim defined in `test/usd/nested_transforms.usda`. Without swapping the `X` and `Z` rotation angles for this prim, the test fails.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers