### PR TITLE
Added SemanticPose Python test

### DIFF
--- a/python/test/pySemanticPose_TEST.py
+++ b/python/test/pySemanticPose_TEST.py
@@ -1,59 +1,57 @@
 # Copyright (C) 2022 Open Source Robotics Foundation
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #       http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(ahcorde) Enable test when sdf::Link is converted
+import copy
+from ignition.math import Pose3d
+from sdformat import Link, SemanticPose
+import unittest
 
-# import copy
-# from ignition.math import Pose3d
-# from sdformat import Link, SemanticPose
-# import unittest
-# import math
-#
-# class semantic_poseTEST(unittest.TestCase):
-#
-#   def test_default_construction(self):
-#     link = Link()
-#     rawPose = Pose3d(1, 0, 0, 0, 0, 0)
-#     link.set_raw_pose(rawPose)
-#     semPose = link.semantic_pose()
-#     self.assertEqual(rawPose, semPose.raw_pose())
-#
-#
-#   def test_copy_construction(self):
-#     link = Link()
-#     rawPose = Pose3d(1, 0, 0, 0, 0, 0)
-#     link.set_raw_pose(rawPose)
-#     semPose1 = link.semantic_pose()
-#
-#     semPose2 = SemanticPose(semPose1)
-#     self.assertEqual(rawPose, semPose2.raw_pose())
-#
-#
-#   def test_deepcopy(self):
-#     link = Link()
-#     rawPose = Pose3d(1, 0, 0, 0, 0, 0)
-#     link.set_raw_pose(rawPose)
-#     semPose1 = link.semantic_pose()
-#
-#     # Create another semantic_pose object from another Link
-#     link2 = Link()
-#     semPose2 = link2.semantic_pose()
-#     self.assertEqual(Pose3d.ZERO, semPose2.raw_pose())
-#
-#     semPose2 = copy.deepcopy(semPose1)
-#     self.assertEqual(rawPose, semPose2.raw_pose())
-#
-#
-# if __name__ == '__main__':
-#     unittest.main()
+class semantic_poseTEST(unittest.TestCase):
+
+
+    def test_default_construction(self):
+        link = Link()
+        rawPose = Pose3d(1, 0, 0, 0, 0, 0)
+        link.set_raw_pose(rawPose)
+        semPose = link.semantic_pose()
+        self.assertEqual(rawPose, semPose.raw_pose())
+
+
+    def test_copy_construction(self):
+        link = Link()
+        rawPose = Pose3d(1, 0, 0, 0, 0, 0)
+        link.set_raw_pose(rawPose)
+        semPose1 = link.semantic_pose()
+
+        semPose2 = SemanticPose(semPose1)
+        self.assertEqual(rawPose, semPose2.raw_pose())
+
+
+    def test_deepcopy(self):
+        link = Link()
+        rawPose = Pose3d(1, 0, 0, 0, 0, 0)
+        link.set_raw_pose(rawPose)
+        semPose1 = link.semantic_pose()
+
+        # Create another semantic_pose object from another Link
+        link2 = Link()
+        semPose2 = link2.semantic_pose()
+        self.assertEqual(Pose3d.ZERO, semPose2.raw_pose())
+
+        semPose2 = copy.deepcopy(semPose1)
+        self.assertEqual(rawPose, semPose2.raw_pose())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature


## Summary
Added SemanticPose Python test

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
