### PR TITLE
SDF to USD: Added collision tag

### DIFF
--- a/usd/src/CMakeLists.txt
+++ b/usd/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(sources
   Conversions.cc
   UsdError.cc
+  sdf_parser/Collision.cc
   sdf_parser/Geometry.cc
   sdf_parser/Joint.cc
   sdf_parser/Light.cc
@@ -72,6 +73,7 @@ endif()
 
 set(sdf2usd_test_sources
   Conversions.cc
+  sdf_parser/Collision.cc
   sdf_parser/Geometry.cc
   sdf_parser/Joint.cc
   sdf_parser/Light.cc

--- a/usd/src/cmd/CMakeLists.txt
+++ b/usd/src/cmd/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(TARGET ${usd_target})
   add_executable(sdf2usd
     sdf2usd.cc
+    ../sdf_parser/Collision.cc
     ../sdf_parser/Model.cc
     ../sdf_parser/Joint.cc
     ../sdf_parser/Link.cc

--- a/usd/src/sdf_parser/Collision.cc
+++ b/usd/src/sdf_parser/Collision.cc
@@ -39,7 +39,7 @@
 
 namespace sdf
 {
-// Inline bracke to help doxygen filtering.
+// Inline bracket to help doxygen filtering.
 inline namespace SDF_VERSION_NAMESPACE {
 //
 namespace usd
@@ -58,7 +58,7 @@ namespace usd
       return errors;
     }
 
-    auto collisionPrim = _stage->GetPrimAtPath(pxr::SdfPath(sdfCollisionPath));
+    auto collisionPrim = _stage->GetPrimAtPath(sdfCollisionPath);
     collisionPrim.CreateAttribute(pxr::TfToken("purpose"),
         pxr::SdfValueTypeNames->Token, false).Set(pxr::TfToken("guide"));
 
@@ -77,7 +77,7 @@ namespace usd
       for (const auto &e : poseErrors)
         errors.push_back(e);
       errors.push_back(UsdError(UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
-            "Unable to set the pose of the link prim corresponding to the "
+            "Unable to set the pose of the prim corresponding to the "
             "SDF collision named [" + _collision.Name() + "]"));
       return errors;
     }
@@ -108,8 +108,7 @@ namespace usd
     {
       errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
         "Internal error: unable to apply a collision to the prim at path ["
-        + _path + "]"));
-      return errors;
+        + geometryPath + "]"));
     }
 
     return errors;

--- a/usd/src/sdf_parser/Collision.cc
+++ b/usd/src/sdf_parser/Collision.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Collision.hh"
+
+#include <string>
+
+#include <ignition/math/Pose3.hh>
+
+// TODO(adlarkin) this is to remove deprecated "warnings" in usd, these warnings
+// are reported using #pragma message so normal diagnostic flags cannot remove
+// them. This workaround requires this block to be used whenever usd is
+// included.
+#pragma push_macro ("__DEPRECATED")
+#undef __DEPRECATED
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdGeom/xform.h>
+#include <pxr/usd/usdPhysics/collisionAPI.h>
+#pragma pop_macro ("__DEPRECATED")
+
+#include "sdf/Collision.hh"
+#include "../UsdUtils.hh"
+#include "Geometry.hh"
+
+namespace sdf
+{
+// Inline bracke to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+//
+namespace usd
+{
+  UsdErrors ParseSdfCollision(const sdf::Collision &_collision,
+      pxr::UsdStageRefPtr &_stage, const std::string &_path)
+  {
+    UsdErrors errors;
+    const pxr::SdfPath sdfCollisionPath(_path);
+    auto usdCollisionXform = pxr::UsdGeomXform::Define(_stage, sdfCollisionPath);
+    if (!usdCollisionXform)
+    {
+      errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_USD_DEFINITION,
+        "Not able to define a Geom Xform at path [" + _path + "]"));
+      return errors;
+    }
+
+    auto primlol = _stage->GetPrimAtPath(pxr::SdfPath(sdfCollisionPath));
+    primlol.CreateAttribute(pxr::TfToken("purpose"),
+        pxr::SdfValueTypeNames->Token, false).Set(pxr::TfToken("guide"));
+    // auto visibilityProp = primlol.HasProperty(pxr::TfToken("visibility"));
+    // auto property = primlol.GetProperty(pxr::TfToken("visibility"));
+    // auto extentAttr = primlol.GetAttribute(pxr::TfToken("visibility"));
+    // extentAttr.Set(pxr::TfToken("guide"));
+    // std::cerr << "visibilityProp " << visibilityProp << '\n';
+
+    ignition::math::Pose3d pose;
+    auto poseErrors = usd::PoseWrtParent(_collision, pose);
+    if (!poseErrors.empty())
+    {
+      for (const auto &e : poseErrors)
+        errors.push_back(e);
+      return errors;
+    }
+
+    poseErrors = usd::SetPose(pose, _stage, sdfCollisionPath);
+    if (!poseErrors.empty())
+    {
+      for (const auto &e : poseErrors)
+        errors.push_back(e);
+      errors.push_back(UsdError(UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
+            "Unable to set the pose of the link prim corresponding to the "
+            "SDF collision named [" + _collision.Name() + "]"));
+      return errors;
+    }
+
+    const auto geometry = *(_collision.Geom());
+    const auto geometryPath = std::string(_path + "/geometry");
+    auto geomErrors = ParseSdfGeometry(geometry, _stage, geometryPath);
+    if (!geomErrors.empty())
+    {
+      errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+      errors.push_back(UsdError(
+        sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
+        "Error parsing geometry attached to _collision [" + _collision.Name() + "]"));
+      return errors;
+    }
+
+    auto geomPrim = _stage->GetPrimAtPath(pxr::SdfPath(geometryPath));
+    if (!geomPrim)
+    {
+      errors.push_back(UsdError(sdf::usd::UsdErrorCode::INVALID_PRIM_PATH,
+        "Internal error: unable to get prim at path ["
+        + geometryPath + "], but a geom prim should exist at this path"));
+      return errors;
+    }
+
+    if (!pxr::UsdPhysicsCollisionAPI::Apply(geomPrim))
+    {
+      errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
+        "Internal error: unable to apply a collision to the prim at path ["
+        + _path + "]"));
+      return errors;
+    }
+
+    return errors;
+  }
+}
+}
+}

--- a/usd/src/sdf_parser/Collision.cc
+++ b/usd/src/sdf_parser/Collision.cc
@@ -49,7 +49,8 @@ namespace usd
   {
     UsdErrors errors;
     const pxr::SdfPath sdfCollisionPath(_path);
-    auto usdCollisionXform = pxr::UsdGeomXform::Define(_stage, sdfCollisionPath);
+    auto usdCollisionXform = pxr::UsdGeomXform::Define(
+      _stage, sdfCollisionPath);
     if (!usdCollisionXform)
     {
       errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_USD_DEFINITION,
@@ -57,14 +58,9 @@ namespace usd
       return errors;
     }
 
-    auto primlol = _stage->GetPrimAtPath(pxr::SdfPath(sdfCollisionPath));
-    primlol.CreateAttribute(pxr::TfToken("purpose"),
+    auto collisionPrim = _stage->GetPrimAtPath(pxr::SdfPath(sdfCollisionPath));
+    collisionPrim.CreateAttribute(pxr::TfToken("purpose"),
         pxr::SdfValueTypeNames->Token, false).Set(pxr::TfToken("guide"));
-    // auto visibilityProp = primlol.HasProperty(pxr::TfToken("visibility"));
-    // auto property = primlol.GetProperty(pxr::TfToken("visibility"));
-    // auto extentAttr = primlol.GetAttribute(pxr::TfToken("visibility"));
-    // extentAttr.Set(pxr::TfToken("guide"));
-    // std::cerr << "visibilityProp " << visibilityProp << '\n';
 
     ignition::math::Pose3d pose;
     auto poseErrors = usd::PoseWrtParent(_collision, pose);
@@ -94,7 +90,8 @@ namespace usd
       errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
       errors.push_back(UsdError(
         sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
-        "Error parsing geometry attached to _collision [" + _collision.Name() + "]"));
+        "Error parsing geometry attached to _collision [" +
+        _collision.Name() + "]"));
       return errors;
     }
 

--- a/usd/src/sdf_parser/Collision.cc
+++ b/usd/src/sdf_parser/Collision.cc
@@ -58,6 +58,17 @@ namespace usd
       return errors;
     }
 
+    // Purpose is a builtin attribute with 4 posible values.
+    // - *default* indicates that a prim has “no special purpose” and should
+    //   generally be included in all traversals
+    // - *render* should generally only be included when performing a
+    //   “final quality” render
+    // - *proxy* should generally only be included when performing a lightweight
+    //    proxy render (such as OpenGL)
+    // - *guide* should generally only be included when an interactive
+    //    application has been explicitly asked to “show guides”
+    // For collisions we need to define this as guide because we don't need
+    // to render anything
     auto collisionPrim = _stage->GetPrimAtPath(sdfCollisionPath);
     collisionPrim.CreateAttribute(pxr::TfToken("purpose"),
         pxr::SdfValueTypeNames->Token, false).Set(pxr::TfToken("guide"));

--- a/usd/src/sdf_parser/Collision.hh
+++ b/usd/src/sdf_parser/Collision.hh
@@ -35,7 +35,7 @@
 
 namespace sdf
 {
-  // Inline bracke to help doxygen filtering.
+  // Inline bracket to help doxygen filtering.
   inline namespace SDF_VERSION_NAMESPACE {
   //
   namespace usd

--- a/usd/src/sdf_parser/Collision.hh
+++ b/usd/src/sdf_parser/Collision.hh
@@ -44,8 +44,8 @@ namespace sdf
     /// \param[in] _collision The SDF collision to parse.
     /// \param[in] _stage The stage that should contain the USD representation
     /// of _collision.
-    /// \param[in] _path The USD path of the parsed collision in _stage, which must
-    /// be a valid USD path.
+    /// \param[in] _path The USD path of the parsed collision in _stage,
+    /// which must be a valid USD path.
     /// \return UsdErrors, which is a vector of UsdError objects. Each UsdError
     /// includes an error code and message. An empty vector indicates no error.
     UsdErrors ParseSdfCollision(

--- a/usd/src/sdf_parser/Collision.hh
+++ b/usd/src/sdf_parser/Collision.hh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SDF_USD_SDF_PARSER_COLLISION_HH_
+#define SDF_USD_SDF_PARSER_COLLISION_HH_
+
+#include <string>
+
+// TODO(adlarkin) this is to remove deprecated "warnings" in usd, these warnings
+// are reported using #pragma message so normal diagnostic flags cannot remove
+// them. This workaround requires this block to be used whenever usd is
+// included.
+#pragma push_macro ("__DEPRECATED")
+#undef __DEPRECATED
+#include <pxr/usd/usd/stage.h>
+#pragma pop_macro ("__DEPRECATED")
+
+#include "sdf/Collision.hh"
+#include "sdf/config.hh"
+#include "sdf/usd/UsdError.hh"
+
+namespace sdf
+{
+  // Inline bracke to help doxygen filtering.
+  inline namespace SDF_VERSION_NAMESPACE {
+  //
+  namespace usd
+  {
+    /// \brief Parse an SDF collision into a USD stage.
+    /// \param[in] _collision The SDF collision to parse.
+    /// \param[in] _stage The stage that should contain the USD representation
+    /// of _collision.
+    /// \param[in] _path The USD path of the parsed collision in _stage, which must
+    /// be a valid USD path.
+    /// \return UsdErrors, which is a vector of UsdError objects. Each UsdError
+    /// includes an error code and message. An empty vector indicates no error.
+    UsdErrors ParseSdfCollision(
+        const sdf::Collision &_collision,
+        pxr::UsdStageRefPtr &_stage,
+        const std::string &_path);
+  }
+  }
+}
+
+#endif

--- a/usd/src/sdf_parser/Geometry.cc
+++ b/usd/src/sdf_parser/Geometry.cc
@@ -45,7 +45,6 @@
 #include <pxr/usd/usdGeom/sphere.h>
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdGeom/xformCommonAPI.h>
-#include <pxr/usd/usdPhysics/collisionAPI.h>
 #include <pxr/usd/usdShade/material.h>
 #include <pxr/usd/usdShade/materialBindingAPI.h>
 #pragma pop_macro ("__DEPRECATED")
@@ -598,40 +597,6 @@ namespace usd
         errors.push_back(UsdError(
               sdf::Error(sdf::ErrorCode::ATTRIBUTE_INCORRECT_TYPE,
                 "Geometry type is either invalid or not supported")));
-    }
-
-    // Set the collision for this geometry.
-    // In SDF, the collisions of a link are defined separately from
-    // the link's visual geometries (in case a user wants to define a simpler
-    // collision, for example). In USD, the collision can be attached to the
-    // geometry so that the collision shape is the geometry shape.
-    // The current approach that's taken here (attaching a collision to the
-    // geometry) assumes that for every visual in a link, the visual should have
-    // a collision that matches its geometry. This approach currently ignores
-    // collisions defined in a link since it instead creates collisions for a
-    // link that match a link's visual geometries.
-    // TODO(adlarkin) support the option of a different collision shape (i.e.,
-    // don't ignore collisions defined in a link),
-    // especially for meshes - here's more information about how to do this:
-    // https://graphics.pixar.com/usd/release/wp_rigid_body_physics.html?highlight=collision#turning-meshes-into-shapes
-    if (errors.empty())
-    {
-      auto geomPrim = _stage->GetPrimAtPath(pxr::SdfPath(_path));
-      if (!geomPrim)
-      {
-        errors.push_back(UsdError(sdf::usd::UsdErrorCode::INVALID_PRIM_PATH,
-          "Internal error: unable to get prim at path ["
-          + _path + "], but a geom prim should exist at this path"));
-        return errors;
-      }
-
-      if (!pxr::UsdPhysicsCollisionAPI::Apply(geomPrim))
-      {
-        errors.push_back(UsdError(sdf::usd::UsdErrorCode::FAILED_PRIM_API_APPLY,
-          "Internal error: unable to apply a collision to the prim at path ["
-          + _path + "]"));
-        return errors;
-      }
     }
 
     return errors;

--- a/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
@@ -153,7 +153,8 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string groundPlaneVisualPath = groundPlaneLinkPath + "/visual";
   const std::string groundPlaneGeometryPath =
     groundPlaneVisualPath + "/geometry";
-  const std::string groundPlaneCollisionPath = groundPlaneLinkPath + "/collision";
+  const std::string groundPlaneCollisionPath =
+    groundPlaneLinkPath + "/collision";
   const std::string groundPlaneCollisionGeometryPath =
     groundPlaneCollisionPath + "/geometry";
 
@@ -163,7 +164,8 @@ TEST_F(UsdStageFixture, Geometry)
 
   const auto groundPlaneCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(groundPlaneCollisionGeometryPath));
-  EXPECT_TRUE(groundPlaneCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
+  EXPECT_TRUE(
+    groundPlaneCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto groundPlaneGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(groundPlaneGeometryPath));
   ASSERT_TRUE(groundPlaneGeometry);
@@ -212,7 +214,8 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string cylinderVisualPath = cylinderLinkPath + "/visual";
   const std::string cylinderGeometryPath = cylinderVisualPath + "/geometry";
   const std::string cylinderCollisionPath = cylinderLinkPath + "/collision";
-  const std::string cylinderCollisionGeometryPath = cylinderCollisionPath + "/geometry";
+  const std::string cylinderCollisionGeometryPath =
+    cylinderCollisionPath + "/geometry";
   const auto cylinderCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(cylinderCollisionGeometryPath));
   EXPECT_TRUE(cylinderCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
@@ -235,7 +238,8 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string sphereVisualPath = sphereLinkPath + "/sphere_vis";
   const std::string sphereGeometryPath = sphereVisualPath + "/geometry";
   const std::string sphereCollisionPath = sphereLinkPath + "/collision";
-  const std::string sphereCollisionGeometryPath = sphereCollisionPath + "/geometry";
+  const std::string sphereCollisionGeometryPath =
+    sphereCollisionPath + "/geometry";
   const auto sphereCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(sphereCollisionGeometryPath));
   EXPECT_TRUE(sphereCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
@@ -274,7 +278,8 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string meshGeometryPath = meshVisualPath + "/geometry";
   const std::string meshGeometryMeshPath = meshGeometryPath + "/Cube";
   const std::string capsuleCollisionPath = capsuleLinkPath + "/collision";
-  const std::string capsuleCollisionGeometryPath = capsuleCollisionPath + "/geometry";
+  const std::string capsuleCollisionGeometryPath =
+    capsuleCollisionPath + "/geometry";
   const auto capsuleCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(capsuleCollisionGeometryPath));
   EXPECT_TRUE(capsuleCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());

--- a/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
@@ -164,6 +164,7 @@ TEST_F(UsdStageFixture, Geometry)
 
   const auto groundPlaneCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(groundPlaneCollisionGeometryPath));
+  ASSERT_TRUE(groundPlaneCollisionGeometry);
   EXPECT_TRUE(
     groundPlaneCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto groundPlaneGeometry = this->stage->GetPrimAtPath(
@@ -193,6 +194,7 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string boxCollisionGeometryPath = boxCollisionPath + "/geometry";
   const auto boxCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(boxCollisionGeometryPath));
+  ASSERT_TRUE(boxCollisionGeometry);
   EXPECT_TRUE(boxCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
 
   ASSERT_TRUE(boxGeometry);
@@ -218,6 +220,7 @@ TEST_F(UsdStageFixture, Geometry)
     cylinderCollisionPath + "/geometry";
   const auto cylinderCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(cylinderCollisionGeometryPath));
+  ASSERT_TRUE(cylinderCollisionGeometry);
   EXPECT_TRUE(cylinderCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto cylinderGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(cylinderGeometryPath));
@@ -242,6 +245,7 @@ TEST_F(UsdStageFixture, Geometry)
     sphereCollisionPath + "/geometry";
   const auto sphereCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(sphereCollisionGeometryPath));
+  ASSERT_TRUE(sphereCollisionGeometry);
   EXPECT_TRUE(sphereCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto sphereGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(sphereGeometryPath));
@@ -282,6 +286,7 @@ TEST_F(UsdStageFixture, Geometry)
     capsuleCollisionPath + "/geometry";
   const auto capsuleCollisionGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(capsuleCollisionGeometryPath));
+  ASSERT_TRUE(capsuleCollisionGeometry);
   EXPECT_TRUE(capsuleCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto meshGeometryParentPrim = this->stage->GetPrimAtPath(
       pxr::SdfPath(meshGeometryPath));

--- a/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
+++ b/usd/src/sdf_parser/Geometry_Sdf2Usd_TEST.cc
@@ -153,15 +153,20 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string groundPlaneVisualPath = groundPlaneLinkPath + "/visual";
   const std::string groundPlaneGeometryPath =
     groundPlaneVisualPath + "/geometry";
+  const std::string groundPlaneCollisionPath = groundPlaneLinkPath + "/collision";
+  const std::string groundPlaneCollisionGeometryPath =
+    groundPlaneCollisionPath + "/geometry";
 
   pxr::GfVec3f scale;
   pxr::VtArray<pxr::GfVec3f> extent;
   double size, height, radius, length;
 
+  const auto groundPlaneCollisionGeometry = this->stage->GetPrimAtPath(
+    pxr::SdfPath(groundPlaneCollisionGeometryPath));
+  EXPECT_TRUE(groundPlaneCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto groundPlaneGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(groundPlaneGeometryPath));
   ASSERT_TRUE(groundPlaneGeometry);
-  EXPECT_TRUE(groundPlaneGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto usdGroundPlane = pxr::UsdGeomCube(groundPlaneGeometry);
   ASSERT_TRUE(usdGroundPlane);
   usdGroundPlane.GetSizeAttr().Get(&size);
@@ -182,8 +187,13 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string boxGeometryPath = boxVisualPath + "/geometry";
   const auto boxGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(boxGeometryPath));
+  const std::string boxCollisionPath = boxLinkPath + "/collision";
+  const std::string boxCollisionGeometryPath = boxCollisionPath + "/geometry";
+  const auto boxCollisionGeometry = this->stage->GetPrimAtPath(
+    pxr::SdfPath(boxCollisionGeometryPath));
+  EXPECT_TRUE(boxCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
+
   ASSERT_TRUE(boxGeometry);
-  EXPECT_TRUE(boxGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto usdCube = pxr::UsdGeomCube(boxGeometry);
   ASSERT_TRUE(usdCube);
   usdCube.GetSizeAttr().Get(&size);
@@ -201,10 +211,14 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string cylinderLinkPath = cylinderPath + "/link";
   const std::string cylinderVisualPath = cylinderLinkPath + "/visual";
   const std::string cylinderGeometryPath = cylinderVisualPath + "/geometry";
+  const std::string cylinderCollisionPath = cylinderLinkPath + "/collision";
+  const std::string cylinderCollisionGeometryPath = cylinderCollisionPath + "/geometry";
+  const auto cylinderCollisionGeometry = this->stage->GetPrimAtPath(
+    pxr::SdfPath(cylinderCollisionGeometryPath));
+  EXPECT_TRUE(cylinderCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto cylinderGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(cylinderGeometryPath));
   ASSERT_TRUE(cylinderGeometry);
-  EXPECT_TRUE(cylinderGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto usdCylinder = pxr::UsdGeomCylinder(cylinderGeometry);
   ASSERT_TRUE(usdCylinder);
   usdCylinder.GetRadiusAttr().Get(&radius);
@@ -220,10 +234,14 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string sphereLinkPath = spherePath + "/link";
   const std::string sphereVisualPath = sphereLinkPath + "/sphere_vis";
   const std::string sphereGeometryPath = sphereVisualPath + "/geometry";
+  const std::string sphereCollisionPath = sphereLinkPath + "/collision";
+  const std::string sphereCollisionGeometryPath = sphereCollisionPath + "/geometry";
+  const auto sphereCollisionGeometry = this->stage->GetPrimAtPath(
+    pxr::SdfPath(sphereCollisionGeometryPath));
+  EXPECT_TRUE(sphereCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto sphereGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(sphereGeometryPath));
   ASSERT_TRUE(sphereGeometry);
-  EXPECT_TRUE(sphereGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto usdSphere = pxr::UsdGeomSphere(sphereGeometry);
   ASSERT_TRUE(usdSphere);
   usdSphere.GetRadiusAttr().Get(&radius);
@@ -239,7 +257,6 @@ TEST_F(UsdStageFixture, Geometry)
   const auto capsuleGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(capsuleGeometryPath));
   ASSERT_TRUE(capsuleGeometry);
-  EXPECT_TRUE(capsuleGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto usdCapsule = pxr::UsdGeomCapsule(capsuleGeometry);
   ASSERT_TRUE(usdCapsule);
   usdCapsule.GetRadiusAttr().Get(&radius);
@@ -256,10 +273,14 @@ TEST_F(UsdStageFixture, Geometry)
   const std::string meshVisualPath = meshLinkPath + "/visual";
   const std::string meshGeometryPath = meshVisualPath + "/geometry";
   const std::string meshGeometryMeshPath = meshGeometryPath + "/Cube";
+  const std::string capsuleCollisionPath = capsuleLinkPath + "/collision";
+  const std::string capsuleCollisionGeometryPath = capsuleCollisionPath + "/geometry";
+  const auto capsuleCollisionGeometry = this->stage->GetPrimAtPath(
+    pxr::SdfPath(capsuleCollisionGeometryPath));
+  EXPECT_TRUE(capsuleCollisionGeometry.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto meshGeometryParentPrim = this->stage->GetPrimAtPath(
       pxr::SdfPath(meshGeometryPath));
   ASSERT_TRUE(meshGeometryParentPrim);
-  EXPECT_TRUE(meshGeometryParentPrim.HasAPI<pxr::UsdPhysicsCollisionAPI>());
   const auto meshGeometry = this->stage->GetPrimAtPath(
     pxr::SdfPath(meshGeometryMeshPath));
   ASSERT_TRUE(meshGeometry);

--- a/usd/src/sdf_parser/Link.cc
+++ b/usd/src/sdf_parser/Link.cc
@@ -37,6 +37,7 @@
 
 #include "sdf/Link.hh"
 #include "../UsdUtils.hh"
+#include "Collision.hh"
 #include "Light.hh"
 #include "Sensor.hh"
 #include "Visual.hh"
@@ -138,6 +139,22 @@ namespace usd
         errors.push_back(UsdError(
           sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
           "Error parsing visual [" + visual.Name() + "]"));
+        return errors;
+      }
+    }
+
+    // parse all of the link's collision and convert them to USD
+    for (uint64_t i = 0; i < _link.CollisionCount(); ++i)
+    {
+      const auto collision = *(_link.CollisionByIndex(i));
+      const auto collisionPath = std::string(_path + "/" + collision.Name());
+      auto errorsLink = ParseSdfCollision(collision, _stage, collisionPath);
+      if (!errorsLink.empty())
+      {
+        errors.insert(errors.end(), errorsLink.begin(), errorsLink.end());
+        errors.push_back(UsdError(
+          sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
+          "Error parsing collision [" + collision.Name() + "]"));
         return errors;
       }
     }

--- a/usd/src/sdf_parser/Link.cc
+++ b/usd/src/sdf_parser/Link.cc
@@ -143,18 +143,21 @@ namespace usd
       }
     }
 
-    // parse all of the link's collision and convert them to USD
+    // parse all of the link's collisions and convert them to USD
     for (uint64_t i = 0; i < _link.CollisionCount(); ++i)
     {
       const auto collision = *(_link.CollisionByIndex(i));
       const auto collisionPath = std::string(_path + "/" + collision.Name());
-      auto errorsLink = ParseSdfCollision(collision, _stage, collisionPath);
-      if (!errorsLink.empty())
+      auto errorsCollision = ParseSdfCollision(collision, _stage,
+          collisionPath);
+      if (!errorsCollision.empty())
       {
-        errors.insert(errors.end(), errorsLink.begin(), errorsLink.end());
+        errors.insert(errors.end(), errorsCollision.begin(),
+            errorsCollision.end());
         errors.push_back(UsdError(
           sdf::usd::UsdErrorCode::SDF_TO_USD_PARSING_ERROR,
-          "Error parsing collision [" + collision.Name() + "]"));
+          "Error parsing collision [" + collision.Name()
+          + "] attached to link [" + _link.Name() + "]"));
         return errors;
       }
     }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Added collision tag to `sdf2usd` converter, we were using the visual to fill the collision. This PR iterate though all the collision and include them in the USD file.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
