### PR TITLE
Added <shininess> to <material>

### DIFF
--- a/include/sdf/Material.hh
+++ b/include/sdf/Material.hh
@@ -112,6 +112,14 @@ namespace sdf
     /// \param[in] _color Specular color.
     public: void SetSpecular(const ignition::math::Color &_color) const;
 
+    /// \brief Get the specular exponent.
+    /// \return Specular exponent.
+    public: double Shininess() const;
+
+    /// \brief Set the specular exponent. 
+    /// \param[in] _shininess Specular exponent.
+    public: void SetShininess(const double _shininess);
+
     /// \brief Get the emissive color. The emissive color is
     /// specified by a set of three numbers representing red/green/blue,
     /// each in the range of [0,1].

--- a/include/sdf/Material.hh
+++ b/include/sdf/Material.hh
@@ -116,7 +116,7 @@ namespace sdf
     /// \return Specular exponent.
     public: double Shininess() const;
 
-    /// \brief Set the specular exponent. 
+    /// \brief Set the specular exponent.
     /// \param[in] _shininess Specular exponent.
     public: void SetShininess(const double _shininess);
 

--- a/sdf/1.7/material.sdf
+++ b/sdf/1.7/material.sdf
@@ -41,6 +41,10 @@
     <description>The specular color of a material specified by set of four numbers representing red/green/blue/alpha, each in the range of [0,1].</description>
   </element>
 
+  <element name="shininess" type="double" default="0" required="0">
+    <description>The specular exponent of a material</description>
+  </element>
+
   <element name="emissive" type="color" default="0 0 0 1" required="0">
     <description>The emissive color of a material specified by set of four numbers representing red/green/blue, each in the range of [0,1].</description>
   </element>

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -54,6 +54,9 @@ class sdf::MaterialPrivate
   /// \brief Specular color
   public: ignition::math::Color specular {0, 0, 0, 1};
 
+  /// \brief Specular exponent
+  public: double shininess {0};
+
   /// \brief Emissive color
   public: ignition::math::Color emissive {0, 0, 0, 1};
 
@@ -93,6 +96,7 @@ Material::Material(const Material &_material)
   this->dataPtr->ambient = _material.dataPtr->ambient;
   this->dataPtr->diffuse = _material.dataPtr->diffuse;
   this->dataPtr->specular = _material.dataPtr->specular;
+  this->dataPtr->shininess = _material.dataPtr->shininess;
   this->dataPtr->emissive = _material.dataPtr->emissive;
   this->dataPtr->sdf = _material.dataPtr->sdf;
   this->dataPtr->filePath = _material.dataPtr->filePath;
@@ -270,6 +274,18 @@ ignition::math::Color Material::Specular() const
 void Material::SetSpecular(const ignition::math::Color &_color) const
 {
   this->dataPtr->specular = _color;
+}
+
+//////////////////////////////////////////////////
+double Material::Shininess() const
+{
+  return this->dataPtr->shininess;
+}
+
+//////////////////////////////////////////////////
+void Material::SetShininess(const double _shininess)
+{
+  this->dataPtr->shininess = _shininess;
 }
 
 //////////////////////////////////////////////////

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -220,6 +220,9 @@ Errors Material::Load(sdf::ElementPtr _sdf)
   this->dataPtr->specular = _sdf->Get<ignition::math::Color>("specular",
       this->dataPtr->specular).first;
 
+  this->dataPtr->shininess = _sdf->Get<double>("shininess",
+      this->dataPtr->shininess).first;
+
   this->dataPtr->emissive = _sdf->Get<ignition::math::Color>("emissive",
       this->dataPtr->emissive).first;
 

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -28,6 +28,7 @@ TEST(DOMMaterial, Construction)
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Ambient());
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Diffuse());
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Specular());
+  EXPECT_DOUBLE_EQ(0.0, material.Shininess());
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Emissive());
   EXPECT_TRUE(material.Lighting());
   EXPECT_FALSE(material.DoubleSided());
@@ -47,6 +48,7 @@ TEST(DOMMaterial, MoveConstructor)
   material.SetAmbient(ignition::math::Color(0.1f, 0.2f, 0.3f, 0.5f));
   material.SetDiffuse(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f));
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
+  material.SetShininess(5.0);
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
   material.SetDoubleSided(true);
@@ -61,6 +63,7 @@ TEST(DOMMaterial, MoveConstructor)
   EXPECT_EQ(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f), material2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f),
       material2.Specular());
+  EXPECT_DOUBLE_EQ(5.0, material2.Shininess());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
@@ -80,6 +83,7 @@ TEST(DOMMaterial, CopyConstructor)
   material.SetAmbient(ignition::math::Color(0.1f, 0.2f, 0.3f, 0.5f));
   material.SetDiffuse(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f));
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
+  material.SetShininess(5.0);
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
   material.SetDoubleSided(true);
@@ -94,6 +98,7 @@ TEST(DOMMaterial, CopyConstructor)
   EXPECT_EQ(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f), material2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f),
       material2.Specular());
+  EXPECT_DOUBLE_EQ(5.0, material2.Shininess());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
@@ -113,6 +118,7 @@ TEST(DOMMaterial, AssignmentOperator)
   material.SetAmbient(ignition::math::Color(0.1f, 0.2f, 0.3f, 0.5f));
   material.SetDiffuse(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f));
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
+  material.SetShininess(5.0);
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
   material.SetDoubleSided(true);
@@ -128,6 +134,7 @@ TEST(DOMMaterial, AssignmentOperator)
   EXPECT_EQ(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f), material2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f),
       material2.Specular());
+  EXPECT_DOUBLE_EQ(5.0, material2.Shininess());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
@@ -147,6 +154,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
   material.SetAmbient(ignition::math::Color(0.1f, 0.2f, 0.3f, 0.5f));
   material.SetDiffuse(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f));
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
+  material.SetShininess(5.0);
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
   material.SetDoubleSided(true);
@@ -161,6 +169,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
   EXPECT_EQ(ignition::math::Color(0.2f, 0.3f, 0.4f, 0.6f), material2.Diffuse());
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f),
       material2.Specular());
+  EXPECT_DOUBLE_EQ(5.0, material2.Shininess());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
@@ -206,6 +215,10 @@ TEST(DOMMaterial, Set)
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Specular());
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f), material.Specular());
+
+  EXPECT_DOUBLE_EQ(0.0, material.Shininess());
+  material.SetShininess(5.0);
+  EXPECT_DOUBLE_EQ(5.0, material.Shininess());
 
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Emissive());
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));


### PR DESCRIPTION
# 🎉 Added ```<shininess>``` to ```<material>```

## Summary
When using default shaders in gazebo, the ogre's default shininess is 0 causing the specular components to have no effect. Without having a shininess element, we are unable to utilize specular highlights with default shaders.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
