### PR TITLE
Use ign-utils instead of ign-cmake utilities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,13 +51,6 @@ if (BUILD_TESTING)
       ${PROJECT_SOURCE_DIR}/test
   )
 
-  if (TARGET UNIT_ign_TEST)
-    # Link the libraries that we always need.
-    target_link_libraries("UNIT_ign_TEST"
-      ignition-cmake${IGN_CMAKE_VER}::utilities
-    )
-  endif()
-
   if (TARGET UNIT_Converter_TEST)
     target_link_libraries(UNIT_Converter_TEST
       TINYXML2::TINYXML2)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string>
 
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "sdf/parser.hh"
 #include "sdf/SDFImpl.hh"

--- a/usd/src/CMakeLists.txt
+++ b/usd/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(gtest_sources
 ign_build_tests(
   TYPE UNIT
   SOURCES ${gtest_sources}
+  LIB_DEPS ignition-common${IGN_COMMON_VER}::ignition-common${IGN_COMMON_VER}
   INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/test usd_parser
 )
 

--- a/usd/src/CMakeLists.txt
+++ b/usd/src/CMakeLists.txt
@@ -66,7 +66,7 @@ set(gtest_sources
 ign_build_tests(
   TYPE UNIT
   SOURCES ${gtest_sources}
-  LIB_DEPS ignition-common${IGN_COMMON_VER}::ignition-common${IGN_COMMON_VER}
+  LIB_DEPS ${usd_target}
   INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/test usd_parser
 )
 

--- a/usd/src/CMakeLists.txt
+++ b/usd/src/CMakeLists.txt
@@ -66,7 +66,6 @@ set(gtest_sources
 ign_build_tests(
   TYPE UNIT
   SOURCES ${gtest_sources}
-  LIB_DEPS ${usd_target} ignition-cmake${IGN_CMAKE_VER}::utilities
   INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/test usd_parser
 )
 

--- a/usd/src/sdf_parser/sdf2usd_TEST.cc
+++ b/usd/src/sdf_parser/sdf2usd_TEST.cc
@@ -20,7 +20,7 @@
 
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/TempDirectory.hh>
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"
 #include "test_utils.hh"

--- a/usd/src/usd_parser/USDData_TEST.cc
+++ b/usd/src/usd_parser/USDData_TEST.cc
@@ -20,7 +20,7 @@
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Util.hh>
 
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include <sdf/usd/usd_parser/USDData.hh>
 #include <sdf/usd/UsdError.hh>

--- a/usd/src/usd_parser/USDStage_TEST.cc
+++ b/usd/src/usd_parser/USDStage_TEST.cc
@@ -19,7 +19,7 @@
 
 #include <ignition/common/Filesystem.hh>
 
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include <sdf/usd/usd_parser/USDStage.hh>
 #include <sdf/usd/UsdError.hh>

--- a/usd/src/usd_parser/USDTransforms_TEST.cc
+++ b/usd/src/usd_parser/USDTransforms_TEST.cc
@@ -21,7 +21,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"
 #include "test_utils.hh"

--- a/usd/src/usd_parser/usd2sdf_TEST.cc
+++ b/usd/src/usd_parser/usd2sdf_TEST.cc
@@ -23,7 +23,7 @@
 #include <ignition/common/TempDirectory.hh>
 #include <ignition/common/Util.hh>
 
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "sdf/Model.hh"
 #include "sdf/Root.hh"


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

`ign-cmake`'s utilities aren't recommended and are deprecated in `ign-cmake3`. We should use `ign-utils` instead.

This should help with

* https://github.com/ignition-tooling/release-tools/issues/685

## Test it
<!--Explain how reviewers can test this new feature manually.-->

CI should pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
