### PR TITLE
Added Error Python interface

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -38,6 +38,7 @@ endfunction()
 
 pybind11_add_module(sdformat SHARED
   src/sdf/_ignition_sdformat_pybind11.cc
+  src/sdf/Error.cc
 )
 
 target_link_libraries(sdformat PRIVATE
@@ -48,6 +49,7 @@ configure_build_install_location(sdformat)
 
 if (BUILD_TESTING)
   set(python_tests
+    Error_TEST
   )
 
   foreach (test ${python_tests})

--- a/python/src/sdf/Error.cc
+++ b/python/src/sdf/Error.cc
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "Error.hh"
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <sstream>
+#include <string>
+
+#include "sdf/Error.hh"
+
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+namespace python
+{
+/////////////////////////////////////////////////
+void defineError(pybind11::object module)
+{
+  pybind11::class_<sdf::Error> errorModule(module, "Error");
+  auto toString = [](const sdf::Error &si) {
+    std::stringstream stream;
+    stream << si;
+    return stream.str();
+  };
+  errorModule
+    .def(pybind11::init<>())
+    .def(pybind11::init<const sdf::ErrorCode, const std::string &>())
+    .def(pybind11::init<const sdf::ErrorCode,
+                        const std::string &,
+                        const std::string &>())
+    .def(pybind11::init<const sdf::ErrorCode,
+                        const std::string &,
+                        const std::string &,
+                        int>())
+    .def("code", &sdf::Error::Code,
+         "Get the error code.")
+    .def("message", &sdf::Error::Message,
+         "Get the error message, which is a description of the error.")
+    .def(
+        "file_path", &sdf::Error::FilePath,
+        "Get the file path associated with this error.")
+    .def(
+        "set_file_path", &sdf::Error::SetFilePath,
+        "Sets the file path that is associated with this error.")
+    .def(
+        "line_number", &sdf::Error::LineNumber,
+        "Get the line number associated with this error.")
+    .def(
+        "set_line_number", &sdf::Error::SetLineNumber,
+        "Sets the line number that is associated with this error.")
+    .def(
+        "xml_path", &sdf::Error::XmlPath,
+        "Get the XPath-like trace that is associated with this error.")
+    .def(
+        "set_xml_path", &sdf::Error::SetXmlPath,
+        "Sets the XML path that is associated with this error.")
+    .def(
+        "is_valid",
+        [](const sdf::Error &self)
+        {
+          return self == true;
+        },
+        "Sets the XML path that is associated with this error.")
+    .def("__str__", toString)
+    .def("__repr__", toString);
+
+  pybind11::enum_<sdf::ErrorCode>(errorModule, "ErrorCode")
+    .value("NONE", sdf::ErrorCode::NONE)
+    .value("FILE_READ", sdf::ErrorCode::FILE_READ)
+    .value("DUPLICATE_NAME", sdf::ErrorCode::DUPLICATE_NAME)
+    .value("RESERVED_NAME", sdf::ErrorCode::RESERVED_NAME)
+    .value("ATTRIBUTE_MISSING", sdf::ErrorCode::ATTRIBUTE_MISSING)
+    .value("ATTRIBUTE_INVALID", sdf::ErrorCode::ATTRIBUTE_INVALID)
+    .value("ATTRIBUTE_DEPRECATED", sdf::ErrorCode::ATTRIBUTE_DEPRECATED)
+    .value("ATTRIBUTE_INCORRECT_TYPE",
+           sdf::ErrorCode::ATTRIBUTE_INCORRECT_TYPE)
+    .value("ELEMENT_MISSING", sdf::ErrorCode::ELEMENT_MISSING)
+    .value("ELEMENT_INVALID", sdf::ErrorCode::ELEMENT_INVALID)
+    .value("ELEMENT_DEPRECATED", sdf::ErrorCode::ELEMENT_DEPRECATED)
+    .value("ELEMENT_INCORRECT_TYPE",
+           sdf::ErrorCode::ELEMENT_INCORRECT_TYPE)
+    .value("URI_INVALID", sdf::ErrorCode::URI_INVALID)
+    .value("URI_LOOKUP", sdf::ErrorCode::URI_LOOKUP)
+    .value("DIRECTORY_NONEXISTANT",
+           sdf::ErrorCode::DIRECTORY_NONEXISTANT)
+    .value("MODEL_CANONICAL_LINK_INVALID",
+           sdf::ErrorCode::MODEL_CANONICAL_LINK_INVALID)
+    .value("MODEL_WITHOUT_LINK", sdf::ErrorCode::MODEL_WITHOUT_LINK)
+    .value("NESTED_MODELS_UNSUPPORTED",
+           sdf::ErrorCode::NESTED_MODELS_UNSUPPORTED)
+    .value("LINK_INERTIA_INVALID", sdf::ErrorCode::LINK_INERTIA_INVALID)
+    .value("JOINT_CHILD_LINK_INVALID",
+           sdf::ErrorCode::JOINT_CHILD_LINK_INVALID)
+    .value("JOINT_PARENT_LINK_INVALID",
+           sdf::ErrorCode::JOINT_PARENT_LINK_INVALID)
+    .value("JOINT_PARENT_SAME_AS_CHILD",
+           sdf::ErrorCode::JOINT_PARENT_SAME_AS_CHILD)
+    .value("FRAME_ATTACHED_TO_INVALID",
+           sdf::ErrorCode::FRAME_ATTACHED_TO_INVALID)
+    .value("FRAME_ATTACHED_TO_CYCLE",
+           sdf::ErrorCode::FRAME_ATTACHED_TO_CYCLE)
+    .value("FRAME_ATTACHED_TO_GRAPH_ERROR",
+           sdf::ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR)
+    .value("POSE_RELATIVE_TO_INVALID",
+           sdf::ErrorCode::POSE_RELATIVE_TO_INVALID)
+    .value("POSE_RELATIVE_TO_CYCLE",
+           sdf::ErrorCode::POSE_RELATIVE_TO_CYCLE)
+    .value("POSE_RELATIVE_TO_GRAPH_ERROR",
+           sdf::ErrorCode::POSE_RELATIVE_TO_GRAPH_ERROR)
+    .value("STRING_READ", sdf::ErrorCode::STRING_READ)
+    .value("MODEL_PLACEMENT_FRAME_INVALID",
+           sdf::ErrorCode::MODEL_PLACEMENT_FRAME_INVALID)
+    .value("VERSION_DEPRECATED", sdf::ErrorCode::VERSION_DEPRECATED)
+    .value("MERGE_INCLUDE_UNSUPPORTED",
+           sdf::ErrorCode::MERGE_INCLUDE_UNSUPPORTED)
+    .export_values();
+}
+}  // namespace python
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf

--- a/python/src/sdf/Error.hh
+++ b/python/src/sdf/Error.hh
@@ -14,12 +14,29 @@
  * limitations under the License.
  */
 
+#ifndef IGNITION_GAZEBO_PYTHON__ERROR_HH_
+#define IGNITION_GAZEBO_PYTHON__ERROR_HH_
+
 #include <pybind11/pybind11.h>
 
-#include "Error.hh"
+#include "sdf/Error.hh"
 
-PYBIND11_MODULE(sdformat, m) {
-  m.doc() = "sdformat Python Library.";
+#include "sdf/config.hh"
 
-  sdf::python::defineError(m);
-}
+namespace sdf
+{
+// Inline bracket to help doxygen filtering.
+inline namespace SDF_VERSION_NAMESPACE {
+namespace python
+{
+/// Define a pybind11 wrapper for an sdf::Error
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void
+defineError(pybind11::object module);
+}  // namespace python
+}  // namespace SDF_VERSION_NAMESPACE
+}  // namespace sdf
+
+#endif  // IGNITION_GAZEBO_PYTHON__ERROR_HH_

--- a/python/test/Error_TEST.py
+++ b/python/test/Error_TEST.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2022 Open Source Robotics Foundation
+
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sdformat import Error
+import unittest
+
+class ErrorColor(unittest.TestCase):
+
+  def test_default_construction(self):
+    error = Error()
+
+    self.assertEqual(error.is_valid(), False)
+    self.assertEqual(error.code(), Error.NONE)
+    self.assertFalse(error.message())
+    self.assertFalse(error.xml_path())
+    self.assertFalse(error.file_path())
+    self.assertFalse(error.line_number())
+
+    error.set_xml_path("/sdf/world")
+    self.assertTrue(error.xml_path())
+
+    self.assertEqual("/sdf/world", error.xml_path())
+
+    error.set_file_path("/tmp/test_file.sdf")
+    self.assertTrue(error.file_path())
+    self.assertEqual("/tmp/test_file.sdf", error.file_path())
+
+    error.set_line_number(5)
+    self.assertTrue(error.line_number())
+    self.assertEqual(5, error.line_number())
+
+
+  def test_value_construction_without_file(self):
+    error = Error(Error.FILE_READ, "Unable to read a file")
+    self.assertEqual(error.is_valid(), True)
+    self.assertEqual(error.code(), error.FILE_READ)
+    self.assertEqual(error.message(), "Unable to read a file")
+    self.assertFalse(error.xml_path())
+    self.assertFalse(error.file_path())
+    self.assertFalse(error.line_number())
+
+
+  def test_value_construction_with_file(self):
+    emptyfile_path = "Empty/file/path";
+    error = Error(
+        Error.FILE_READ,
+        "Unable to read a file",
+        emptyfile_path)
+    self.assertEqual(error.is_valid(), True)
+    self.assertEqual(error.code(), error.FILE_READ)
+    self.assertEqual(error.message(), "Unable to read a file")
+    self.assertFalse(error.xml_path())
+    self.assertTrue(error.file_path())
+    self.assertEqual(error.file_path(), emptyfile_path)
+    self.assertFalse(error.line_number())
+
+
+  def test_value_construction_with_line_number(self):
+    emptyfile_path = "Empty/file/path";
+    line_number = 10;
+    error = Error(
+        Error.FILE_READ,
+        "Unable to read a file",
+        emptyfile_path,
+        line_number)
+    self.assertEqual(error.is_valid(), True)
+    self.assertEqual(error.code(), Error.FILE_READ)
+    self.assertEqual(error.message(), "Unable to read a file")
+    self.assertFalse(error.xml_path())
+    self.assertTrue(error.file_path())
+    self.assertEqual(error.file_path(), emptyfile_path)
+    self.assertTrue(error.line_number())
+    self.assertEqual(error.line_number(), line_number)
+
+
+  def test_value_construction_with_xmlpath(self):
+    emptyfile_path = "Empty/file/path";
+    line_number = 10;
+    error = Error(
+        Error.FILE_READ,
+        "Unable to read a file",
+        emptyfile_path,
+        line_number)
+    self.assertEqual(error.is_valid(), True)
+    self.assertEqual(error.code(), Error.FILE_READ)
+    self.assertEqual(error.message(), "Unable to read a file")
+    self.assertTrue(error.file_path())
+    self.assertEqual(error.file_path(), emptyfile_path)
+    self.assertTrue(error.line_number())
+    self.assertEqual(error.line_number(), line_number)
+
+    emptyxml_path = "/sdf/model";
+    self.assertFalse(error.xml_path())
+    error.set_xml_path(emptyxml_path)
+    self.assertTrue(error.xml_path())
+    self.assertEqual(error.xml_path(), emptyxml_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

This PR is part of this mete ticket https://github.com/ignitionrobotics/sdformat/issues/931

## Summary

Added Error Python interface

## Test it

```python
from sdformat import Error

error = Error(Error.FILE_READ, "Unable to read a file")
print(error.message())
print(error.code())
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
