### PR TITLE
Backport ``ign sdf --inertial-stats``

### DIFF
--- a/src/cmd/cmdsdformat.rb.in
+++ b/src/cmd/cmdsdformat.rb.in
@@ -41,6 +41,7 @@ COMMANDS = {  'sdf' =>
                        "  -k [ --check ] arg               Check if an SDFormat file is valid.\n" +
                        "  -d [ --describe ] [SPEC VERSION] Print the aggregated SDFormat spec description. Default version (@SDF_PROTOCOL_VERSION@).\n" +
                        "  -p [ --print ] arg               Print converted arg.\n" +
+                       "  --inertial-stats  arg             Prints moment of inertia, centre of mass, and total mass from a model sdf file.\n" +
                        COMMON_OPTIONS
             }
 
@@ -69,6 +70,10 @@ class Cmd
       opts.on('-k arg', '--check arg', String,
               'Check if an SDFormat file is valid.') do |arg|
         options['check'] = arg
+      end
+      opts.on('--inertial-stats arg', String,
+              'Prints moment of inertia, centre of mass, and total mass from a model sdf file.') do |arg|
+        options['inertial_stats'] = arg
       end
       opts.on('-d', '--describe [VERSION]', 'Print the aggregated SDFormat spec description. Default version (@SDF_PROTOCOL_VERSION@)') do |v|
         options['describe'] = v
@@ -150,6 +155,9 @@ class Cmd
         if options.key?('check')
           Importer.extern 'int cmdCheck(const char *)'
           exit(Importer.cmdCheck(File.expand_path(options['check'])))
+        elsif options.key?('inertial_stats')
+          Importer.extern 'int cmdInertialStats(const char *)'
+          exit(Importer.cmdInertialStats(options['inertial_stats']))
         elsif options.key?('describe')
           Importer.extern 'int cmdDescribe(const char *)'
           exit(Importer.cmdDescribe(options['describe']))

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -178,7 +178,6 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
     {
       std::cerr << "Error: " << error.Message() << std::endl;
     }
-    return -1;
   }
 
   if (root.WorldCount() > 0)

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -253,7 +253,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
     size_t spacePadding = maxLength - moiVector[i].size();
     // Print the matrix element
     std::cout << moiVector[i];
-    for (int j = 0; j < spacePadding; j++)
+    for (size_t j = 0; j < spacePadding; j++)
     {
       std::cout << " ";
     }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -16,6 +16,7 @@
 */
 
 #include <iostream>
+#include <string>
 #include <string.h>
 #include <vector>
 

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -17,12 +17,17 @@
 
 #include <iostream>
 #include <string.h>
+#include <vector>
 
 #include "sdf/sdf_config.h"
 #include "sdf/Filesystem.hh"
+#include "sdf/Link.hh"
+#include "sdf/Model.hh"
 #include "sdf/Root.hh"
 #include "sdf/parser.hh"
 #include "sdf/system_util.hh"
+
+#include "ignition/math/Inertial.hh"
 
 #include "ign.hh"
 
@@ -150,6 +155,117 @@ extern "C" SDFORMAT_VISIBLE int cmdPrint(const char *_path)
   }
 
   sdf->PrintValues();
+
+  return 0;
+}
+
+//////////////////////////////////////////////////
+extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
+    const char *_path)
+{
+  if (!sdf::filesystem::exists(_path))
+  {
+    std::cerr << "Error: File [" << _path << "] does not exist.\n";
+    return -1;
+  }
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(_path);
+  if (!errors.empty())
+  {
+    for (auto &error : errors)
+    {
+      std::cerr << "Error: " << error.Message() << std::endl;
+    }
+    return -1;
+  }
+
+  if (root.WorldCount() > 0)
+  {
+    std::cerr << "Error: Expected a model file but received a world file."
+            << std::endl;
+    return -1;
+  }
+
+  const sdf::Model *model = root.ModelByIndex(0);
+  if (!model)
+  {
+    std::cerr << "Error: Could not find the model." << std::endl;
+    return -1;
+  }
+
+  if (model->ModelCount() > 0)
+  {
+    std::cout << "Warning: Inertial properties of links in nested"
+            " models will not be included." << std::endl;
+  }
+
+  ignition::math::Inertiald totalInertial;
+
+  for (uint64_t i = 0; i < model->LinkCount(); i++)
+  {
+    ignition::math::Pose3d linkPoseRelativeToModel;
+    errors = model->LinkByIndex(i)->SemanticPose().
+      Resolve(linkPoseRelativeToModel, "__model__");
+
+    auto currentLinkInertial = model->LinkByIndex(i)->Inertial();
+    currentLinkInertial.SetPose(linkPoseRelativeToModel *
+      currentLinkInertial.Pose());
+    totalInertial += currentLinkInertial;
+  }
+
+  auto totalMass = totalInertial.MassMatrix().Mass();
+  auto xCentreOfMass = totalInertial.Pose().Pos().X();
+  auto yCentreOfMass = totalInertial.Pose().Pos().Y();
+  auto zCentreOfMass = totalInertial.Pose().Pos().Z();
+
+  std::cout << "Inertial statistics for model: " << model->Name() << std::endl;
+  std::cout << "---" << std::endl;
+  std::cout << "Total mass of the model: " << totalMass << std::endl;
+  std::cout << "---" << std::endl;
+
+  std::cout << "Centre of mass in model frame: " << std::endl;
+  std::cout << "X: " << xCentreOfMass << std::endl;
+  std::cout << "Y: " << yCentreOfMass << std::endl;
+  std::cout << "Z: " << zCentreOfMass << std::endl;
+  std::cout << "---" << std::endl;
+
+  std::cout << "Moment of inertia matrix: " << std::endl;
+
+  // Pretty print the MOI matrix
+  std::stringstream ss;
+  ss << totalInertial.Moi();
+
+  std::string s;
+  auto maxLength = 0u;
+  std::vector<std::string> moiVector;
+  while ( std::getline(ss, s, ' ' ) )
+  {
+    moiVector.push_back(s);
+    if (s.size() > maxLength)
+    {
+      maxLength = s.size();
+    }
+  }
+
+  for (int i = 0; i < 9; i++)
+  {
+    int spacePadding = maxLength - moiVector[i].size();
+    // Print the matrix element
+    std::cout << moiVector[i];
+    for (int j = 0; j < spacePadding; j++)
+    {
+      std::cout << " ";
+    }
+    // Add space for the next element
+    std::cout << "  ";
+    // Add '\n' if the next row is about to start
+    if ((i+1)%3 == 0)
+    {
+      std::cout << "\n";
+    }
+  }
+  std::cout << "---" << std::endl;
 
   return 0;
 }

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -237,7 +237,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
   ss << totalInertial.Moi();
 
   std::string s;
-  auto maxLength = 0u;
+  size_t maxLength = 0u;
   std::vector<std::string> moiVector;
   while ( std::getline(ss, s, ' ' ) )
   {
@@ -250,7 +250,7 @@ extern "C" SDFORMAT_VISIBLE int cmdInertialStats(
 
   for (int i = 0; i < 9; i++)
   {
-    int spacePadding = maxLength - moiVector[i].size();
+    size_t spacePadding = maxLength - moiVector[i].size();
     // Print the matrix element
     std::cout << moiVector[i];
     for (int j = 0; j < spacePadding; j++)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -776,7 +776,21 @@ TEST(inertial_stats, SDF)
   }
 
   expectedOutput =
-          "Error: A link named link has invalid inertia.\n";
+          "Error: A link named link has invalid inertia.\n"
+          "Inertial statistics for model: model\n"
+          "---\n"
+          "Total mass of the model: 0\n"
+          "---\n"
+          "Centre of mass in model frame: \n"
+          "X: 0\n"
+          "Y: 0\n"
+          "Z: 0\n"
+          "---\n"
+          "Moment of inertia matrix: \n"
+          "0  0  0  \n"
+          "0  0  0  \n"
+          "0  0  0  \n"
+          "---\n";
 
   // Check an invalid SDF file by passing the absolute path
   {

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -733,6 +733,75 @@ TEST(print, SDF)
 }
 
 /////////////////////////////////////////////////
+TEST(inertial_stats, SDF)
+{
+  std::string pathBase = PROJECT_SOURCE_PATH;
+  pathBase += "/test/sdf";
+
+  auto expectedOutput =
+    "Inertial statistics for model: test_model\n"
+    "---\n"
+    "Total mass of the model: 24\n"
+    "---\n"
+    "Centre of mass in model frame: \n"
+    "X: 0\n"
+    "Y: 0\n"
+    "Z: 0\n"
+    "---\n"
+    "Moment of inertia matrix: \n"
+    "304  0    0    \n"
+    "0    304  0    \n"
+    "0    0    604  \n"
+    "---\n";
+
+  // Check a good SDF file by passing the absolute path
+  {
+    std::string path = pathBase +"/inertial_stats.sdf";
+
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
+  // Check a good SDF file from the same folder by passing a relative path
+  {
+    std::string path = "inertial_stats.sdf";
+
+    std::string output =
+      custom_exec_str("cd " + pathBase + " && " +
+                      IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
+  expectedOutput =
+          "Error Code 18: Msg: A link named link has invalid inertia.\n\n";
+
+  // Check an invalid SDF file by passing the absolute path
+  {
+    std::string path = pathBase +"/inertial_invalid.sdf";
+
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+
+  expectedOutput =
+          "Error: Expected a model file but received a world file.\n";
+  // Check a valid world file.
+  {
+    std::string path = pathBase +"/box_plane_low_friction_test.world";
+
+    std::string output =
+      custom_exec_str(IgnCommand() + " sdf --inertial-stats " +
+                      path + SdfVersion());
+    EXPECT_EQ(expectedOutput, output);
+  }
+}
+
+/////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)
 {

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -776,7 +776,7 @@ TEST(inertial_stats, SDF)
   }
 
   expectedOutput =
-          "Error Code 18: Msg: A link named link has invalid inertia.\n\n";
+          "Error: A link named link has invalid inertia.\n";
 
   // Check an invalid SDF file by passing the absolute path
   {

--- a/test/sdf/inertial_stats.sdf
+++ b/test/sdf/inertial_stats.sdf
@@ -1,0 +1,131 @@
+<?xml version="1.0" ?>
+<!---
+Model consists of 4 cubes places symmetrically
+in the XY plane. This model is used to verify the
+"ign sdf --inertial-stats" tool .
+            +y
+            │
+          ┌─┼─┐
+       L3 │ │ │(0,5,0)
+          └─┼─┘
+            │
+  L2┌───┐   │     ┌───┐L1
+────┼┼┼┼┼───┼─────┼┼┼┼┼─── +x
+    └───┘   │     └───┘
+  (-5,0,0)  │     (5,0,0)
+          ┌─┼─┐
+          │ │ │(0,-5,0)
+          └─┼─┘
+          L4│
+-->
+<sdf version="1.6">
+
+    <model name="test_model">
+      <pose>0 0 0 0 0 0</pose>
+
+      <link name="link_1">
+        <pose>5 0 0 0 0 0</pose>
+        <inertial>
+          <mass>6.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_1">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_1">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="link_2">
+        <pose>-5 0 0 0 0 0</pose>
+        <inertial>
+          <mass>6.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_2">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_2">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="link_3">
+        <pose>0 5 0 0 0 0</pose>
+        <inertial>
+          <mass>6.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_3">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_3">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="link_4">
+        <pose>0 -5 0 0 0 0</pose>
+        <inertial>
+          <mass>6.0</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <iyy>1</iyy>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision_4">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_4">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+</sdf>


### PR DESCRIPTION

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
Backport of https://github.com/ignitionrobotics/sdformat/pull/936

## Test it
Added a test case to ``ign_TEST.cc`` and an example model sdf file.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸