### PR TITLE
Backport #487 to sdf9: support L16 pixel format

### DIFF
--- a/sdf/1.7/camera.sdf
+++ b/sdf/1.7/camera.sdf
@@ -18,7 +18,7 @@
       <description>Height in pixels </description>
     </element>
     <element name="format" type="string" default="R8G8B8" required="0">
-      <description>(L8|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
+      <description>(L8|L16|R_FLOAT16|R_FLOAT32|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
     </element>
     <element name="anti_aliasing" type="int" default="4" required="0">
       <description>Value used for anti-aliasing</description>

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -945,6 +945,8 @@ PixelFormatType Camera::ConvertPixelFormat(const std::string &_format)
     return PixelFormatType::RGB_INT8;
   else if (_format == "L8")
     return PixelFormatType::L_INT8;
+  else if (_format == "L16")
+    return PixelFormatType::L_INT16;
   else if (_format == "B8G8R8")
     return PixelFormatType::BGR_INT8;
   else if (_format == "BAYER_RGGB8")


### PR DESCRIPTION
Support for the `L16` pixel format was added in `sdf10`, so this back ports it to `sdf9`. Use Rebase and Merge.

* #487