### PR TITLE
Added ``--inertial-stats`` option to ``ign sdf``

### DIFF
--- a/src/cmd/cmdsdformat.rb.in
+++ b/src/cmd/cmdsdformat.rb.in
@@ -50,6 +50,7 @@ COMMANDS = {  'sdf' =>
                        "      --snap-tolerance arg          Used in conjunction with --snap-to-degrees, specifies the tolerance at which snapping\n" +
                        "                                    occurs. This value must be larger than 0, less than 360, and less than the defined\n" +
                        "                                    degrees value to snap to. If unspecified, its default value is 0.01.\n" +
+                       "  --inertial-stats  arg             Prints moment of inertia, centre of mass, and total mass from a model sdf file.\n" +
                        COMMON_OPTIONS
             }
 
@@ -80,6 +81,10 @@ class Cmd
       opts.on('-k arg', '--check arg', String,
               'Check if an SDFormat file is valid.') do |arg|
         options['check'] = arg
+      end
+      opts.on('--inertial-stats arg', String,
+              'Prints moment of inertia, centre of mass, and total mass from a model sdf file.') do |arg|
+        options['inertial_stats'] = arg
       end
       opts.on('-d', '--describe [VERSION]', 'Print the aggregated SDFormat spec description. Default version (@SDF_PROTOCOL_VERSION@)') do |v|
         options['describe'] = v
@@ -201,6 +206,9 @@ class Cmd
         if options.key?('check')
           Importer.extern 'int cmdCheck(const char *)'
           exit(Importer.cmdCheck(File.expand_path(options['check'])))
+        elsif options.key?('inertial_stats')
+          Importer.extern 'int cmdInertialStats(const char *)'
+          exit(Importer.cmdInertialStats(options['inertial_stats']))
         elsif options.key?('describe')
           Importer.extern 'int cmdDescribe(const char *)'
           exit(Importer.cmdDescribe(options['describe']))

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -287,10 +287,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
   sdf::Errors errors = root.Load(_path);
   if (!errors.empty())
   {
-    for (auto &error : errors)
-    {
-      std::cerr << error << std::endl;
-    }
+    std::cerr << errors << std::endl;
     return -1;
   }
 
@@ -301,7 +298,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
     return -1;
   }
 
-  const sdf::Model * model = root.Model();
+  const sdf::Model *model = root.Model();
   if (!model)
   {
     std::cerr << "Error: Could not find the model." << std::endl;

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -329,7 +329,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
   ss << totalInertial.Moi();
 
   std::string s;
-  auto maxLength = 0;
+  auto maxLength = 0u;
   std::vector<std::string> moiVector;
   while ( std::getline(ss, s, ' ' ) ) {
     moiVector.push_back(s);

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -296,7 +296,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
 
   if (root.WorldCount() > 0)
   {
-    std::cerr << "Error: Expected a model file but received a world file"
+    std::cerr << "Error: Expected a model file but received a world file."
             << std::endl;
     return -1;
   }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -23,10 +23,14 @@
 
 #include "sdf/sdf_config.h"
 #include "sdf/Filesystem.hh"
+#include "sdf/Link.hh"
+#include "sdf/Model.hh"
 #include "sdf/Root.hh"
 #include "sdf/parser.hh"
 #include "sdf/PrintConfig.hh"
 #include "sdf/system_util.hh"
+
+#include "ignition/math/Inertial.hh"
 
 #include "FrameSemantics.hh"
 #include "ScopedGraph.hh"
@@ -264,6 +268,88 @@ extern "C" SDFORMAT_VISIBLE int cmdGraph(
     std::cerr << R"(Only "pose" and "frame" graph types are supported)"
               << std::endl;
   }
+
+  return 0;
+}
+
+//////////////////////////////////////////////////
+extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
+    const char *_path)
+{
+  if (!sdf::filesystem::exists(_path))
+  {
+    std::cerr << "Error: File [" << _path << "] does not exist.\n";
+    return -1;
+  }
+
+  sdf::Root root;
+  if (!root.Load(_path).empty()) {
+    return -1;
+  }
+
+  const sdf::Model * model = root.Model();
+  if (!model){
+    return -1;
+  }
+
+  ignition::math::Inertiald totalInertial;
+
+  for (uint64_t i = 0; i < model->LinkCount(); i++) {
+    ignition::math::Pose3d linkPoseRelativeToModel;
+    auto errors = model->LinkByIndex(i)->SemanticPose().Resolve(linkPoseRelativeToModel, "__model__");
+
+    auto currentLinkInertial = model->LinkByIndex(i)->Inertial();
+    currentLinkInertial.SetPose(linkPoseRelativeToModel * currentLinkInertial.Pose());
+    totalInertial += currentLinkInertial;
+  }
+
+  auto totalMass = totalInertial.MassMatrix().Mass();
+  auto xCentreOfMass = totalInertial.Pose().Pos().X();
+  auto yCentreOfMass = totalInertial.Pose().Pos().Y();
+  auto zCentreOfMass = totalInertial.Pose().Pos().Z();
+
+  std::cout << "Inertial statistics for model: " << model->Name() << std::endl;
+  std::cout << "---" << std::endl;
+  std::cout << "Total mass of the model: " << totalMass << std::endl;
+  std::cout << "---" << std::endl;
+
+  std::cout << "Centre of mass in model frame: " << std::endl;
+  std::cout << "X: " << xCentreOfMass << std::endl;
+  std::cout << "Y: " << yCentreOfMass << std::endl;
+  std::cout << "Z: " << zCentreOfMass << std::endl;
+  std::cout << "---" << std::endl;
+
+  std::cout << "Moment of inertia matrix: " << std::endl;
+
+  // Pretty print the MOI matrix
+  std::stringstream ss;
+  ss << totalInertial.Moi();
+
+  std::string s;
+  long unsigned int maxLength = 0;
+  std::vector<std::string> moiVector;
+  while ( std::getline(ss, s, ' ' ) ) {
+    moiVector.push_back(s);
+    if (s.size() > maxLength) {
+      maxLength = s.size();
+    }
+  }
+
+  for (int i = 0; i < 9; i++) {
+    int spacePadding = maxLength - moiVector[i].size();
+    // Print the matrix element
+    std::cout << moiVector[i];
+    for (int j = 0; j < spacePadding; j++) {
+      std::cout << " ";
+    }
+    // Add space for the next element
+    std::cout << "  ";
+    // Add '\n' if the next row is about to start
+    if ((i+1)%3 == 0) {
+      std::cout << "\n";
+    }
+  }
+  std::cout << "---" << std::endl;
 
   return 0;
 }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -284,20 +284,36 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
   }
 
   sdf::Root root;
-  if (!root.Load(_path).empty()) {
+  sdf::Errors errors = root.Load(_path);
+  if (!errors.empty())
+  {
+    for (auto &error : errors)
+    {
+      std::cerr << error << std::endl;
+    }
+    return -1;
+  }
+
+  if (root.WorldCount() > 0)
+  {
+    std::cerr << "Error: Expected a model file but received a world file"
+            << std::endl;
     return -1;
   }
 
   const sdf::Model * model = root.Model();
-  if (!model){
+  if (!model)
+  {
+    std::cerr << "Error: Could not find the model." << std::endl;
     return -1;
   }
 
   ignition::math::Inertiald totalInertial;
 
-  for (uint64_t i = 0; i < model->LinkCount(); i++) {
+  for (uint64_t i = 0; i < model->LinkCount(); i++)
+  {
     ignition::math::Pose3d linkPoseRelativeToModel;
-    auto errors = model->LinkByIndex(i)->SemanticPose().
+    errors = model->LinkByIndex(i)->SemanticPose().
       Resolve(linkPoseRelativeToModel, "__model__");
 
     auto currentLinkInertial = model->LinkByIndex(i)->Inertial();
@@ -331,24 +347,29 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
   std::string s;
   auto maxLength = 0u;
   std::vector<std::string> moiVector;
-  while ( std::getline(ss, s, ' ' ) ) {
+  while ( std::getline(ss, s, ' ' ) )
+  {
     moiVector.push_back(s);
-    if (s.size() > maxLength) {
+    if (s.size() > maxLength)
+    {
       maxLength = s.size();
     }
   }
 
-  for (int i = 0; i < 9; i++) {
+  for (int i = 0; i < 9; i++)
+  {
     int spacePadding = maxLength - moiVector[i].size();
     // Print the matrix element
     std::cout << moiVector[i];
-    for (int j = 0; j < spacePadding; j++) {
+    for (int j = 0; j < spacePadding; j++)
+    {
       std::cout << " ";
     }
     // Add space for the next element
     std::cout << "  ";
     // Add '\n' if the next row is about to start
-    if ((i+1)%3 == 0) {
+    if ((i+1)%3 == 0)
+    {
       std::cout << "\n";
     }
   }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -308,6 +308,12 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
     return -1;
   }
 
+  if (model->ModelCount() > 0)
+  {
+    std::cout << "Warning: Inertial properties of links in nested"
+            " models will not be included." << std::endl;
+  }
+
   ignition::math::Inertiald totalInertial;
 
   for (uint64_t i = 0; i < model->LinkCount(); i++)

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <string.h>
+#include <vector>
 
 #include "sdf/sdf_config.h"
 #include "sdf/Filesystem.hh"
@@ -296,10 +297,12 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
 
   for (uint64_t i = 0; i < model->LinkCount(); i++) {
     ignition::math::Pose3d linkPoseRelativeToModel;
-    auto errors = model->LinkByIndex(i)->SemanticPose().Resolve(linkPoseRelativeToModel, "__model__");
+    auto errors = model->LinkByIndex(i)->SemanticPose().
+      Resolve(linkPoseRelativeToModel, "__model__");
 
     auto currentLinkInertial = model->LinkByIndex(i)->Inertial();
-    currentLinkInertial.SetPose(linkPoseRelativeToModel * currentLinkInertial.Pose());
+    currentLinkInertial.SetPose(linkPoseRelativeToModel *
+      currentLinkInertial.Pose());
     totalInertial += currentLinkInertial;
   }
 
@@ -326,7 +329,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
   ss << totalInertial.Moi();
 
   std::string s;
-  long unsigned int maxLength = 0;
+  auto maxLength = 0;
   std::vector<std::string> moiVector;
   while ( std::getline(ss, s, ' ' ) ) {
     moiVector.push_back(s);

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -1839,7 +1839,7 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   }
 
   expectedOutput =
-          "Error Code 18: Msg: A link named link has invalid inertia.\n";
+          "Error Code 18: Msg: A link named link has invalid inertia.\n\n";
 
   // Check an invalid SDF file by passing the absolute path
   {

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -1796,6 +1796,48 @@ TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFrameAttachedTo))
 }
 
 /////////////////////////////////////////////////
+TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
+{
+  std::string pathBase = PROJECT_SOURCE_PATH;
+  pathBase += "/test/sdf";
+
+  auto expectedOutput =
+    std::string("Inertial statistics for model: test_model\n") +
+    std::string("---\n") +
+    std::string("Total mass of the model: 4\n") +
+    std::string("---\n") +
+    std::string("Centre of mass in model frame: \n") +
+    std::string("X: 0\n") +
+    std::string("Y: 0\n") +
+    std::string("Z: 0\n") +
+    std::string("---\n") +
+    std::string("Moment of inertia matrix: \n") +
+    std::string("54   0    0    \n") +
+    std::string("0    54   0    \n") +
+    std::string("0    0    104  \n") +
+    std::string("---\n");
+
+  // Check a good SDF file by passing the absolute path
+  {
+    std::string path = pathBase +"/inertial_stats.sdf";
+
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " + path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
+  // Check a good SDF file from the same folder by passing a relative path
+  {
+    std::string path = "inertial_stats.sdf";
+
+    std::string output =
+      custom_exec_str("cd " + pathBase + " && " +
+                      IgnCommand() + " sdf --inertial-stats " + path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+}
+
+/////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)
 {

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -1802,20 +1802,20 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   pathBase += "/test/sdf";
 
   auto expectedOutput =
-    std::string("Inertial statistics for model: test_model\n") +
-    std::string("---\n") +
-    std::string("Total mass of the model: 24\n") +
-    std::string("---\n") +
-    std::string("Centre of mass in model frame: \n") +
-    std::string("X: 0\n") +
-    std::string("Y: 0\n") +
-    std::string("Z: 0\n") +
-    std::string("---\n") +
-    std::string("Moment of inertia matrix: \n") +
-    std::string("304  0    0    \n") +
-    std::string("0    304  0    \n") +
-    std::string("0    0    604  \n") +
-    std::string("---\n");
+    "Inertial statistics for model: test_model\n"
+    "---\n"
+    "Total mass of the model: 24\n"
+    "---\n"
+    "Centre of mass in model frame: \n"
+    "X: 0\n"
+    "Y: 0\n"
+    "Z: 0\n"
+    "---\n"
+    "Moment of inertia matrix: \n"
+    "304  0    0    \n"
+    "0    304  0    \n"
+    "0    0    604  \n"
+    "---\n";
 
   // Check a good SDF file by passing the absolute path
   {
@@ -1834,6 +1834,31 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     std::string output =
       custom_exec_str("cd " + pathBase + " && " +
                       IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
+  expectedOutput =
+          "Error Code 18: Msg: A link named link has invalid inertia.\n";
+
+  // Check an invalid SDF file by passing the absolute path
+  {
+    std::string path = pathBase +"/inertial_invalid.sdf";
+
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
+  expectedOutput =
+          "Error: Expected a model file but received a world file.\n";
+  // Check a valid world file.
+  {
+    std::string path = pathBase +"/box_plane_low_friction_test.world";
+
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " +
                       path + SdfVersion());
     EXPECT_EQ(expectedOutput, output);
   }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -1822,7 +1822,8 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     std::string path = pathBase +"/inertial_stats.sdf";
 
     std::string output =
-      custom_exec_str(IgnCommand() + " sdf --inertial-stats " + path + SdfVersion());
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
     EXPECT_EQ(expectedOutput, output);
   }
 
@@ -1832,7 +1833,8 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 
     std::string output =
       custom_exec_str("cd " + pathBase + " && " +
-                      IgnCommand() + " sdf --inertial-stats " + path + SdfVersion());
+                      IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
     EXPECT_EQ(expectedOutput, output);
   }
 }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -1804,7 +1804,7 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
   auto expectedOutput =
     std::string("Inertial statistics for model: test_model\n") +
     std::string("---\n") +
-    std::string("Total mass of the model: 4\n") +
+    std::string("Total mass of the model: 24\n") +
     std::string("---\n") +
     std::string("Centre of mass in model frame: \n") +
     std::string("X: 0\n") +
@@ -1812,9 +1812,9 @@ TEST(inertial_stats, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
     std::string("Z: 0\n") +
     std::string("---\n") +
     std::string("Moment of inertia matrix: \n") +
-    std::string("54   0    0    \n") +
-    std::string("0    54   0    \n") +
-    std::string("0    0    104  \n") +
+    std::string("304  0    0    \n") +
+    std::string("0    304  0    \n") +
+    std::string("0    0    604  \n") +
     std::string("---\n");
 
   // Check a good SDF file by passing the absolute path

--- a/test/sdf/inertial_stats.sdf
+++ b/test/sdf/inertial_stats.sdf
@@ -1,0 +1,115 @@
+<?xml version="1.0" ?>
+<!---
+Model consists of 4 cubes places symmetrically
+in the XY plane. This model is used to verity the
+"ign sdf --inertial-stats" tool .
+            +y
+            │
+          ┌─┼─┐
+       L3 │ │ │(0,5,0)
+          └─┼─┘
+            │
+  L2┌───┐   │     ┌───┐L1
+────┼┼┼┼┼───┼─────┼┼┼┼┼─── +x
+    └───┘   │     └───┘
+  (-5,0,0)  │     (5,0,0)
+          ┌─┼─┐
+          │ │ │(0,-5,0)
+          └─┼─┘
+          L4│
+-->
+<sdf version="1.6">
+
+    <model name="test_model">
+      <pose>0 0 0 0 0 0</pose>
+
+      <link name="link_1">
+        <pose>5 0 0 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_1">
+          <geometry>
+            <box></box>
+          </geometry>
+        </collision>
+        <visual name="visual_1">
+          <geometry>
+            <box></box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="link_2">
+        <pose>-5 0 0 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_2">
+          <geometry>
+            <box></box>
+          </geometry>
+        </collision>
+        <visual name="visual_2">
+          <geometry>
+            <box></box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="link_3">
+        <pose>0 5 0 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_3">
+          <geometry>
+            <box></box>
+          </geometry>
+        </collision>
+        <visual name="visual_3">
+          <geometry>
+            <box></box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="link_4">
+        <pose>0 -5 0 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_4">
+          <geometry>
+            <box></box>
+          </geometry>
+        </collision>
+        <visual name="visual_4">
+          <geometry>
+            <box></box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+</sdf>

--- a/test/sdf/inertial_stats.sdf
+++ b/test/sdf/inertial_stats.sdf
@@ -26,7 +26,7 @@ in the XY plane. This model is used to verity the
       <link name="link_1">
         <pose>5 0 0 0 0 0</pose>
         <inertial>
-          <mass>1.0</mass>
+          <mass>6.0</mass>
           <inertia>
             <ixx>1</ixx>
             <iyy>1</iyy>
@@ -48,7 +48,7 @@ in the XY plane. This model is used to verity the
       <link name="link_2">
         <pose>-5 0 0 0 0 0</pose>
         <inertial>
-          <mass>1.0</mass>
+          <mass>6.0</mass>
           <inertia>
             <ixx>1</ixx>
             <iyy>1</iyy>
@@ -70,7 +70,7 @@ in the XY plane. This model is used to verity the
       <link name="link_3">
         <pose>0 5 0 0 0 0</pose>
         <inertial>
-          <mass>1.0</mass>
+          <mass>6.0</mass>
           <inertia>
             <ixx>1</ixx>
             <iyy>1</iyy>
@@ -92,7 +92,7 @@ in the XY plane. This model is used to verity the
       <link name="link_4">
         <pose>0 -5 0 0 0 0</pose>
         <inertial>
-          <mass>1.0</mass>
+          <mass>6.0</mass>
           <inertia>
             <ixx>1</ixx>
             <iyy>1</iyy>

--- a/test/sdf/inertial_stats.sdf
+++ b/test/sdf/inertial_stats.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!---
 Model consists of 4 cubes places symmetrically
-in the XY plane. This model is used to verity the
+in the XY plane. This model is used to verify the
 "ign sdf --inertial-stats" tool .
             +y
             │
@@ -35,12 +35,16 @@ in the XY plane. This model is used to verity the
         </inertial>
         <collision name="collision_1">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </collision>
         <visual name="visual_1">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </visual>
       </link>
@@ -57,12 +61,16 @@ in the XY plane. This model is used to verity the
         </inertial>
         <collision name="collision_2">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </collision>
         <visual name="visual_2">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </visual>
       </link>
@@ -79,12 +87,16 @@ in the XY plane. This model is used to verity the
         </inertial>
         <collision name="collision_3">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </collision>
         <visual name="visual_3">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </visual>
       </link>
@@ -101,12 +113,16 @@ in the XY plane. This model is used to verity the
         </inertial>
         <collision name="collision_4">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </collision>
         <visual name="visual_4">
           <geometry>
-            <box></box>
+            <box>
+              <size>1 1 1</size>
+            </box>
           </geometry>
         </visual>
       </link>


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes https://github.com/ignitionrobotics/sdformat/issues/832

## Summary
Adds an option of ``--inertial-stats`` to ``ign sdf`` tool and prints out centre of mass, total mass, and moment of inertia matrix of the given model sdf.

## Test it
Working on a test case.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
