### PR TITLE
Added __copy__ and __deepcopy__ to Error and ParserConfig

### DIFF
--- a/python/src/sdf/pyError.cc
+++ b/python/src/sdf/pyError.cc
@@ -79,7 +79,8 @@ void defineError(pybind11::object module)
         {
           return self == true;
         },
-        "Sets the XML path that is associated with this error.")
+        "True if this Error's Code() != NONE. In otherwords, this is "
+        "true when there is an error, or false otherwise.")
     .def("__str__", toString)
     .def("__repr__", toString)
     .def("__copy__", [](const sdf::Error &self) {

--- a/python/src/sdf/pyError.cc
+++ b/python/src/sdf/pyError.cc
@@ -24,6 +24,8 @@
 
 #include "sdf/Error.hh"
 
+using namespace pybind11::literals;
+
 namespace sdf
 {
 // Inline bracket to help doxygen filtering.
@@ -79,7 +81,13 @@ void defineError(pybind11::object module)
         },
         "Sets the XML path that is associated with this error.")
     .def("__str__", toString)
-    .def("__repr__", toString);
+    .def("__repr__", toString)
+    .def("__copy__", [](const sdf::Error &self) {
+      return sdf::Error(self);
+    })
+    .def("__deepcopy__", [](const sdf::Error &self, pybind11::dict) {
+      return sdf::Error(self);
+    }, "memo"_a);
 
   pybind11::enum_<sdf::ErrorCode>(errorModule, "ErrorCode")
     .value("NONE", sdf::ErrorCode::NONE)

--- a/python/src/sdf/pyParserConfig.cc
+++ b/python/src/sdf/pyParserConfig.cc
@@ -23,6 +23,8 @@
 
 #include "sdf/ParserConfig.hh"
 
+using namespace pybind11::literals;
+
 namespace sdf
 {
 // Inline bracket to help doxygen filtering.
@@ -80,7 +82,13 @@ void defineParserConfig(pybind11::object module)
          "Set the preserveFixedJoint flag.")
     .def("urdf_preserve_fixed_joint",
          &sdf::ParserConfig::URDFPreserveFixedJoint,
-         "Get the preserveFixedJoint flag value.");
+         "Get the preserveFixedJoint flag value.")
+    .def("__copy__", [](const sdf::ParserConfig &self) {
+      return sdf::ParserConfig(self);
+    })
+    .def("__deepcopy__", [](const sdf::ParserConfig &self, pybind11::dict) {
+      return sdf::ParserConfig(self);
+    }, "memo"_a);
 
   pybind11::enum_<sdf::EnforcementPolicy>(
     parseConfigModule, "EnforcementPolicy")

--- a/python/test/pyError_TEST.py
+++ b/python/test/pyError_TEST.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from sdformat import Error
 import unittest
 
@@ -49,6 +50,18 @@ class ErrorColor(unittest.TestCase):
     self.assertFalse(error.xml_path())
     self.assertFalse(error.file_path())
     self.assertFalse(error.line_number())
+
+
+  def test_deepcopy(self):
+    error = Error(Error.ErrorCode.FILE_READ, "Unable to read a file")
+
+    error2 = copy.deepcopy(error)
+    self.assertEqual(error.is_valid(), error2.is_valid())
+    self.assertEqual(error.code(), error2.code())
+    self.assertEqual(error.message(), error2.message())
+    self.assertEqual(error.xml_path(), error2.xml_path())
+    self.assertEqual(error.file_path(), error2.file_path())
+    self.assertEqual(error.line_number(), error2.line_number())
 
 
   def test_value_construction_with_file(self):

--- a/python/test/pyError_TEST.py
+++ b/python/test/pyError_TEST.py
@@ -63,6 +63,15 @@ class ErrorColor(unittest.TestCase):
     self.assertEqual(error.file_path(), error2.file_path())
     self.assertEqual(error.line_number(), error2.line_number())
 
+    error.set_file_path("file.sdf")
+    error.set_line_number(5)
+    error.set_xml_path("/sdf/mode")
+    self.assertEqual(error.file_path(), "file.sdf")
+    self.assertEqual(error2.file_path(), None)
+    self.assertEqual(error.line_number(), 5)
+    self.assertEqual(error2.line_number(), None)
+    self.assertEqual(error.xml_path(), "/sdf/mode")
+    self.assertEqual(error2.xml_path(), None)
 
   def test_value_construction_with_file(self):
     emptyfile_path = "Empty/file/path";

--- a/python/test/pyParserConfig_TEST.py
+++ b/python/test/pyParserConfig_TEST.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from sdformat import ParserConfig
 from sdformattest import source_file, test_file
 import unittest
@@ -54,6 +55,34 @@ class ParserConfigColor(unittest.TestCase):
         self.assertEqual(it[0], testDir1)
 
         config2 = ParserConfig(config1)
+        it = config2.uri_path_map().get("file://")
+        self.assertEqual(1, len(it))
+        self.assertEqual(it[0], testDir1)
+
+        config2.add_uri_path("file://", testDir2)
+        it = config2.uri_path_map().get("file://")
+        self.assertEqual(2, len(it))
+        self.assertEqual(it[1], testDir2)
+
+        # Updating config2 should not affect config1
+        it = config1.uri_path_map().get("file://")
+        self.assertEqual(1, len(it))
+        self.assertEqual(it[0], testDir1)
+
+
+    def test_deepcopy(self):
+        # The directory used in add_uri_path must exist in the filesystem
+        # so we'll use the source path
+        testDir1 = source_file()
+        testDir2 = test_file()
+
+        config1 = ParserConfig()
+        config1.add_uri_path("file://", testDir1)
+        it = config1.uri_path_map().get("file://")
+        self.assertEqual(1, len(it))
+        self.assertEqual(it[0], testDir1)
+
+        config2 = copy.deepcopy(config1)
         it = config2.uri_path_map().get("file://")
         self.assertEqual(1, len(it))
         self.assertEqual(it[0], testDir1)


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

For consistency we are going to add `__copy__` and `__deepcopy__` to `Error` and `ParserConfig` class


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
